### PR TITLE
retrieve nodes for interdatabase_activity_mapping after timeline

### DIFF
--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -36,6 +36,7 @@ from .utils import (
     extract_date_as_integer,
     resolve_temporalized_node_name,
     round_datetime,
+    find_matching_node,
 )
 
 
@@ -1117,14 +1118,7 @@ class TimexLCA:
 
             for background_db in background_databases:
                 try:
-                    other_node = bd.get_node(
-                        **{
-                            "database": background_db,
-                            "name": orig_act["name"],
-                            "product": orig_act["reference product"],
-                            "location": orig_act["location"],
-                        }
-                    )
+                    other_node = find_matching_node(orig_act, background_db)
                     first_level_background_node_ids_interpolated.add(other_node.id)
                     act_set.add((other_node.id, background_db))
 
@@ -1137,14 +1131,7 @@ class TimexLCA:
                 original_database not in background_databases
             ):  # add original background db in case it's not interpolated to in the timeline
                 try:
-                    other_node = bd.get_node(
-                        **{
-                            "database": original_database,
-                            "name": orig_act["name"],
-                            "product": orig_act["reference product"],
-                            "location": orig_act["location"],
-                        }
-                    )
+                    other_node = find_matching_node(orig_act, original_database)
                     first_level_background_node_ids_interpolated.add(other_node.id)
                     act_set.add((other_node.id, original_database))
 

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -250,6 +250,8 @@ class TimexLCA:
 
         self.timeline = self.timeline_builder.build_timeline()
 
