### PR TITLE
Rounding dates instead of cutting off

### DIFF
--- a/bw_timex/dynamic_biosphere_builder.py
+++ b/bw_timex/dynamic_biosphere_builder.py
@@ -235,7 +235,7 @@ class DynamicBiosphereBuilder:
                         td_producer = TemporalDistribution(
                             date=np.array([str(time_in_datetime)], dtype=self.time_res),
                             amount=np.array([1]),
-                        ).date  # TODO: Simplify
+                        ).date
                         date = td_producer[0]
 
                         time_mapped_matrix_id = self.biosphere_time_mapping_dict.add(

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -13,6 +13,7 @@ from .utils import (
     convert_date_string_to_datetime,
     extract_date_as_integer,
     extract_date_as_string,
+    round_datetime,
 )
 
 
@@ -157,11 +158,18 @@ class TimelineBuilder:
             edges_df["consumer"] == -1, "producer_date"
         ]
 
+        edges_df["rounded_consumer_date"] = edges_df["consumer_date"].apply(
+            lambda x: round_datetime(x, self.temporal_grouping)
+        )
+        edges_df["rounded_producer_date"] = edges_df["producer_date"].apply(
+            lambda x: round_datetime(x, self.temporal_grouping)
+        )
+
         # extract grouping time of consumer and producer: processes occuring at different times within in the same time window of grouping get the same grouping time
-        edges_df["consumer_grouping_time"] = edges_df["consumer_date"].apply(
+        edges_df["consumer_grouping_time"] = edges_df["rounded_consumer_date"].apply(
             lambda x: extract_date_as_string(x, self.temporal_grouping)
         )
-        edges_df["producer_grouping_time"] = edges_df["producer_date"].apply(
+        edges_df["producer_grouping_time"] = edges_df["rounded_producer_date"].apply(
             lambda x: extract_date_as_string(x, self.temporal_grouping)
         )
 

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -31,19 +31,15 @@ from .dynamic_biosphere_builder import DynamicBiosphereBuilder
 from .helper_classes import SetList, TimeMappingDict
 from .matrix_modifier import MatrixModifier
 from .timeline_builder import TimelineBuilder
-from .utils import (
-    extract_date_as_integer,
-    resolve_temporalized_node_name,
-    round_datetime_to_nearest_year,
-)
+from .utils import extract_date_as_integer, resolve_temporalized_node_name
 
 
 class TimexLCA:
     """
     Class to perform time-explicit LCA calculations.
 
-    A TimexLCA contains the LCI of processes occuring at explicit points in time. It tracks the timing of processes, 
-    relinks their technosphere and biosphere exchanges to match the technology landscape at that point in time, 
+    A TimexLCA contains the LCI of processes occuring at explicit points in time. It tracks the timing of processes,
+    relinks their technosphere and biosphere exchanges to match the technology landscape at that point in time,
     and also keeps track of the timing of the resulting emissions. As such, it combines prospective and dynamic LCA
     approaches.
 
@@ -255,7 +251,7 @@ class TimexLCA:
         )
 
         self.timeline = self.timeline_builder.build_timeline()
-        
+
         return self.timeline[
             [
                 "date_producer",
@@ -446,18 +442,6 @@ class TimexLCA:
 
         # Set a default for inventory_in_time_horizon using the full dynamic_inventory_df
         inventory_in_time_horizon = self.dynamic_inventory_df
-
-        # Round dates to nearest year and sum up emissions for each year
-        inventory_in_time_horizon.date = inventory_in_time_horizon.date.apply(
-            round_datetime_to_nearest_year
-        )
-        inventory_in_time_horizon = (
-            inventory_in_time_horizon.groupby(
-                inventory_in_time_horizon.columns.tolist()
-            )
-            .sum()
-            .reset_index()
-        )
 
         # Calculate the latest considered impact date
         t0_date = pd.Timestamp(self.timeline_builder.edge_extractor.t0.date[0])
@@ -1103,7 +1087,7 @@ class TimexLCA:
         (('database', 'code'), datetime_as_integer): time_mapping_id) that is later used to uniquely
         identify time-resolved processes. Here,  the activity_time_mapping_dict is the pre-population with
         the static activities. The time-explicit activities (from other temporalized background
-        databases) are added later on by the TimelineBuilder. Activities in the foreground database are 
+        databases) are added later on by the TimelineBuilder. Activities in the foreground database are
         mapped with (('database', 'code'), "dynamic"): time_mapping_id)" as their timing is not yet known.
 
         Parameters

--- a/bw_timex/utils.py
+++ b/bw_timex/utils.py
@@ -2,7 +2,6 @@ import warnings
 from datetime import datetime, timedelta
 from typing import Callable, List, Optional, Union
 
-import bw2data as bd
 import matplotlib.pyplot as plt
 import pandas as pd
 from bw2data.backends import ActivityDataset as AD
@@ -140,24 +139,23 @@ def round_datetime(date: datetime, resolution: str) -> datetime:
             else pd.Timestamp(f"{date.year}-01-01")
         )
 
-    elif resolution == "month":
+    if resolution == "month":
         start_of_month = pd.Timestamp(f"{date.year}-{date.month}-01")
         next_month = start_of_month + pd.DateOffset(months=1)
         mid_month = start_of_month + (next_month - start_of_month) / 2
         return next_month if date >= mid_month else start_of_month
 
-    elif resolution == "day":
+    if resolution == "day":
         start_of_day = datetime(date.year, date.month, date.day)
         mid_day = start_of_day + timedelta(hours=12)
         return start_of_day + timedelta(days=1) if date >= mid_day else start_of_day
 
-    elif resolution == "hour":
+    if resolution == "hour":
         start_of_hour = datetime(date.year, date.month, date.day, date.hour)
         mid_hour = start_of_hour + timedelta(minutes=30)
         return start_of_hour + timedelta(hours=1) if date >= mid_hour else start_of_hour
 
-    else:
-        raise ValueError("Resolution must be one of 'year', 'month', 'day', or 'hour'.")
+    raise ValueError("Resolution must be one of 'year', 'month', 'day', or 'hour'.")
 
 
 def add_flows_to_characterization_function_dict(


### PR DESCRIPTION
Instead of always rounding off the dates in the timeline (using the resolution specified in temporal_grouping), this rounds them to the nearest year/month/day/hour (depending on temporal_grouping). 

Accordingly, if I run a TimexLCA with a demand for today, the timeline says the date is 2025-01-01 which I find somewhat weird, but is probably more correct than 2024-01-01 in a sense. 