+        self.add_interdatabase_activity_mapping_from_timeline()
+
         return self.timeline[
             [
                 "date_producer",
@@ -983,7 +985,7 @@ class TimexLCA:
         - ``demand_dependent_background_node_ids``: set of node ids of all processes that depend on the demand processes and are in the background databases
         - ``foreground_node_ids``: set of node ids of all processes that are not in the background databases
         - ``first_level_background_node_ids_static``: set of node ids of all processes that are in the background databases and are directly linked to the demand processes
-        - ``first_level_background_node_ids_all``: like first_level_background_node_ids_static, but includes first level background processes from other time explicit databases.
+        - ``first_level_background_node_ids_interpolated``: like first_level_background_node_ids_static, but includes first level background processes from the other time explicit databases that are used (is filled after timeline is built)
         - ``first_level_background_node_id_dbs``: dictionary with the first_level_background_node_ids_static as keys returning their database
 
         It also initiates an instance of SetList which contains all mappings of equivalent
@@ -1001,8 +1003,7 @@ class TimexLCA:
             as well as interdatabase_activity_mapping
         """
         self.node_id_collection_dict = {}
-        self.interdatabase_activity_mapping = SetList()
-
+        
         # Original variable names preserved, set types for performance and uniqueness
         demand_database_names = {
             db
@@ -1042,9 +1043,10 @@ class TimexLCA:
         self.node_id_collection_dict["foreground_node_ids"] = foreground_node_ids
 
         first_level_background_node_ids_static = set()
-        first_level_background_node_ids_all = set()
+        foreground_db = bd.Database(list(demand_database_names)[0])
+
         for node_id in foreground_node_ids:
-            node = bd.get_node(id=node_id)
+            node = foreground_db.get(id=node_id)
             for exc in chain(node.technosphere(), node.substitution()):
                 if (
                     exc.input["database"]
@@ -1053,35 +1055,89 @@ class TimexLCA:
                     ]
                 ):
                     first_level_background_node_ids_static.add(exc.input.id)
-                    act_set = {(exc.input.id, exc.input["database"])}
-
-                    for background_db in self.database_date_dict_static_only.keys():
-                        try:
-                            other_node = bd.get_node(
-                                **{
-                                    "database": background_db,
-                                    "name": exc.input["name"],
-                                    "product": exc.input["reference product"],
-                                    "location": exc.input["location"],
-                                }
-                            )
-                            first_level_background_node_ids_all.add(other_node.id)
-                            act_set.add((other_node.id, background_db))
-                        except KeyError as e:
-                            warnings.warn(
-                                f"Failed to find process in database {background_db} for \
-                                    name='{exc.input['name']}', \
-                                    reference product='{exc.input['reference product']}', \
-                                    location='{exc.input['location']}': {e}"
-                            )
-                    self.interdatabase_activity_mapping.add(act_set)
 
         self.node_id_collection_dict["first_level_background_node_ids_static"] = (
             first_level_background_node_ids_static
         )
-        self.node_id_collection_dict["first_level_background_node_ids_all"] = (
-            first_level_background_node_ids_all
-        )
+   
+
+    def add_interdatabase_activity_mapping_from_timeline(self) -> None:
+        """
+        Fills the interdatabase_activity_mapping, which is a SetList of the matching processes across background databases
+        in the format of {(id, database_name_1), (id, database_name_2)} with only those activities and background databases that are actually mapped in the timeline.
+        Also adds the ids to the node_id_collection_dict["first_level_background_node_ids_interpolated"].
+        This avoids unneccessary peewee calls.
+
+        Parameters
+        ----------
+        None
+
+
+        Returns
+        -------
+        None, but adds the ids of producers in other background databases (only those interpolated to in the timeline) to the `interdatabase_activity_mapping` and `node_id_collection["first_level_background_node_ids_interpolated"]`.
+        """
+        if not hasattr(self, "timeline"):
+            warnings.warn("Timeline not yet built. Call TimexLCA.build_timeline() first.")
+            return
+                          
+        self.interdatabase_activity_mapping = SetList()
+        first_level_background_node_ids_interpolated = set()
+        unique_producer_background_db_combos = {}
+
+        # get unique combos of producers and background dbs from timeline
+        for _, row in self.timeline.iterrows():
+            if row["interpolation_weights"] is not None: # "None" corresponds to exchanges linked within the foreground -> skipped
+                
+                if row['producer'] not in unique_producer_background_db_combos.keys():
+                    unique_producer_background_db_combos[row['producer']] = set()
+                unique_producer_background_db_combos[row['producer']].update(row["interpolation_weights"].keys())
+
+        # fill interdatabase_activity_mapping with unique combos
+        for original_producer_id, background_databases in unique_producer_background_db_combos.items():
+            original_database = list(self.node_id_collection_dict["demand_dependent_background_database_names"])[0] #what if more than one orignal bg database is linked?
+            orig_act = bd.get_node(id=original_producer_id)
+            act_set = set()
+
+            for background_db in background_databases:
+                try:
+                    other_node = bd.get_node(
+                        **{
+                            "database": background_db,
+                            "name": orig_act["name"],
+                            "product": orig_act["reference product"],
+                            "location": orig_act["location"],
+                        }
+                    )
+                    first_level_background_node_ids_interpolated.add(other_node.id)
+                    act_set.add((other_node.id, background_db)) 
+                
+                except KeyError as e:
+                    warnings.warn(
+                    f"Failed to find process in database {background_db} for name='{orig_act['name']}', reference product='{orig_act['reference product']}', location='{orig_act['location']}': {e}"
+                    )
+
+            if original_database not in background_databases: # add original background db in case it's not interpolated to in the timeline
+                try:
+                    other_node = bd.get_node(
+                    **{
+                        "database": original_database,
+                        "name": orig_act["name"],
+                        "product": orig_act["reference product"],
+                        "location": orig_act["location"],
+                    }
+                    )
+                    first_level_background_node_ids_interpolated.add(other_node.id)
+                    act_set.add((other_node.id, original_database))
+                    
+                except KeyError as e:
+                    warnings.warn(
+                    f"Failed to find process in database {original_database} for name='{orig_act["name"]}', reference product='{orig_act['reference product']}', location='{orig_act['location']}': {e}"
+                    )
+            
+            self.interdatabase_activity_mapping.add(act_set)
+            self.node_id_collection_dict["first_level_background_node_ids_interpolated"] = first_level_background_node_ids_interpolated
+        return
 
     def collect_temporalized_processes_from_timeline(self) -> None:
         """

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -1132,7 +1132,7 @@ class TimexLCA:
                     
                 except KeyError as e:
                     warnings.warn(
-                    f"Failed to find process in database {original_database} for name='{orig_act["name"]}', reference product='{orig_act['reference product']}', location='{orig_act['location']}': {e}"
+                    f"Failed to find process in database {original_database} for name='{orig_act['name']}', reference product='{orig_act['reference product']}', location='{orig_act['location']}': {e}"
                     )
             
             self.interdatabase_activity_mapping.add(act_set)

--- a/bw_timex/utils.py
+++ b/bw_timex/utils.py
@@ -4,6 +4,7 @@ from typing import Callable, List, Optional, Union
 
 import matplotlib.pyplot as plt
 import pandas as pd
+import bw2data as bd
 from bw2data.backends import ActivityDataset as AD
 from bw2data.backends.proxies import Exchange
 from bw2data.backends.schema import ExchangeDataset
@@ -219,6 +220,34 @@ def resolve_temporalized_node_name(code: str) -> str:
     elif not qs:
         raise UnknownObject
     return names.pop()
+
+
+def find_matching_node(original_node, other_background_db):
+    """
+    Find a node in another background database that matches the original node based on name,
+    reference product, and location.
+
+    Parameters
+    ----------
+    original_node : dict
+        Original node to find a match for.
+    other_background_db : str
+        Name of the other background database to search in.
+
+    Returns
+    -------
+    dict
+        Matching node in the other background database.
+    """
+    other_node = bd.get_node(
+        **{
+            "database": other_background_db,
+            "name": original_node["name"],
+            "product": original_node["reference product"],
+            "location": original_node["location"],
+        }
+    )
+    return other_node
 
 
 def plot_characterized_inventory_as_waterfall(


### PR DESCRIPTION
retrieve nodes for interdatabase_activity_mapping only once and only for producer-database pairs that are part of the interpolation in the timeline.

changes include:
- moving the look-up of nodes from other databases from init() to after build_timeline()
- looking up nodes in a background database only once (by using a set) and not everytime when it is an exchange at the intersection between foreground and background (Previously: if electricity from a background database was consumed by foreground process A, B and C, it would have been looked up 3 times in the former implementation)
- only look up a node in those background databases between which is interpolated in the timeline (previously: if there were 10 databases in the database-date-dict, it would have looked up the node in all of them)

This is quite similar to what is on the refactor_node_id_collection branch, but because that branch was branched off quite long ago, I've put this into a new branch.

The tests work and especially for larger systems, this should save time from redundant peewee calls, but please check if you think this makes sense.