### PR TITLE
Support explicit product-modelling

### DIFF
--- a/bw_timex/dynamic_biosphere_builder.py
+++ b/bw_timex/dynamic_biosphere_builder.py
@@ -194,8 +194,12 @@ class DynamicBiosphereBuilder:
                 # Get temporal evolution factor for this timestamp
                 temporal_evolution_factor = 1.0
                 if hasattr(row, "temporal_evolution") and row.temporal_evolution is not None:
+                    reference = getattr(row, "temporal_evolution_reference", "producer")
+                    reference_time = (
+                        row.date_consumer if reference == "consumer" else time_in_datetime
+                    )
                     temporal_evolution_factor = get_temporal_evolution_factor(
-                        row.temporal_evolution, time_in_datetime
+                        row.temporal_evolution, reference_time
                     )
 
                 for input_id, exc_amount, temporal_distribution in (

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -11,6 +11,11 @@ from bw2data.backends.schema import ActivityDataset as AD
 from bw2data.backends.schema import ExchangeDataset as ED
 from bw_temporalis import TemporalDistribution, TemporalisLCA, loader_registry
 
+from .utils import get_reference_product_production_amount
+
+if not hasattr(np, "in1d"):
+    np.in1d = np.isin
+
 datetime_type = np.dtype("datetime64[s]")
 timedelta_type = np.dtype("timedelta64[s]")
 
@@ -36,6 +41,7 @@ class Edge:
     abs_td_producer: TemporalDistribution = None
     abs_td_consumer: TemporalDistribution = None
     temporal_evolution: dict = None
+    temporal_evolution_reference: str = "producer"
 
 
 def extract_temporal_evolution(exc_data: dict) -> dict | None:
@@ -133,13 +139,56 @@ class EdgeExtractor(TemporalisLCA):
             self.unique_id
         ]:  # starting at the edges of the functional unit
             node = self.nodes[edge.producer_unique_id]
+            td_producer = edge.amount
+            initial_distribution = self.t0 * edge.amount
+            abs_td_producer = self.t0
+            abs_td_consumer = None
+
+            row_id = self.lca_object.dicts.product.reversed[edge.product_index]
+            col_id = node.activity_datapackage_id
+            exchange = self.get_technosphere_exchange(input_id=row_id, output_id=col_id)
+
+            # In the explicit process/product paradigm, the demanded product is produced
+            # by an off-diagonal production edge. A TD on that edge distributes the
+            # process invocation itself before the process inputs are traversed.
+            if (
+                row_id != col_id
+                and hasattr(exchange, "data")
+                and exchange.data.get("type") == "production"
+            ):
+                production_amount = abs(
+                    get_reference_product_production_amount(
+                        col_id, reference_product=row_id, lca=self.lca_object
+                    )
+                )
+                td_producer = (
+                    self._exchange_value(
+                        exchange=exchange,
+                        row_id=row_id,
+                        col_id=col_id,
+                        matrix_label="technosphere_matrix",
+                    )
+                    / production_amount
+                    * edge.amount
+                )
+                if isinstance(td_producer, Number):
+                    td_producer = TemporalDistribution(
+                        date=np.array([0], dtype="timedelta64[Y]"),
+                        amount=np.array([td_producer]),
+                    )
+                initial_distribution = (self.t0 * td_producer).simplify()
+                abs_td_producer = self.join_datetime_and_timedelta_distributions(
+                    td_producer, self.t0
+                )
+                abs_td_consumer = self.t0
+
             heappush(
                 heap,
                 (
                     1 / node.cumulative_score,
-                    self.t0 * edge.amount,
+                    initial_distribution,
                     self.t0,
-                    self.t0,
+                    abs_td_producer,
                     node,
                 ),
             )
@@ -147,13 +196,14 @@ class EdgeExtractor(TemporalisLCA):
             timeline.append(
                 Edge(
                     edge_type="production",  # FU exchange always type production (?)
-                    distribution=self.t0 * edge.amount,
+                    distribution=initial_distribution,
                     leaf=False,
                     consumer=self.unique_id,
                     producer=node.activity_datapackage_id,
-                    td_producer=edge.amount,
+                    td_producer=td_producer,
                     td_consumer=self.t0,
-                    abs_td_producer=self.t0,
+                    abs_td_producer=abs_td_producer,
+                    abs_td_consumer=abs_td_consumer,
                 )
             )
 
@@ -163,10 +213,17 @@ class EdgeExtractor(TemporalisLCA):
             for edge in self.edge_mapping[node.unique_id]:
                 row_id = self.nodes[edge.producer_unique_id].activity_datapackage_id
                 col_id = node.activity_datapackage_id
+                product_id = self.lca_object.dicts.product.reversed[edge.product_index]
                 exchange = self.get_technosphere_exchange(
-                    input_id=row_id,
+                    input_id=product_id,
                     output_id=col_id,
                 )
+                if not hasattr(exchange, "data"):
+                    exchange = self.get_technosphere_exchange(
+                        input_id=row_id,
+                        output_id=col_id,
+                    )
+                    product_id = row_id
 
                 edge_type = exchange.data[
                     "type"
@@ -174,15 +231,22 @@ class EdgeExtractor(TemporalisLCA):
 
                 # Extract temporal evolution data from exchange
                 temporal_evolution = extract_temporal_evolution(exchange.data)
+                temporal_evolution_reference = exchange.data.get(
+                    "temporal_evolution_reference", "producer"
+                )
 
                 td_producer = (  # td_producer is the TemporalDistribution of the edge
                     self._exchange_value(
                         exchange=exchange,
-                        row_id=row_id,
+                        row_id=product_id,
                         col_id=col_id,
                         matrix_label="technosphere_matrix",
                     )
-                    / abs(node.reference_product_production_amount)
+                    / abs(
+                        get_reference_product_production_amount(
+                            node.activity_datapackage_id, lca=self.lca_object
+                        )
+                    )
                 )
                 producer = self.nodes[edge.producer_unique_id]
                 leaf = self.edge_ff(row_id)
@@ -193,6 +257,38 @@ class EdgeExtractor(TemporalisLCA):
                         date=np.array([0], dtype="timedelta64[Y]"),
                         amount=np.array([td_producer]),
                     )
+
+                if product_id != row_id:
+                    production_exchange = self.get_technosphere_exchange(
+                        input_id=product_id,
+                        output_id=row_id,
+                    )
+                    if (
+                        hasattr(production_exchange, "data")
+                        and production_exchange.data.get("type") == "production"
+                    ):
+                        production_amount = abs(
+                            get_reference_product_production_amount(
+                                row_id,
+                                reference_product=product_id,
+                                lca=self.lca_object,
+                            )
+                        )
+                        production_td = (
+                            self._exchange_value(
+                                exchange=production_exchange,
+                                row_id=product_id,
+                                col_id=row_id,
+                                matrix_label="technosphere_matrix",
+                            )
+                            / production_amount
+                        )
+                        if isinstance(production_td, Number):
+                            production_td = TemporalDistribution(
+                                date=np.array([0], dtype="timedelta64[Y]"),
+                                amount=np.array([production_td]),
+                            )
+                        td_producer = (td_producer * production_td).simplify()
 
                 distribution = (
                     td * td_producer
@@ -212,6 +308,7 @@ class EdgeExtractor(TemporalisLCA):
                         ),
                         abs_td_consumer=abs_td,
                         temporal_evolution=temporal_evolution,
+                        temporal_evolution_reference=temporal_evolution_reference,
                     )
                 )
                 if not leaf:
@@ -368,10 +465,11 @@ class EdgeExtractorBFS:
         return amount, edge_type, temporal_evolution
 
     def _get_production_amount(self, activity_id: int) -> float:
-        """Get the reference product production amount (diagonal of tech matrix)."""
-        product_idx = self.lca_object.dicts.product[activity_id]
-        col_idx = self.lca_object.dicts.activity[activity_id]
-        return self.tech_matrix_csc[product_idx, col_idx]
+        """Get the reference product production amount."""
+        activity = self.lca_object.dicts.activity.reversed[
+            self.lca_object.dicts.activity[activity_id]
+        ]
+        return get_reference_product_production_amount(activity)
 
     def _get_technosphere_inputs(self, activity_id: int) -> list[int]:
         """Get all technosphere input activity IDs for a given activity."""

--- a/bw_timex/matrix_modifier.py
+++ b/bw_timex/matrix_modifier.py
@@ -7,7 +7,10 @@ import numpy as np
 import pandas as pd
 
 from .helper_classes import InterDatabaseMapping
-from .utils import get_temporal_evolution_factor
+from .utils import (
+    get_reference_product_production_amount,
+    get_temporal_evolution_factor,
+)
 
 
 class MatrixModifier:
@@ -220,7 +223,9 @@ class MatrixModifier:
 
         if row.consumer == -1:  # functional unit
             new_producer_id = row.time_mapped_producer
-            fu_production_amount = self.nodes[row.producer].rp_exchange().amount
+            fu_production_amount = get_reference_product_production_amount(
+                self.nodes[row.producer]
+            )
             new_nodes.add((new_producer_id, fu_production_amount))
             self.temporalized_process_ids.add(
                 new_producer_id
@@ -233,15 +238,21 @@ class MatrixModifier:
         previous_producer_id = row.producer
         previous_producer_node = self.nodes[previous_producer_id]
 
-        production_exchange_amount = self.nodes[row.consumer].rp_exchange().amount
+        production_exchange_amount = get_reference_product_production_amount(
+            self.nodes[row.consumer], reference_product=row.consumer
+        )
         scaled_amount = row.amount * abs(
             production_exchange_amount
         )  # abs value used for scaling to preserve the sign of the exchange
 
         # Apply temporal evolution scaling if present
         if hasattr(row, "temporal_evolution") and row.temporal_evolution is not None:
+            reference = getattr(row, "temporal_evolution_reference", "producer")
+            reference_date = (
+                row.date_consumer if reference == "consumer" else row.date_producer
+            )
             factor = get_temporal_evolution_factor(
-                row.temporal_evolution, row.date_producer
+                row.temporal_evolution, reference_date
             )
             scaled_amount *= factor
 
@@ -316,8 +327,8 @@ class MatrixModifier:
                         "The producer activity is of type IOTableActivity, but has more than one production exchange. This is currently not supported."
                     )
             elif isinstance(previous_producer_node, bd.backends.proxies.Activity):
-                producer_production_amount = (
-                    self.nodes[row.producer].rp_exchange().amount
+                producer_production_amount = get_reference_product_production_amount(
+                    self.nodes[row.producer], reference_product=row.producer
                 )
             else:
                 raise ValueError(

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -222,6 +222,7 @@ class TimelineBuilder:
                     "producer",
                     "consumer",
                     "_te_key",
+                    "temporal_evolution_reference",
                 ],
                 dropna=False,
             )
@@ -314,6 +315,7 @@ class TimelineBuilder:
                 "amount",
                 "temporal_market_shares",
                 "temporal_evolution",
+                "temporal_evolution_reference",
             ]
         ]
 
@@ -363,6 +365,7 @@ class TimelineBuilder:
             "amount": edge.abs_td_producer.amount,
             "edge_type": edge.edge_type,
             "temporal_evolution": edge.temporal_evolution,
+            "temporal_evolution_reference": edge.temporal_evolution_reference,
         }
 
     def adjust_sign_of_amount_based_on_edge_type(self, edge_type):

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -1300,27 +1300,10 @@ class TimexLCA:
 
         if demands:
             indexed_demand = [
-                {
-                    self.activity_time_mapping[
-                        (
-                            bd.get_node(id=bd.get_id(k)).key,
-                            self.demand_timing[bd.get_id(k)],
-                        )
-                    ]: v
-                    for k, v in dct.items()
-                }
-                for dct in demands
+                self._build_indexed_demand(dct) for dct in demands
             ]
         elif demand:
-            indexed_demand = {
-                self.activity_time_mapping[
-                    (
-                        ("temporalized", bd.get_node(id=bd.get_id(k))["code"]),
-                        self.demand_timing[bd.get_id(k)],
-                    )
-                ]: v
-                for k, v in demand.items()
-            }
+            indexed_demand = self._build_indexed_demand(demand)
         else:
             indexed_demand = None
 
@@ -1529,11 +1512,11 @@ class TimexLCA:
 
     def create_demand_timing(self) -> dict:
         """
-        Generate a dictionary that maps producer (key) to timing (value) for the demands in the
-        product system. It searches the timeline for those rows that contain the functional units
-        (demand-processes as producer and -1 as consumer) and returns the time of the demand as an
-        integer. Time of demand can have flexible resolution (year=YYYY, month=YYYYMM, day=YYYYMMDD,
-        hour=YYYYMMDDHH) defined in `temporal_grouping`.
+        Generate a dictionary that maps demand id (key) to timing (value) for the demands in the
+        product system. It searches the timeline for the FU rows (consumer == -1) and looks up the
+        timing of the producing process. For demands keyed by an explicit product node, the producer
+        in the timeline is the process producing that product, so we resolve the product → process
+        relationship via the production exchange.
 
         Parameters
         ----------
@@ -1542,31 +1525,107 @@ class TimexLCA:
         Returns
         -------
         dict
-            Dictionary mapping producer ids to reference timing for the specified demands.
+            Dictionary mapping demand ids to reference timing for the specified demands.
         """
-        demand_ids = [bd.get_id(key) for key in self.demand.keys()]
-        demand_rows = self.timeline[
-            self.timeline["producer"].isin(demand_ids)
-            & (self.timeline["consumer"] == -1)
-        ]
+        process_id_by_demand_id = {
+            bd.get_activity(key).id: self._resolve_demand_to_process_id(key)
+            for key in self.demand.keys()
+        }
+        fu_rows = self.timeline[self.timeline["consumer"] == -1]
+        timing_by_process_id = {
+            row.producer: row.hash_producer for row in fu_rows.itertuples()
+        }
 
-        missing_demand_ids = sorted(set(demand_ids) - set(demand_rows["producer"]))
-        if missing_demand_ids:
-            functional_unit_producers = sorted(
-                set(self.timeline.loc[self.timeline["consumer"] == -1, "producer"])
-            )
+        missing_process_ids = sorted(
+            set(process_id_by_demand_id.values()) - set(timing_by_process_id)
+        )
+        if missing_process_ids:
+            functional_unit_producers = sorted(set(timing_by_process_id))
             raise ValueError(
-                "Could not find functional-unit timing rows for demand id(s) "
-                f"{missing_demand_ids}. The existing timeline contains functional-unit "
+                "Could not find functional-unit timing rows for producing process id(s) "
+                f"{missing_process_ids}. The existing timeline contains functional-unit "
                 f"producer id(s) {functional_unit_producers}. This usually means the "
                 "Brightway database or demand nodes changed after build_timeline(); "
                 "recreate the TimexLCA object and rebuild the timeline before calling lci()."
             )
 
+
         self.demand_timing = {
-            row.producer: row.hash_producer for row in demand_rows.itertuples()
+            demand_id: timing_by_process_id[process_id]
+            for demand_id, process_id in process_id_by_demand_id.items()
+            if process_id in timing_by_process_id
         }
         return self.demand_timing
+
+    def _build_indexed_demand(self, demand_dict) -> dict:
+        """Map a demand dict to time-mapped producer ids, distributed across
+        every install-vintage cohort produced by an output-side temporal
+        distribution.
+
+        Each FU row in the timeline corresponds to one cohort of the demand's
+        producing process; ``row.amount`` is the cohort's share of the
+        original demand value. Summing the FU rows reproduces the user's
+        demand magnitude while preserving the cohort split, so that
+        downstream matrix-modifier logic (which keys temporal markets by
+        ``time_mapped_producer``) routes each cohort's inputs to the
+        appropriate background database.
+        """
+        if not hasattr(self, "timeline"):
+            raise AttributeError(
+                "Timeline not yet built. Call TimexLCA.build_timeline() first."
+            )
+
+        fu_rows = self.timeline[self.timeline["consumer"] == -1]
+        indexed = {}
+        for k, v in demand_dict.items():
+            process_id = self._resolve_demand_to_process_id(k)
+            cohort_rows = fu_rows[fu_rows["producer"] == process_id]
+            if cohort_rows.empty:
+                raise ValueError(
+                    f"No functional-unit rows in timeline for demand `{k}` "
+                    f"(process id {process_id}). Did you call build_timeline?"
+                )
+            cohort_total = float(cohort_rows["amount"].sum())
+            if cohort_total == 0:
+                raise ValueError(
+                    f"Functional-unit rows for demand `{k}` sum to zero amount."
+                )
+            scale = float(v) / cohort_total
+            for row in cohort_rows.itertuples():
+                indexed[row.time_mapped_producer] = (
+                    indexed.get(row.time_mapped_producer, 0.0)
+                    + float(row.amount) * scale
+                )
+        return indexed
+
+    def _resolve_demand_to_process_id(self, key) -> int:
+        """Return the id of the process producing ``key``.
+
+        For demands keyed by a process node this is the demand id itself. For demands keyed by a
+        product node (explicit process/product paradigm) we look up the process via the production
+        exchange targeting that product.
+        """
+        node = bd.get_activity(key) if not hasattr(key, "id") else key
+        if node.get("type") != "product":
+            return node.id
+        for exc in node.upstream(kinds=["production"]):
+            return exc.output.id
+        raise ValueError(
+            f"Could not resolve product `{node}` to its producing process: no production "
+            "exchange targets it."
+        )
+
+    def _resolve_demand_to_process_key(self, key):
+        """Return the (database, code) key of the process producing ``key``."""
+        node = bd.get_activity(key) if not hasattr(key, "id") else key
+        if node.get("type") != "product":
+            return node.key
+        for exc in node.upstream(kinds=["production"]):
+            return exc.output.key
+        raise ValueError(
+            f"Could not resolve product `{node}` to its producing process: no production "
+            "exchange targets it."
+        )
 
     ######################################
     # For creating human-friendly output #

--- a/bw_timex/utils.py
+++ b/bw_timex/utils.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime, timedelta
 from typing import Callable, List, Optional, Union
 
+import bw2data as bd
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -34,6 +35,49 @@ time_res_mapping_strftime = {
     "day": "%Y%m%d",
     "hour": "%Y%m%d%H",
 }
+
+
+def get_reference_product_production_amount(
+    node, *, reference_product=None, lca=None
+) -> float:
+    """Return a node's production amount in a paradigm-agnostic way.
+
+    Supports chimaera activities via ``rp_exchange`` and explicit process/product
+    setups via production exchanges.
+    """
+    if isinstance(node, (int, np.integer)):
+        node = bd.get_activity(id=int(node))
+
+    if hasattr(node, "rp_exchange"):
+        rp_exc = node.rp_exchange()
+        if rp_exc is not None:
+            return rp_exc.amount
+
+    productions = list(node.production())
+    if not productions:
+        raise ValueError(
+            f"Could not determine production amount for node `{node}`: no production exchanges found."
+        )
+
+    if reference_product is not None:
+        ref_id = (
+            reference_product.id
+            if hasattr(reference_product, "id")
+            else int(reference_product)
+        )
+        for exc in productions:
+            if exc.input.id == ref_id:
+                return exc.amount
+        raise ValueError(
+            f"Could not find production exchange from `{node}` to reference product id `{ref_id}`."
+        )
+
+    if len(productions) == 1:
+        return productions[0].amount
+
+    raise ValueError(
+        f"Node `{node}` has multiple production exchanges; pass `reference_product` to disambiguate."
+    )
 
 
 def extract_date_as_integer(dt_obj: datetime, time_res: Optional[str] = "year") -> int:
@@ -503,6 +547,7 @@ def add_temporal_distribution_to_exchange(
 def add_temporal_evolution_to_exchange(
     temporal_evolution_factors: dict = None,
     temporal_evolution_amounts: dict = None,
+    temporal_evolution_reference: str = "producer",
     **kwargs,
 ):
     """Add temporal evolution data to an exchange specified by kwargs.
@@ -513,6 +558,8 @@ def add_temporal_evolution_to_exchange(
         Dictionary mapping datetime keys to scaling factors.
     temporal_evolution_amounts : dict, optional
         Dictionary mapping datetime keys to absolute amounts.
+    temporal_evolution_reference : {"producer", "consumer"}, optional
+        Whether temporal evolution is evaluated at producer or consumer timestamps.
     **kwargs :
         Arguments to specify an exchange (same as get_exchange).
 
@@ -526,12 +573,14 @@ def add_temporal_evolution_to_exchange(
     TemporalEvolutionExchangeInputs(
         temporal_evolution_factors=temporal_evolution_factors,
         temporal_evolution_amounts=temporal_evolution_amounts,
+        temporal_evolution_reference=temporal_evolution_reference,
     )
     exchange = get_exchange(**kwargs)
     if temporal_evolution_factors is not None:
         exchange["temporal_evolution_factors"] = temporal_evolution_factors
     if temporal_evolution_amounts is not None:
         exchange["temporal_evolution_amounts"] = temporal_evolution_amounts
+    exchange["temporal_evolution_reference"] = temporal_evolution_reference
     exchange.save()
     logger.info(f"Added temporal evolution to exchange {exchange}.")
 

--- a/bw_timex/validation.py
+++ b/bw_timex/validation.py
@@ -177,6 +177,7 @@ class TemporalEvolutionExchangeInputs(BaseModel):
 
     temporal_evolution_factors: Optional[dict] = None
     temporal_evolution_amounts: Optional[dict] = None
+    temporal_evolution_reference: Literal["producer", "consumer"] = "producer"
 
     @model_validator(mode="after")
     def validate_mutual_exclusivity(self) -> "TemporalEvolutionExchangeInputs":

--- a/docs/content/decisiontree.md
+++ b/docs/content/decisiontree.md
@@ -43,3 +43,97 @@ flowchart TD
     BackgroundDecision -- "no" --> CodeDynamicLCIA
     BackgroundDecision -- "yes" --> CodeDisaggregatedLCIA
 ```
+
+## Modeling paradigm option: chimaera vs explicit process/product
+
+Brightway supports more than one way to represent inventory data. See the Brightway inventory
+overview on [processes, products, and something in between](https://docs.brightway.dev/en/latest/content/overview/inventory.html#processes-products-and-something-in-between)
+for the broader data-model discussion. In short:
+
+- **Explicit process/product** (`type="process"` + `type="product"`): products are separate
+  nouns, processes are separate verbs, and production edges connect processes to products.
+- **Chimaera** (`type="processwithreferenceproduct"`): one node acts as both process and
+  reference product. This is common in existing LCI databases and compact for many models.
+
+Both paradigms are valid modelling choices. `bw_timex` aims to support both when building
+timelines and expanding matrices. The right choice depends on what you need to express and on the
+data you start from.
+
+### Terms used below
+
+A **production-time group** is a set of product units supplied or produced at the same time. In
+fleet and stock modelling, this is often called a **cohort**; for example, all vehicles produced in
+2030 are the 2030 cohort. A **process/product version date** is the date that fixes a foreground
+property of that group, such as vehicle efficiency or a material requirement. Some literature calls
+this a **vintage**.
+
+### When chimaera nodes are often pragmatic
+
+Use chimaera activities when your data already comes this way, when each process has one clear
+reference product, and when you do not need to attach separate temporal meaning to the product
+output edge itself. Most conventional Brightway examples and many imported databases follow this
+style.
+
+For production-time group timing in a chimaera model, you usually add an intermediary foreground
+activity and put the temporal distribution on a normal technosphere edge, e.g.:
+
+```text
+fleet_service -- production-time group TD --> fleet_driving
+fleet_driving -- age TD --> electricity
+```
+
+This is a structural modelling pattern: `fleet_service` exists to give the production-time group
+timing a place to live.
+
+### When explicit process/product nodes are often clearer
+
+Use explicit process/product nodes when distinguishing the demanded product from the operation
+that produces it helps the model. This is especially useful when timing belongs naturally to the
+production output edge, such as production of multiple production-time groups, delayed delivery, service availability, or
+multi-output process modelling.
+
+For production-time group timing in an explicit model, put the temporal distribution directly on
+the production edge:
+
+```text
+fleet_process -- production-time group TD --> fleet_product
+fleet_process -- age TD --> electricity
+```
+
+This makes production timing part of the graph topology instead of introducing a wrapper activity.
+It also makes the two timeline dates easier to interpret:
+
+- `date_consumer`: the process/product version date or demand-side process instance date.
+- `date_producer`: the actual exchange event date.
+
+### How this relates to temporal evolution
+
+The modelling paradigm does not decide whether you use `consumer` or `producer` for temporal
+evolution. That choice depends on what the evolving exchange amount means:
+
+- Use `consumer` when the amount is a property of the consuming foreground process/product
+  version date.
+- Use `producer` when the amount is a property of the calendar year in which the exchange event
+  happens.
+
+Explicit process/product models often make this distinction more visible because a production-edge
+temporal distribution can create distinct product/process version dates without an intermediary
+node.
+But the same conceptual rule applies in chimaera models if your graph structure creates meaningful
+consumer and producer dates.
+
+### Which temporal evolution reference should I use?
+
+Foreground temporal evolution can be keyed to either the consumer timestamp or the producer timestamp. The names are graph terms:
+
+- `temporal_evolution_reference="consumer"` means the factor is evaluated at `date_consumer`: the time of the foreground process instance using the exchange. In production-time group models, this is usually the **process/product version date**.
+- `temporal_evolution_reference="producer"` means the factor is evaluated at `date_producer`: the time when the exchanged input/output event actually happens. This is the **calendar event date**.
+
+Use `consumer` for version-locked properties, e.g. a vehicle produced in 2025 keeps its 2025 kWh/km in 2035. Use `producer` for calendar-year properties, e.g. a repair operation becomes more efficient for all active vehicles in 2035.
+
+Rule of thumb:
+
+```text
+Property of the foreground process/product version date? -> consumer
+Property of the exchange event year?                -> producer
+```

--- a/docs/content/dev/explicit_process_product_paradigm.md
+++ b/docs/content/dev/explicit_process_product_paradigm.md
@@ -1,0 +1,258 @@
+# Implementation plan: explicit `process` + `product` node support
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed (not yet scheduled) |
+| Audience | `bw_timex` maintainers and contributors |
+| Scope | Add full support for Brightway's explicit `process` / `product` node paradigm, including `temporal_distribution` on production-typed output edges |
+| Related issues | TBD (file when prioritised) |
+| Related notebook | `notebooks/example_electric_vehicle_fleet.ipynb` (motivating use case) |
+
+This document captures the analysis behind that scope and the concrete changes needed in `bw_timex` (and one upstream dependency). It is intended to be read end-to-end before any of the changes below are picked up; the order, rationale and out-of-scope items matter.
+
+## 1. Motivation
+
+`bw_timex` distributes exchanges in time via `TemporalDistribution` (TD) attached to *technosphere* edges. When a model needs to inject a *cohort* distribution — i.e., a temporal pattern on the **output** of an activity rather than on any single input — the only working pattern today is to insert an aggregator node:
+
+```text
+FU = {fleet_service: 1}
+fleet_service ──[TD = cohort distribution]──▶ fleet_driving
+                                               ├──[TD = age survival]──▶ electricity
+                                               └──[TD = age retirement PDF]──▶ used_ev
+```
+
+This works (it is the pattern used in `example_electric_vehicle_fleet.ipynb`), but the `fleet_service` node is purely structural: it exists to give the cohort TD a technosphere edge to live on. In Brightway's explicit paradigm — `process` and `product` as separate nodes connected by an off-diagonal output edge — the cohort TD has a natural home on the `process → product` edge, and the aggregator disappears:
+
+```text
+FU = {fleet_driving_product: 1}
+fleet_driving_process ──[output edge, type="production", TD = cohort]──▶ fleet_driving_product
+fleet_driving_process ←──[input edge,  type="technosphere",  TD = age]── electricity_product
+fleet_driving_process ←──[input edge,  type="technosphere",  TD = retirement]── used_ev_product
+```
+
+Same math, three nodes instead of four, and the topology says what it means. The barrier today is that `bw_timex`'s graph traversal silently fails on this paradigm; the aim of this plan is to remove that barrier.
+
+## 2. Background: how Brightway represents activities
+
+`bw2data ≥ 4.0` defines two complementary node-type families (`bw2data/configuration.py`):
+
+```python
+process_node_types  = ["process", "processwithreferenceproduct"]
+product_node_types  = ["product"]
+chimaera_node_default = "processwithreferenceproduct"
+```
+
+Two relevant paradigms emerge:
+
+1. **Chimaera (default).** A single `processwithreferenceproduct` node represents both the activity and its reference product. The technosphere matrix has one column per node and one row per node; each chimaera contributes one diagonal entry (the production self-loop) and zero or more off-diagonal entries (technosphere consumption from other chimaeras).
+2. **Explicit.** Two distinct nodes — a `process` and a `product` — connected by a `type="production"` exchange. Process columns and product rows are decoupled; the production exchange is a real off-diagonal entry whose `amount` is the output coefficient. Multi-product processes (co-production) are expressible by adding more `process → product` output edges from the same process.
+
+The chimaera paradigm is by far the most common in published Brightway practice; explicit nodes appear in input-output and SUT-style models, in some `bonsai`-style supply-chain models, and in any modelling style that wants to attach TDs (or other metadata) to the act of producing the reference product.
+
+`bw2calc.LCA` accepts both paradigms: it requires the FU to be a **product** (`"LCA can only be performed on products, not activities"`), but the producer can be either a chimaera or an explicit process. Static LCAs over explicit graphs work today.
+
+## 3. Current `bw_timex` behaviour on explicit graphs
+
+A minimal repro (electricity-only model, FU = `{fleet_driving_product: 1}`, cohort TD on the `process → product` output edge, age TD on the electricity input):
+
+```python
+import bw2calc as bc
+bc.LCA({fd_product: 1}, method).lci();  bc.LCA(...).lcia()
+# → static_score = 5.0 (correct)
+
+from bw_timex import TimexLCA
+tlca = TimexLCA({fd_product: 1}, method, database_dates)
+tlca.build_timeline(starting_datetime=datetime(2030,1,1), temporal_grouping="year")
+# → timeline rows: 1
+#    only the FU placeholder, no supply chain walk
+tlca.lci()
+# → KeyError on the product id (not in demand_timing / activity_time_mapping)
+```
+
+Three independent failures stack up:
+
+1. **`bw_graph_tools.matrix_tools.gpe_second_heuristic` crashes on NumPy 2** because of a `np.in1d` call (removed in NumPy 2.0; replaced by `np.isin`). This heuristic only fires when the production-exchange diagonal is ambiguous, which is exactly the explicit-paradigm case. A `np.in1d = np.isin` shim unblocks this layer but is *not* a fix.
+2. **The graph traversal terminates at the demanded product.** Both the `EdgeExtractor` (priority traversal, inheriting from `bw_temporalis.TemporalisLCA`) and the BFS variant (`EdgeExtractorBFS._get_technosphere_inputs` in `bw_timex/edge_extractor.py:390`) assume `dicts.product[activity_id]` resolves — i.e., that each tech-matrix column corresponds to a single product on the diagonal. With explicit nodes, `dicts.product.get(process_id)` is `None`, and:
+   - The "skip self-loop" filter (`if row_idx == product_idx: continue`) becomes a no-op, so the *output* row is treated as just another input with the wrong sign.
+   - With a `Product` as FU, `bw_graph_tools` does not perform the bipartite step "find producing process for this product, then descend into its inputs."
+3. **`prepare_bw_timex_inputs` fails** because the demanded `Product` was never registered in `demand_timing` / `activity_time_mapping` (the traversal didn't reach it). This surfaces as a `KeyError` in `timex_lca.py:1133`.
+
+In addition, the matrix-modifier layer assumes chimaera-shaped activities:
+
+- `edge_extractor.py:178` — `node.reference_product_production_amount`
+- `matrix_modifier.py:223` — `self.nodes[row.producer].rp_exchange().amount` (FU branch)
+- `matrix_modifier.py:236` — `self.nodes[row.consumer].rp_exchange().amount` (general branch)
+- `matrix_modifier.py:314-321` — already special-cases `IOTableActivity`; the explicit `process` case must be added alongside.
+
+For a pure `process` node, `rp_exchange()` returns `None` or raises depending on the bw2data branch; either way the call site needs to look up the production-typed output edge to the reference product instead.
+
+## 4. Theoretical model: TD on the production output edge
+
+Notation: process column `P`, product row `Q`, output coefficient `α` (entry of the tech matrix at row `Q`, column `P`), input coefficient `β` from another product `R` (row `R`, column `P`).
+
+Static LCA: scaling factor for `P` to satisfy `{Q: 1}` = `1/α`. Each unit of `P` consumes `β/α` of `R`.
+
+Now decorate the output edge with a cohort TD `{c_i: w_i}` (offsets relative to the FU date, weights summing to 1) and the input edge with an age TD `{a_j: v_j}` (offsets relative to each cohort instance):
+
+- Each cohort `c_i` invokes `P` at scale `w_i / α`.
+- For each cohort instance, the input from `R` is consumed at age `a_j` with weight `v_j × β × w_i / α` at calendar year `c_i + a_j`.
+- `date_consumer` of the input edge is the cohort year `c_i` (because the consumer-side date is the date of the producing process invocation).
+
+This is exactly the cohort × age decomposition we want from the `fleet_service` intermediary today, with two architectural simplifications:
+
+1. The cohort TD lives on a single edge of `fleet_driving_process`, not on a foreign edge from a structural placeholder. The model reads as the system that exists.
+2. `temporal_evolution_factors` with `reference="consumer"` evaluates at `c_i` directly — vintage locking is the natural reading, not a thing one has to argue for.
+
+The output-edge TD is a *first-class temporal modifier on the production decision*, not a workaround. This is the abstraction we want long-term.
+
+## 5. Required changes
+
+Ordered shallow → deep. Each phase is independently testable and ships value on its own.
+
+### Phase 0 — unblock `bw_graph_tools` on NumPy 2
+
+**Type:** upstream / dependency hygiene. Not strictly part of this plan, but blocks anyone trying explicit graphs today.
+
+- Either pin `bw_graph_tools` to a version known to work, or upstream a one-line patch replacing `np.in1d` with `np.isin` in `bw_graph_tools/matrix_tools.py:132` (and any other call sites). The latter is preferable.
+- No new test in `bw_timex` until phase 1 is in; the failure mode is masked by an `AttributeError` on import paths users don't normally hit.
+
+### Phase 1 — replace chimaera-only production-amount lookups with a paradigm-aware helper
+
+**Files:** `bw_timex/edge_extractor.py`, `bw_timex/matrix_modifier.py`.
+**Effort:** ~half a day, mostly mechanical.
+**User-visible behaviour:** static LCAs over explicit graphs (single-product processes only) start to produce sensible *base_lca* results inside `TimexLCA`, even before any traversal changes. Multi-output / cohort-TD use cases still won't work; that's later phases.
+
+Add one helper:
+
+```python
+# bw_timex/utils.py (new function)
+def get_reference_product_production_amount(node, *, reference_product=None):
+    """Return the production amount for `node`'s reference product, paradigm-agnostic.
+
+    - chimaera (`processwithreferenceproduct`): self-loop production exchange amount.
+    - explicit `process`: amount of the production-typed output edge into the
+      requested `reference_product` (or, if the process has exactly one
+      production output, that one).
+    - explicit `product`: production amount of the producing process for this
+      product; raises if multiple producers exist (caller must disambiguate).
+    - `IOTableActivity`: existing branch, kept.
+    """
+```
+
+Replace these call sites with the helper (preserving the existing `IOTableActivity` special-case):
+
+- `edge_extractor.py:178` (priority traversal) — `node.reference_product_production_amount`
+- `edge_extractor.py:447` (BFS traversal, `_get_production_amount`) — `tech_matrix[product_idx, col_idx]`
+- `matrix_modifier.py:223` (FU branch)
+- `matrix_modifier.py:236, 324` (general branches)
+
+`_get_technosphere_inputs` (`edge_extractor.py:390`) needs to learn about explicit nodes too: for an explicit `process` column, the *output* row carries a positive amount and is **not** an input. The current `if row_idx == product_idx: continue` heuristic must be generalised to "skip any row connected by a `type="production"` exchange to this column," not "skip the diagonal."
+
+**Tests to add (`tests/test_explicit_paradigm.py`):**
+
+- A four-node fixture: one explicit `process` + `product` pair in the foreground and one chimaera background process. Static `TimexLCA(...).base_lca.score` matches `bw2calc.LCA(...).score`.
+- A multi-output process fixture (one process, two products with different output amounts) where the FU asks for product A and product B respectively. Each demand gives the correct static score; the helper picks the right `α` per product.
+
+### Phase 2 — bipartite supply-chain traversal
+
+**Files:** `bw_timex/edge_extractor.py` (priority + BFS variants); coordinated with `bw_temporalis` if the change is upstreamed.
+**Effort:** several days. The substantive work in this plan.
+**User-visible behaviour:** explicit graphs produce non-trivial timelines; supply chain is fully walked; demand-timing is populated.
+
+The traversal needs three concrete behaviours added:
+
+1. **From a Product node, find producing Process(es).** Look up the product's row in the tech matrix; for each negative entry (sign convention: production rows are negative in BW), the column index is a producing process. Most foregrounds will have exactly one producer per product; the API needs to handle (and warn? error? attribute-resolve?) the multi-producer case, mirroring how `bw2calc` does activity selection. *Open question — see §7.*
+2. **From a Process node, walk both directions.** Output edges (`type="production"`, the off-diagonal positive entries in the process column) carry the production amount and may carry a `temporal_distribution`. Input edges (`type="technosphere"`, off-diagonal negative entries) are the existing case. The `Edge` dataclass already has `edge_type`; the convolution needs to fire correctly for *both* directions.
+3. **Timeline rows for output edges.** Today only one synthetic FU edge has `edge_type="production"` (the placeholder created in `edge_extractor.py:431`). Real production output edges need their own rows in the timeline, with `producer = product_id`, `consumer = process_id`, and `td_producer` carrying the cohort TD. Downstream input rows then inherit `abs_td_consumer` from this row's `abs_td_producer`, exactly as they inherit from technosphere rows today.
+
+Two variants need parallel changes (the priority `EdgeExtractor` inheriting from `TemporalisLCA`, and the BFS `EdgeExtractorBFS`). Either keep the variants in step manually (current convention) or refactor the shared logic into a paradigm-aware mixin first; we recommend the latter, in a small refactor PR before Phase 2's main work.
+
+Recommended approach for *where* the bipartite walk lives:
+
+- **Preferred — push it upstream into `bw_graph_tools`/`bw_temporalis`.** Both libraries already have to detect explicit production exchanges (`bw_graph_tools.matrix_tools.guess_production_exchanges`); extending that detection to drive the traversal is in-scope upstream and benefits other consumers. `bw_timex` then receives the correctly-walked edge graph and only needs Phase 3 work below.
+- **Fallback — pre-process in `bw_timex`.** Before invoking `TemporalisLCA`, synthesise a chimaera-shaped view of the technosphere (one virtual chimaera per `(process, product)` pair, inputs union'd from the process's input edges, self-loop production amount equal to the output edge's `α`). The TD on the output edge becomes a TD on the synthetic self-loop — but production-self-loop TDs are silently ignored today (see §6, *known footgun*), so this fallback only buys backward-compat for *static* explicit graphs, not the cohort-injection use case. Therefore: viable as a stopgap for Phase 1 testing only.
+
+**Tests to add:**
+
+- The repro from §3: explicit `fleet_driving_process / fleet_driving_product` with cohort TD on the output edge and age TD on the electricity input. Timeline has the expected `cohort × age` row count; per-row dates and amounts match the `cohort_TD ⊛ age_TD` convolution; `date_consumer` of every input row is the cohort year.
+- Same fixture as Phase 1 multi-output; assert that the timeline correctly attributes inputs across products by output coefficient.
+- Direct port of the cohort+age fleet model (the `fleet_service` notebook), refactored to explicit paradigm. Total static and dynamic scores match the chimaera version within numerical tolerance.
+
+### Phase 3 — honour TDs on production-typed output edges
+
+**Files:** `bw_timex/edge_extractor.py` (convolution), `bw_timex/matrix_modifier.py`, `bw_timex/timeline_builder.py`.
+**Effort:** smaller than Phase 2 if the traversal is correct; the math is a sign-flip away from the input case. Mostly tests + matrix-side correctness.
+
+Once Phase 2 produces timeline rows for production output edges, the matrix-modifier layer needs to interpret `temporal_distribution` on them correctly:
+
+- The output edge's role in the matrix is to set the production coefficient `α` at the time-mapped process instance. The time mapping must place one process column per cohort year, each with its own `α` (potentially equal, since the TD weights normalise to 1). The cohort-share scaling enters through the `td_producer.amount` on the output row.
+- `temporal_evolution_factors` semantics: `reference="producer"` evaluates at the production calendar date (cohort year, since that's when the process is invoked). `reference="consumer"` evaluates at the consumer (the FU, in our use case) date. For most cohort use cases the relevant reference is `consumer`, applied via the *input* edge from the process to a downstream product — same as today. Output-edge `temporal_evolution_factors` would represent something like "how the act of producing changes over time" — semantically valid but rare; we should support it but it's a niche.
+
+**Tests:** vintage-locked efficiency test on the explicit fleet model, mirroring the existing isolation test in the notebook. Verify the per-cohort-year electricity factor lands at the right rows.
+
+### Phase 4 — surface the abstraction and clean up
+
+**Files:** `bw_timex/utils.py` (`add_temporal_distribution_to_exchange`), `bw_timex/validation.py`, `docs/`.
+**Effort:** half a day.
+
+- Add explicit checks in `add_temporal_distribution_to_exchange` that warn if a TD is being attached to a chimaera self-production edge: under the current implementation it is *silently ignored* (this is the §6 footgun). The same TD on an explicit `process → product` output edge **does** fire after Phases 1-3 — message should explain the difference.
+- Add a "Modeling paradigms and TD placement" section to the docs decision tree (`docs/content/decisiontree.md`) covering the three patterns explored in the fleet notebook (intermediary, self-loop, explicit) and which one to use when.
+- Optional but valuable: support `TemporalDistribution` as an FU-dict value (`{product: TD(1)}`) by translating it into a synthetic intermediary at construction time. Closes the "inject a cohort TD without restructuring the foreground" gap. Validation currently rejects it (`validation.py`); change to accept and dispatch to the synthesizer.
+
+## 6. Known footgun: silent ignore of TDs on chimaera production self-loops
+
+Independent of explicit-node support, the chimaera paradigm has a quiet failure mode that we should fix in passing.
+
+A `temporal_distribution` set on a chimaera's self-production exchange (`fleet_driving → fleet_driving`, `type="production"`) is silently dropped by the traversal — `edge_mapping[node.unique_id]` only includes consumption edges into the node, not the diagonal self-loop. Empirically:
+
+| Variant | Outcome |
+| --- | --- |
+| Cohort TD on `fleet_service → fleet_driving` (intermediary) | Honoured. 13 timeline rows. |
+| Cohort TD on `fleet_driving → fleet_driving` (self-loop) | Silently ignored. 4 timeline rows. Wrong dynamic timing; *correct static total* by accident. |
+| Cohort TD as `{fleet_driving: TD(1)}` in FU dict | `ValidationError: demand values must be numeric`. |
+
+The static total being correct masks the bug — a user doing development with `tlca.static_score` will see the expected number, only finding the problem later when `dynamic_lcia` or `temporal_evolution_reference="consumer"` reveals the missing cohort spread.
+
+Recommended fix in Phase 4:
+
+- `bw_timex/utils.py:add_temporal_distribution_to_exchange` — if the target is a chimaera's production self-loop, raise a `NotImplementedError` (or warn loudly) pointing the user at the intermediary or explicit pattern.
+- `bw_timex/validation.py` — same check via the structured-input validator path.
+
+Doing this without explicit-paradigm support is fine: the warning still applies once explicit support lands (the explicit *output* edge is a different beast and remains valid).
+
+## 7. Open design questions
+
+These need a decision before Phase 2 ships and should be collected into the issue when filed.
+
+1. **Multi-producer products.** When a foreground product has more than one producing process (e.g., `electricity_product` produced by both gas and wind processes in the foreground), how does `bw_timex` resolve the producer for traversal? Options:
+   - Replicate `bw2calc` behaviour (which uses `dicts.product` to pick by `(database, code)` mapping; in practice ambiguity is rare because foreground graphs are usually injective).
+   - Aggregate via temporal-market-shares (analogous to the existing background interpolation code). This is the more powerful answer but requires a foreground-side market-share concept that doesn't exist today.
+2. **Co-products.** A single process with multiple output edges (each carrying its own `α` and possibly its own TD). Each TD must be honoured per-product, which means per-product time-mapping of the *same* process column. Doable but it complicates `activity_time_mapping` (today: one entry per `(activity, time)`; needed: one per `(activity, product, time)`).
+3. **TD type compatibility.** Should we constrain `temporal_distribution` on production output edges to *datetime* TDs (so the cohort dimension is calendar-time) versus *timedelta* TDs (relative to the consumer)? The current code accepts both forms; for cohort use cases datetime TDs are usually wanted, but enforcing it would complicate the FU-relative anchoring.
+4. **Backward compatibility.** Phases 1-3 should be additive — chimaera workflows must continue to work exactly as they do today. The Phase 4 footgun fix changes one previously-silent path into a loud failure. Should it be opt-in via a config flag for one minor version, or hard-error immediately?
+
+## 8. Out of scope
+
+- **Substitution exchanges (`type="substitution"`)** beyond what's already supported. The convolution math is the same, but interaction with co-products + TDs deserves its own design pass.
+- **Non-foreground explicit graphs.** Background databases can be in either paradigm independently of the foreground; this plan implicitly assumes the foreground is the explicit one. Phase 1's helper should still work on background nodes (it's paradigm-agnostic by design), but full traversal of explicit *backgrounds* is not a goal here — backgrounds are leaves and are not traversed beyond temporal-market-share lookup.
+- **`prospective_*` waterfall plumbing.** The fleet notebook's prospective comparison (`example_electric_vehicle_fleet.ipynb`, cell 74) walks `fleet_driving.technosphere()` and copies activities. This walk needs to be paradigm-aware too, but is a notebook concern more than a `bw_timex` API concern — leave for a notebook update once Phases 1-3 are usable.
+
+## 9. Estimated total effort
+
+| Phase | Effort | Risk |
+| --- | --- | --- |
+| 0 — `np.in1d` upstream patch | <1h | None |
+| 1 — paradigm-aware production-amount helper | 0.5d | Low |
+| 2 — bipartite traversal | 3-5d | Medium-high (touches upstream `bw_graph_tools` / `bw_temporalis`) |
+| 3 — honour TDs on output edges | 1-2d | Medium |
+| 4 — surface + footgun fix + docs | 0.5d | Low |
+
+Total: roughly one to two weeks of focused work, plus review cycles. Phase 1 is a sensible first PR; it ships small visible value (static scoring works on explicit graphs) and forces the helper abstraction that Phases 2-3 will lean on.
+
+## 10. References
+
+- `notebooks/example_electric_vehicle_fleet.ipynb` — current fleet model using the chimaera + intermediary pattern.
+- `bw2data/configuration.py` — node-type taxonomy.
+- `bw_graph_tools/matrix_tools.py` — production-exchange detection heuristics.
+- `bw_temporalis/lca.py:115` — supply-chain traversal entry point.
+- Empirical scripts used during this analysis (kept under `/tmp/` during exploration; reproduce by setting up a minimal explicit-paradigm foreground and demanding the product as FU).

--- a/docs/content/getting_started/adding_temporal_information.md
+++ b/docs/content/getting_started/adding_temporal_information.md
@@ -104,6 +104,19 @@ bd.Method(("our", "method")).write(
 
 Now, if you want to consider time in your LCA, you need to somehow add temporal information. For time-explicit LCA, we consider two kinds of temporal information, that will be discussed in the following.
 
+:::{note}
+Brightway can represent inventory data either with separate process and product nodes or with
+chimaera process+product nodes. See the Brightway inventory overview on
+[processes, products, and something in between](https://docs.brightway.dev/en/latest/content/overview/inventory.html#processes-products-and-something-in-between).
+
+This getting-started page uses the common chimaera style, where Process A is also its reference
+product. The temporal concepts below also apply to explicit process/product models; the main
+difference is where output-side timing can be attached. If you want to represent several
+production-time groups of the same product, you can do this in either paradigm. In a chimaera
+model, this timing is often represented with an intermediary foreground edge. In an explicit
+model, it can live directly on the process→product production edge.
+:::
+
 ## Temporal distributions
 To determine the timing of the exchanges within the production system, we add the `temporal_distribution` attribute to the respective exchanges. To carry the temporal information, we use the [`TemporalDistribution`](https://docs.brightway.dev/projects/bw-temporalis/en/stable/content/api/bw_temporalis/temporal_distribution/index.html#bw_temporalis.temporal_distribution.TemporalDistribution) class from [`bw_temporalis`](https://github.com/brightway-lca/bw_temporalis). This class is a *container for a series of amount spread over time*, so it tells you what share of an exchange happens at what point in time. So, let's include this information in our production system - first visually:
 ```{mermaid}
@@ -287,7 +300,59 @@ exchange["temporal_evolution_amounts"] = {
 }
 ```
 
-For dates between the specified points, values are linearly interpolated. For dates outside the range, the nearest boundary value is used. You can specify either `temporal_evolution_amounts` or `temporal_evolution_amounts` for the same exchange, but not both.
+For dates between the specified points, values are linearly interpolated. For dates outside the range, the nearest boundary value is used. You can specify either `temporal_evolution_factors` or `temporal_evolution_amounts` for the same exchange, but not both.
+
+This mechanism can represent **production-version-specific efficiency** if the exchange is
+evaluated at the timestamp of the process/product version. Here, "version" means the production or
+design date that fixes a foreground exchange amount. This fixed production/design date is often
+called a **vintage**. For example, with factors `{2025: 1.0, 2030: 1.1}`, a unit produced in
+2025 uses the 2025 vintage factor and a unit produced in 2030 uses the 2030 vintage factor (with
+interpolation in-between). If a single foreground exchange represents a mixed fleet over multiple
+production years, that one exchange still has just one amount at each event time; to model distinct
+production-time groups explicitly, create separate exchanges or processes for each group (e.g.,
+EV_2025, EV_2030) and assign their temporal distributions accordingly.
+
+### Choosing `temporal_evolution_reference`
+
+Temporal evolution factors need a timestamp. In a time-explicit foreground exchange, `bw_timex` can carry two relevant timestamps:
+
+- `date_consumer`: when the consuming foreground process instance exists. If the model splits a
+  product into production-time groups, read this as the **process/product version date** of the
+  process using the exchange. In fleet and stock models, this is usually the **vintage**.
+- `date_producer`: when the exchanged input/output event actually happens. Read this as the **calendar event date** of the exchange.
+
+Use `temporal_evolution_reference="consumer"` when the exchange amount is a property of the
+consuming process or product version. The factor is locked to `date_consumer`.
+
+Examples:
+
+- A vehicle built in 2025 keeps its 2025 electricity consumption per km when it drives in 2035.
+- A building built in 2020 keeps its 2020 insulation standard during later operation.
+- A 2030 production line needs less material because of its design, and keeps that efficiency for all later maintenance or use-phase exchanges.
+
+Use `temporal_evolution_reference="producer"` when the exchange amount is a property of the calendar year in which the exchange happens. The factor follows `date_producer`.
+
+Examples:
+
+- A maintenance operation uses less solvent in 2035 because maintenance practice improved by then, regardless of when the serviced asset was built.
+- A foreground repair process becomes more efficient over calendar time.
+- A foreground input is reduced by a retrofit or operational learning that applies to all active product/process versions in that year.
+
+Rule of thumb:
+
+```text
+Is the change a property of the foreground process/product version date?
+-> use consumer
+
+Is the change a property of the calendar year when the exchange happens?
+-> use producer
+```
+
+This choice is independent of whether you model with chimaera nodes or explicit process/product
+nodes. Explicit process/product models can make the distinction easier to see because a product can
+have a production-edge temporal distribution, creating clear product/process version dates. Chimaera
+models can represent the same idea by adding a foreground intermediary activity whose exchange
+creates those version dates.
 
 A convenience function is available to add temporal evolution to an existing exchange:
 
@@ -299,6 +364,7 @@ add_temporal_evolution_to_exchange(
         datetime(2020, 1, 1): 1.0,
         datetime(2030, 1, 1): 0.75,
     },
+    temporal_evolution_reference="consumer",
     input_code="B",
     input_database="background",
     output_code="A",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from .fixtures.dynamic_biomatrix_db_fixture import dynamic_biosphere_matrix_db
+from .fixtures.explicit_process_product_db_fixture import explicit_process_product_db
 from .fixtures.nonunitary_db_fixture import nonunitary_db
 from .fixtures.process_at_base_database_time_db_fixture import (
     process_at_base_database_time_db,
@@ -14,3 +15,4 @@ from .fixtures.temporal_evolution_db_fixture import (
     temporal_evolution_db,
 )
 from .fixtures.vehicle_db_fixture import vehicle_db
+from .fixtures.vehicle_explicit_db_fixture import vehicle_explicit_db

--- a/tests/fixtures/explicit_process_product_db_fixture.py
+++ b/tests/fixtures/explicit_process_product_db_fixture.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+
+import bw2data as bd
+import numpy as np
+import pytest
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+def explicit_process_product_db():
+    bd.projects.set_current("__test_explicit_process_product__")
+    bd.databases.clear()
+    bd.methods.clear()
+
+    bio = bd.Database("bio")
+    bio.write(
+        {
+            ("bio", "co2"): {
+                "name": "Carbon dioxide",
+                "unit": "kg",
+                "type": "emission",
+            }
+        }
+    )
+
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    bd.Database("bg_2030").write(
+        {
+            ("bg_2030", "electricity"): {
+                "name": "electricity",
+                "unit": "kWh",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("bg_2030", "electricity"),
+                        "amount": 1,
+                        "type": "production",
+                    },
+                    {"input": ("bio", "co2"), "amount": 0.5, "type": "biosphere"},
+                ],
+            }
+        }
+    )
+
+    td = TemporalDistribution(
+        date=np.array([0, 1], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "fleet_driving_process"): {
+                "name": "fleet driving process",
+                "unit": "unit",
+                "location": "GLO",
+                "type": "process",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "fleet_driving_product"),
+                        "amount": 1,
+                        "type": "production",
+                        "temporal_distribution": td,
+                    },
+                    {
+                        "input": ("bg_2030", "electricity"),
+                        "amount": 10,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+            ("foreground", "fleet_driving_product"): {
+                "name": "fleet driving product",
+                "unit": "unit",
+                "location": "GLO",
+                "type": "product",
+                "exchanges": [],
+            },
+        }
+    )
+
+    return {
+        "database_dates": {
+            "bg_2030": datetime.strptime("2030", "%Y"),
+            "foreground": "dynamic",
+        }
+    }

--- a/tests/fixtures/vehicle_explicit_db_fixture.py
+++ b/tests/fixtures/vehicle_explicit_db_fixture.py
@@ -1,0 +1,292 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def vehicle_explicit_db():
+    """
+    Same EV system as ``vehicle_db`` but with the foreground modeled in the
+    explicit process/product paradigm (separate product node + process node)
+    instead of a chimaera node.
+    """
+    bd.Database("bio").write(
+        {
+            ("bio", "CO2"): {
+                "type": "emission",
+                "name": "carbon dioxide",
+            },
+        },
+    )
+
+    bd.Database("db_2020").write(
+        {
+            ("db_2020", "glider"): {
+                "name": "market for glider, passenger car",
+                "location": "somewhere",
+                "reference product": "market for glider, passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "glider")},
+                    {"amount": 6.29, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2020", "powertrain"): {
+                "name": "market for powertrain, for electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for powertrain, for electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "powertrain")},
+                    {"amount": 17.89, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2020", "battery"): {
+                "name": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "location": "somewhere",
+                "reference product": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "battery")},
+                    {"amount": 8.23, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2020", "electricity"): {
+                "name": "market group for electricity, low voltage",
+                "location": "somewhere",
+                "reference product": "market group for electricity, low voltage",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "electricity")},
+                    {"amount": 0.73, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2020", "dismantling"): {
+                "name": "market for manual dismantling of used electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for manual dismantling of used electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "dismantling")},
+                    {"amount": 0.0091, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2020", "battery_recycling"): {
+                "name": "market for used Li-ion battery",
+                "location": "somewhere",
+                "reference product": "market for used Li-ion battery",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "battery_recycling")},
+                    {"amount": -1.18, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+        }
+    )
+
+    bd.Database("db_2030").write(
+        {
+            ("db_2030", "glider"): {
+                "name": "market for glider, passenger car",
+                "location": "somewhere",
+                "reference product": "market for glider, passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "glider")},
+                    {"amount": 4.37, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2030", "powertrain"): {
+                "name": "market for powertrain, for electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for powertrain, for electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "powertrain")},
+                    {"amount": 11.90, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2030", "battery"): {
+                "name": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "location": "somewhere",
+                "reference product": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "battery")},
+                    {"amount": 5.26, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2030", "electricity"): {
+                "name": "market group for electricity, low voltage",
+                "location": "somewhere",
+                "reference product": "market group for electricity, low voltage",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "electricity")},
+                    {"amount": 0.23, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2030", "dismantling"): {
+                "name": "market for manual dismantling of used electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for manual dismantling of used electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "dismantling")},
+                    {"amount": 0.008, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2030", "battery_recycling"): {
+                "name": "market for used Li-ion battery",
+                "location": "somewhere",
+                "reference product": "market for used Li-ion battery",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "battery_recycling")},
+                    {"amount": -0.60, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+        }
+    )
+
+    bd.Database("db_2040").write(
+        {
+            ("db_2040", "glider"): {
+                "name": "market for glider, passenger car",
+                "location": "somewhere",
+                "reference product": "market for glider, passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "glider")},
+                    {"amount": 3.71, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2040", "powertrain"): {
+                "name": "market for powertrain, for electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for powertrain, for electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "powertrain")},
+                    {"amount": 9.79, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2040", "battery"): {
+                "name": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "location": "somewhere",
+                "reference product": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "battery")},
+                    {"amount": 4.25, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2040", "electricity"): {
+                "name": "market group for electricity, low voltage",
+                "location": "somewhere",
+                "reference product": "market group for electricity, low voltage",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "electricity")},
+                    {"amount": 0.067, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2040", "dismantling"): {
+                "name": "market for manual dismantling of used electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for manual dismantling of used electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "dismantling")},
+                    {"amount": 0.0077, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2040", "battery_recycling"): {
+                "name": "market for used Li-ion battery",
+                "location": "somewhere",
+                "reference product": "market for used Li-ion battery",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "battery_recycling")},
+                    {"amount": -0.40, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+        }
+    )
+
+    ELECTRICITY_CONSUMPTION = 0.2
+    MILEAGE = 150_000
+    LIFETIME = 16
+    MASS_GLIDER = 840
+    MASS_POWERTRAIN = 80
+    MASS_BATTERY = 280
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "EV_product"): {
+                "name": "electric vehicle life cycle product",
+                "location": "somewhere",
+                "unit": "unit",
+                "type": "product",
+                "exchanges": [],
+            },
+            ("foreground", "EV_process"): {
+                "name": "electric vehicle life cycle process",
+                "location": "somewhere",
+                "unit": "unit",
+                "type": "process",
+                "exchanges": [
+                    {
+                        "amount": 1,
+                        "type": "production",
+                        "input": ("foreground", "EV_product"),
+                    },
+                    {
+                        "amount": MASS_GLIDER,
+                        "type": "technosphere",
+                        "input": ("db_2020", "glider"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([-2, -1], dtype="timedelta64[Y]"),
+                            amount=np.array([0.6, 0.4]),
+                        ),
+                    },
+                    {
+                        "amount": MASS_POWERTRAIN,
+                        "type": "technosphere",
+                        "input": ("db_2020", "powertrain"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([-2, -1], dtype="timedelta64[Y]"),
+                            amount=np.array([0.6, 0.4]),
+                        ),
+                    },
+                    {
+                        "amount": MASS_BATTERY,
+                        "type": "technosphere",
+                        "input": ("db_2020", "battery"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([-2, -1], dtype="timedelta64[Y]"),
+                            amount=np.array([0.6, 0.4]),
+                        ),
+                    },
+                    {
+                        "amount": ELECTRICITY_CONSUMPTION * MILEAGE,
+                        "type": "technosphere",
+                        "input": ("db_2020", "electricity"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([int(LIFETIME / 2)], dtype="timedelta64[Y]"),
+                            amount=np.array([1]),
+                        ),
+                    },
+                    {
+                        "amount": MASS_GLIDER,
+                        "type": "technosphere",
+                        "input": ("db_2020", "dismantling"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([LIFETIME + 1], dtype="timedelta64[Y]"),
+                            amount=np.array([1]),
+                        ),
+                    },
+                    {
+                        "amount": -MASS_BATTERY,
+                        "type": "technosphere",
+                        "input": ("db_2020", "battery_recycling"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([LIFETIME + 1], dtype="timedelta64[Y]"),
+                            amount=np.array([1]),
+                        ),
+                    },
+                ],
+            },
+        }
+    )
+
+    bd.Method(("GWP", "example")).write([(("bio", "CO2"), 1)])
+
+    for db in bd.databases:
+        bd.Database(db).register()
+        bd.Database(db).process()

--- a/tests/test_electric_vehicle_explicit.py
+++ b/tests/test_electric_vehicle_explicit.py
@@ -1,0 +1,130 @@
+"""
+Mirror of ``test_electric_vehicle.py`` using the explicit process/product
+paradigm instead of the chimaera node convention. Verifies that demanding a
+bare product node and routing all edges through a separate process node
+yields the same TimexLCA static score as the chimaera-modeled equivalent.
+"""
+
+from datetime import datetime
+
+import bw2calc as bc
+import bw2data as bd
+import pytest
+
+from bw_timex import TimexLCA
+
+
+def test_vehicle_explicit_db_fixture(vehicle_explicit_db):
+    assert len(bd.databases) == 5
+
+
+@pytest.mark.usefixtures("vehicle_explicit_db")
+class TestClass_EV_Explicit:
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self, vehicle_explicit_db):
+        self.ev_product = bd.get_node(database="foreground", code="EV_product")
+
+        database_dates = {
+            "db_2020": datetime.strptime("2020", "%Y"),
+            "db_2030": datetime.strptime("2030", "%Y"),
+            "db_2040": datetime.strptime("2040", "%Y"),
+            "foreground": "dynamic",
+        }
+
+        self.tlca = TimexLCA(
+            demand={self.ev_product.key: 1},
+            method=("GWP", "example"),
+            database_dates=database_dates,
+        )
+
+        self.tlca.build_timeline(
+            starting_datetime=datetime.strptime("2024-01-02", "%Y-%m-%d")
+        )
+        self.tlca.lci()
+        self.tlca.static_lcia()
+
+    def test_base_lca_score(self):
+        slca = bc.LCA({self.ev_product.key: 1}, method=("GWP", "example"))
+        slca.lci()
+        slca.lcia()
+        assert self.tlca.base_lca.score == slca.score
+
+    def test_bw_timex_score_matches_chimaera_manual(self):
+        # Identical hand-computation to test_electric_vehicle.py — the
+        # explicit product/process model must produce the same temporal
+        # interpolation result as the chimaera node.
+        ELECTRICITY_CONSUMPTION = 0.2
+        MILEAGE = 150_000
+        MASS_GLIDER = 840
+        MASS_POWERTRAIN = 80
+        MASS_BATTERY = 280
+
+        glider_2020 = [
+            exc["amount"] for exc in bd.get_activity(("db_2020", "glider")).biosphere()
+        ][0]
+        glider_2030 = [
+            exc["amount"] for exc in bd.get_activity(("db_2030", "glider")).biosphere()
+        ][0]
+        powertrain_2020 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2020", "powertrain")).biosphere()
+        ][0]
+        powertrain_2030 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2030", "powertrain")).biosphere()
+        ][0]
+        battery_2020 = [
+            exc["amount"] for exc in bd.get_activity(("db_2020", "battery")).biosphere()
+        ][0]
+        battery_2030 = [
+            exc["amount"] for exc in bd.get_activity(("db_2030", "battery")).biosphere()
+        ][0]
+        elec_2030 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2030", "electricity")).biosphere()
+        ][0]
+        elec_2040 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2040", "electricity")).biosphere()
+        ][0]
+        dismantling_2040 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2040", "dismantling")).biosphere()
+        ][0]
+        battery_recycling_2040 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2040", "battery_recycling")).biosphere()
+        ][0]
+
+        # 2022 -> 80% 2020, 20% 2030; 2023 -> 70% 2020, 30% 2030
+        expected_glider_score = (
+            0.6 * MASS_GLIDER * (0.8 * glider_2020 + 0.2 * glider_2030)
+            + 0.4 * MASS_GLIDER * (0.7 * glider_2020 + 0.3 * glider_2030)
+        )
+        expected_powertrain_score = (
+            0.6 * MASS_POWERTRAIN * (0.8 * powertrain_2020 + 0.2 * powertrain_2030)
+            + 0.4 * MASS_POWERTRAIN * (0.7 * powertrain_2020 + 0.3 * powertrain_2030)
+        )
+        expected_battery_score = (
+            0.6 * MASS_BATTERY * (0.8 * battery_2020 + 0.2 * battery_2030)
+            + 0.4 * MASS_BATTERY * (0.7 * battery_2020 + 0.3 * battery_2030)
+        )
+        # electricity in 2032 -> 80% 2030, 20% 2040
+        expected_electricity_score = (
+            MILEAGE * ELECTRICITY_CONSUMPTION * (0.8 * elec_2030 + 0.2 * elec_2040)
+        )
+        # dismantling 2041 -> 100% 2040
+        expected_glider_recycling_score = MASS_GLIDER * dismantling_2040
+        expected_battery_recycling_score = -(MASS_BATTERY * battery_recycling_2040)
+
+        expected_timex_score = (
+            expected_glider_score
+            + expected_powertrain_score
+            + expected_battery_score
+            + expected_electricity_score
+            + expected_glider_recycling_score
+            + expected_battery_recycling_score
+        )
+
+        assert self.tlca.static_score == pytest.approx(expected_timex_score, abs=0.5)

--- a/tests/test_explicit_process_product_end_to_end.py
+++ b/tests/test_explicit_process_product_end_to_end.py
@@ -498,3 +498,107 @@ def test_multi_vintage_demand_splits_across_cohorts():
     ]
 
     assert tlca.static_score == pytest.approx(0.5 * 0.40 + 0.5 * 0.10)
+
+
+def test_explicit_output_coefficient_alpha_scales_inputs():
+    """Production output coefficient alpha != 1 must scale the supply chain by 1/alpha.
+
+    A process produces *2* units of its product per invocation and consumes 4
+    units of background input. Demanding 1 unit of the product therefore runs
+    the process at scale 1/2, so the input is consumed at 0.5 * 4 = 2.0 and the
+    score is 2.0 (background = 1 kg CO2 per input unit, GWP = 1).
+
+    Every existing explicit fixture uses production amount = 1, so the 1/alpha
+    division is otherwise never exercised: a bug there would be invisible.
+    """
+    bd.projects.set_current("__test_explicit_alpha_scaling__")
+    bd.databases.clear()
+    bd.methods.clear()
+
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Database("background").write(
+        {
+            ("background", "input"): {
+                "name": "input production",
+                "reference product": "input",
+                "unit": "kg",
+                "location": "GLO",
+                "exchanges": [
+                    {"input": ("background", "input"), "amount": 1, "type": "production"},
+                    {"input": ("bio", "co2"), "amount": 1, "type": "biosphere"},
+                ],
+            }
+        }
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_output = TemporalDistribution(
+        date=np.array([0, 1], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "product"): {
+                "name": "product",
+                "type": "product",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [],
+            },
+            ("foreground", "process"): {
+                "name": "process",
+                "type": "process",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "product"),
+                        "amount": 2,  # alpha != 1
+                        "type": "production",
+                        "temporal_distribution": td_output,
+                    },
+                    {
+                        "input": ("background", "input"),
+                        "amount": 4,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+        }
+    )
+    for db in bd.databases:
+        bd.Database(db).process()
+
+    product = bd.get_node(database="foreground", code="product")
+    method = ("GWP", "example")
+    demand = {product.key: 1}
+    database_dates = {"background": datetime(2030, 1, 1), "foreground": "dynamic"}
+
+    slca = bc.LCA(demand, method=method)
+    slca.lci()
+    slca.lcia()
+    # Sanity: bw2calc itself applies 1/alpha -> 0.5 * 4 * 1 = 2.0
+    assert slca.score == pytest.approx(2.0)
+
+    tlca = TimexLCA(demand=demand, method=method, database_dates=database_dates)
+    tlca.build_timeline(starting_datetime=datetime(2030, 1, 1))
+    tlca.lci()
+    tlca.static_lcia()
+
+    assert tlca.base_lca.score == pytest.approx(2.0)
+    assert tlca.static_score == pytest.approx(2.0)
+
+    # The per-cohort-instance input intensity carries the 1/alpha scaling:
+    # edge amount 4 / alpha 2 = 2.0 per cohort row (the cohort TD weights 0.6/0.4
+    # are applied to the process column in the matrix, summing to 1, so the total
+    # input is 0.6*2 + 0.4*2 = 2.0 and the score is 2.0). If 1/alpha were dropped
+    # the row amount would be 4.0; if mis-applied, 8.0.
+    input_rows = tlca.timeline[tlca.timeline["producer_name"] == "input production"]
+    observed = sorted(
+        (row.date_consumer.year, row.date_producer.year, float(row.amount))
+        for row in input_rows.itertuples()
+    )
+    assert observed == pytest.approx([(2030, 2030, 2.0), (2031, 2031, 2.0)])

--- a/tests/test_explicit_process_product_end_to_end.py
+++ b/tests/test_explicit_process_product_end_to_end.py
@@ -1,0 +1,500 @@
+from datetime import datetime
+
+import bw2calc as bc
+import bw2data as bd
+import numpy as np
+import pytest
+from bw_temporalis import TemporalDistribution
+
+from bw_timex import TimexLCA
+
+
+def _write_multilayer_explicit_process_product_db():
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Database("background").write(
+        {
+            ("background", "input"): {
+                "name": "input production",
+                "reference product": "input",
+                "unit": "kg",
+                "location": "GLO",
+                "exchanges": [
+                    {"input": ("background", "input"), "amount": 1, "type": "production"},
+                    {"input": ("bio", "co2"), "amount": 1, "type": "biosphere"},
+                ],
+            }
+        }
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_final_output = TemporalDistribution(
+        date=np.array([0, 2], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+    td_component_output = TemporalDistribution(
+        date=np.array([0, 1], dtype="timedelta64[Y]"),
+        amount=np.array([0.25, 0.75]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "component_product"): {
+                "name": "component product",
+                "type": "product",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [],
+            },
+            ("foreground", "component_process"): {
+                "name": "component process",
+                "type": "process",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "component_product"),
+                        "amount": 1,
+                        "type": "production",
+                        "temporal_distribution": td_component_output,
+                    },
+                    {
+                        "input": ("background", "input"),
+                        "amount": 4,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+            ("foreground", "final_product"): {
+                "name": "final product",
+                "type": "product",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [],
+            },
+            ("foreground", "final_process"): {
+                "name": "final process",
+                "type": "process",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "final_product"),
+                        "amount": 1,
+                        "type": "production",
+                        "temporal_distribution": td_final_output,
+                    },
+                    {
+                        "input": ("foreground", "component_product"),
+                        "amount": 2,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+        }
+    )
+    for db in bd.databases:
+        bd.Database(db).process()
+
+
+def _run_multilayer_explicit_process_product_lca():
+    final_product = bd.get_node(database="foreground", code="final_product")
+    tlca = TimexLCA(
+        demand={final_product.key: 1},
+        method=("GWP", "example"),
+        database_dates={
+            "background": datetime(2030, 1, 1),
+            "foreground": "dynamic",
+        },
+    )
+    tlca.build_timeline(starting_datetime=datetime(2030, 1, 1))
+    tlca.lci()
+    tlca.static_lcia()
+    return tlca
+
+
+@pytest.mark.usefixtures("explicit_process_product_db")
+class TestExplicitProcessProductEndToEnd:
+    def test_static_and_timex_scores_match(self, explicit_process_product_db):
+        fu_product = bd.get_node(database="foreground", code="fleet_driving_product")
+        demand = {fu_product.key: 1}
+        method = ("GWP", "example")
+
+        slca = bc.LCA(demand, method=method)
+        slca.lci()
+        slca.lcia()
+
+        tlca = TimexLCA(
+            demand=demand,
+            method=method,
+            database_dates=explicit_process_product_db["database_dates"],
+        )
+        tlca.build_timeline(starting_datetime=datetime(2030, 1, 1))
+        tlca.lci()
+        tlca.static_lcia()
+
+        assert tlca.base_lca.score == pytest.approx(slca.score)
+        assert len(tlca.timeline) > 1
+
+        production_rows = tlca.timeline[
+            tlca.timeline["producer_name"] == "fleet driving process"
+        ]
+        assert set(production_rows["date_producer"].dt.year) == {2030, 2031}
+        assert sorted(production_rows["amount"].tolist()) == pytest.approx([0.4, 0.6])
+
+        electricity_rows = tlca.timeline[tlca.timeline["producer_name"] == "electricity"]
+        assert set(electricity_rows["date_consumer"].dt.year) == {2030, 2031}
+        assert tlca.static_score == pytest.approx(slca.score)
+
+
+def test_explicit_product_output_td_convolves_with_input_td():
+    bd.projects.set_current("__test_explicit_product_output_input_td__")
+    bd.databases.clear()
+    bd.methods.clear()
+
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Database("background").write(
+        {
+            ("background", "input"): {
+                "name": "input production",
+                "reference product": "input",
+                "unit": "kg",
+                "location": "GLO",
+                "exchanges": [
+                    {"input": ("background", "input"), "amount": 1, "type": "production"},
+                    {"input": ("bio", "co2"), "amount": 0.5, "type": "biosphere"},
+                ],
+            }
+        }
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_output = TemporalDistribution(
+        date=np.array([0, 2], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+    td_input = TemporalDistribution(
+        date=np.array([0, 1], dtype="timedelta64[Y]"),
+        amount=np.array([0.25, 0.75]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "service_process"): {
+                "name": "service process",
+                "type": "process",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "service_product"),
+                        "amount": 1,
+                        "type": "production",
+                        "temporal_distribution": td_output,
+                    },
+                    {
+                        "input": ("background", "input"),
+                        "amount": 8,
+                        "type": "technosphere",
+                        "temporal_distribution": td_input,
+                    },
+                ],
+            },
+            ("foreground", "service_product"): {
+                "name": "service product",
+                "type": "product",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [],
+            },
+        }
+    )
+    for db in bd.databases:
+        bd.Database(db).process()
+
+    product = bd.get_node(database="foreground", code="service_product")
+    method = ("GWP", "example")
+    demand = {product.key: 1}
+    database_dates = {
+        "background": datetime(2030, 1, 1),
+        "foreground": "dynamic",
+    }
+
+    slca = bc.LCA(demand, method=method)
+    slca.lci()
+    slca.lcia()
+
+    tlca = TimexLCA(demand=demand, method=method, database_dates=database_dates)
+    tlca.build_timeline(starting_datetime=datetime(2030, 1, 1))
+    tlca.lci()
+    tlca.static_lcia()
+
+    production_rows = tlca.timeline[
+        tlca.timeline["producer_name"] == "service process"
+    ].sort_values("date_producer")
+    assert production_rows["date_producer"].dt.year.tolist() == [2030, 2032]
+    assert production_rows["date_consumer"].dt.year.tolist() == [2030, 2032]
+    assert production_rows["amount"].tolist() == pytest.approx([0.6, 0.4])
+
+    input_rows = tlca.timeline[tlca.timeline["producer_name"] == "input production"]
+    observed = sorted(
+        (
+            row.date_consumer.year,
+            row.date_producer.year,
+            float(row.amount),
+        )
+        for row in input_rows.itertuples()
+    )
+    assert observed == pytest.approx(
+        [
+            (2030, 2030, 2.0),
+            (2030, 2031, 6.0),
+            (2032, 2032, 2.0),
+            (2032, 2033, 6.0),
+        ]
+    )
+
+    assert tlca.base_lca.score == pytest.approx(slca.score)
+    assert tlca.static_score == pytest.approx(4.0)
+    assert tlca.static_score == pytest.approx(slca.score)
+
+    service_process = bd.get_node(database="foreground", code="service_process")
+    input_edge = next(edge for edge in service_process.technosphere())
+    input_edge["temporal_evolution_factors"] = {
+        datetime(2030, 1, 1): 1.0,
+        datetime(2032, 1, 1): 0.5,
+    }
+    input_edge["temporal_evolution_reference"] = "consumer"
+    input_edge.save()
+    bd.Database("foreground").process()
+
+    tlca_with_process_version_evolution = TimexLCA(
+        demand=demand,
+        method=method,
+        database_dates=database_dates,
+    )
+    tlca_with_process_version_evolution.build_timeline(
+        starting_datetime=datetime(2030, 1, 1)
+    )
+    tlca_with_process_version_evolution.lci()
+    tlca_with_process_version_evolution.static_lcia()
+
+    evolved_rows = tlca_with_process_version_evolution.timeline[
+        tlca_with_process_version_evolution.timeline["producer_name"] == "input production"
+    ]
+    assert set(evolved_rows["date_consumer"].dt.year) == {2030, 2032}
+    assert set(evolved_rows["temporal_evolution_reference"]) == {"consumer"}
+    # Cohort 2030 (weight 0.6, cop 1.0) → 0.6 * 8 * 1.0 * 0.5 = 2.4
+    # Cohort 2032 (weight 0.4, cop 0.5) → 0.4 * 8 * 0.5 * 0.5 = 0.8
+    assert tlca_with_process_version_evolution.static_score == pytest.approx(3.2)
+
+
+def test_multilayer_explicit_process_product_chain_with_evolution():
+    bd.projects.set_current("__test_multilayer_explicit_process_product_chain__")
+    bd.databases.clear()
+    bd.methods.clear()
+    _write_multilayer_explicit_process_product_db()
+
+    tlca = _run_multilayer_explicit_process_product_lca()
+
+    final_rows = tlca.timeline[
+        tlca.timeline["producer_name"] == "final process"
+    ].sort_values("date_producer")
+    assert final_rows["date_producer"].dt.year.tolist() == [2030, 2032]
+    assert final_rows["date_consumer"].dt.year.tolist() == [2030, 2032]
+    assert final_rows["amount"].tolist() == pytest.approx([0.6, 0.4])
+
+    component_rows = tlca.timeline[
+        tlca.timeline["producer_name"] == "component process"
+    ]
+    observed_component_timeline = sorted(
+        (
+            row.date_consumer.year,
+            row.date_producer.year,
+            float(row.amount),
+        )
+        for row in component_rows.itertuples()
+    )
+    assert observed_component_timeline == pytest.approx(
+        [
+            (2030, 2030, 0.5),
+            (2030, 2031, 1.5),
+            (2032, 2032, 0.5),
+            (2032, 2033, 1.5),
+        ]
+    )
+
+    background_rows = tlca.timeline[
+        tlca.timeline["producer_name"] == "input production"
+    ]
+    observed_background_timeline = sorted(
+        (
+            row.date_consumer.year,
+            row.date_producer.year,
+            float(row.amount),
+        )
+        for row in background_rows.itertuples()
+    )
+    assert observed_background_timeline == pytest.approx(
+        [
+            (2030, 2030, 4.0),
+            (2031, 2031, 4.0),
+            (2032, 2032, 4.0),
+            (2033, 2033, 4.0),
+        ]
+    )
+    assert tlca.static_score == pytest.approx(8.0)
+
+    final_process = bd.get_node(database="foreground", code="final_process")
+    component_edge = next(
+        edge
+        for edge in final_process.technosphere()
+        if edge.input["code"] == "component_product"
+    )
+    component_edge["temporal_evolution_factors"] = {datetime(2030, 1, 1): 0.5}
+    component_edge["temporal_evolution_reference"] = "consumer"
+    component_edge.save()
+    bd.Database("foreground").process()
+
+    evolved_tlca = _run_multilayer_explicit_process_product_lca()
+    evolved_component_rows = evolved_tlca.timeline[
+        evolved_tlca.timeline["producer_name"] == "component process"
+    ]
+    assert sorted(
+        (
+            row.date_consumer.year,
+            row.date_producer.year,
+            float(row.amount),
+        )
+        for row in evolved_component_rows.itertuples()
+    ) == pytest.approx(observed_component_timeline)
+    assert set(evolved_component_rows["temporal_evolution_reference"]) == {"consumer"}
+    assert evolved_tlca.static_score == pytest.approx(4.0)
+
+
+def test_multi_vintage_demand_splits_across_cohorts():
+    """Two install-year cohorts each draw from a different background database.
+
+    With install-year RTD = [2025: 0.5, 2035: 0.5] and the use-phase happening
+    at the install year, cohort 2025 should source electricity from
+    `electricity_market_2025` and cohort 2035 from `electricity_market_2035`.
+    The fleet score must therefore be the demand-weighted mix of both
+    backgrounds, not just one of them.
+    """
+    bd.projects.set_current("__test_multi_vintage_demand_split__")
+    bd.databases.clear()
+    bd.methods.clear()
+
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    for db_name, co2_per_kwh in [
+        ("electricity_market_2025", 0.40),
+        ("electricity_market_2035", 0.10),
+    ]:
+        bd.Database(db_name).write(
+            {
+                (db_name, "elec"): {
+                    "name": "electricity market",
+                    "reference product": "electricity",
+                    "location": "DE",
+                    "unit": "kWh",
+                    "exchanges": [
+                        {
+                            "amount": 1,
+                            "type": "production",
+                            "input": (db_name, "elec"),
+                        },
+                        {
+                            "amount": co2_per_kwh,
+                            "type": "biosphere",
+                            "input": ("bio", "co2"),
+                        },
+                    ],
+                },
+            }
+        )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_install = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.5, 0.5]),
+    )
+    td_use_at_install = TemporalDistribution(
+        date=np.array([0], dtype="timedelta64[Y]"),
+        amount=np.array([1.0]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "unit_product"): {
+                "name": "unit product",
+                "type": "product",
+                "unit": "unit",
+                "location": "DE",
+                "exchanges": [],
+            },
+            ("foreground", "unit_lifecycle"): {
+                "name": "unit lifecycle",
+                "type": "process",
+                "unit": "unit",
+                "location": "DE",
+                "exchanges": [
+                    {
+                        "amount": 1,
+                        "type": "production",
+                        "input": ("foreground", "unit_product"),
+                        "temporal_distribution": td_install,
+                    },
+                    {
+                        "amount": 1.0,
+                        "type": "technosphere",
+                        "input": ("electricity_market_2025", "elec"),
+                        "temporal_distribution": td_use_at_install,
+                    },
+                ],
+            },
+        }
+    )
+    for db in bd.databases:
+        bd.Database(db).process()
+
+    product = bd.get_node(database="foreground", code="unit_product")
+    database_dates = {
+        "electricity_market_2025": datetime(2025, 1, 1),
+        "electricity_market_2035": datetime(2035, 1, 1),
+        "foreground": "dynamic",
+    }
+    tlca = TimexLCA(
+        demand={product.key: 1},
+        method=("GWP", "example"),
+        database_dates=database_dates,
+    )
+    tlca.build_timeline(
+        starting_datetime=datetime(2025, 1, 1),
+        temporal_grouping="year",
+    )
+    tlca.lci()
+    tlca.static_lcia()
+
+    fu_rows = tlca.timeline[tlca.timeline["consumer"] == -1].sort_values(
+        "date_producer"
+    )
+    assert fu_rows["date_producer"].dt.year.tolist() == [2025, 2035]
+    assert fu_rows["amount"].tolist() == pytest.approx([0.5, 0.5])
+
+    elec_rows = tlca.timeline[
+        tlca.timeline["producer_name"] == "electricity market"
+    ].sort_values("date_consumer")
+    assert elec_rows["date_consumer"].dt.year.tolist() == [2025, 2035]
+    assert [
+        row.temporal_market_shares for row in elec_rows.itertuples()
+    ] == [
+        {"electricity_market_2025": 1.0},
+        {"electricity_market_2035": 1.0},
+    ]
+
+    assert tlca.static_score == pytest.approx(0.5 * 0.40 + 0.5 * 0.10)

--- a/tests/test_temporal_evolution.py
+++ b/tests/test_temporal_evolution.py
@@ -343,6 +343,80 @@ def test_temporal_evolution_score_matches_hardcoded():
 
 
 @bw2test
+def test_temporal_evolution_reference_consumer_vs_producer():
+    """Temporal evolution can be evaluated at consumer (vintage) time or producer time."""
+    bd.Database("bio").write(
+        {("bio", "CO2"): {"type": "emission", "name": "carbon dioxide"}}
+    )
+
+    for db_name in ("db_2020", "db_2030"):
+        bd.Database(db_name).write(
+            {
+                (db_name, "electricity"): {
+                    "name": "electricity production",
+                    "reference product": "electricity",
+                    "location": "GLO",
+                    "exchanges": [
+                        {"amount": 1, "type": "production", "input": (db_name, "electricity")},
+                        {"amount": 1, "type": "biosphere", "input": ("bio", "CO2")},
+                    ],
+                }
+            }
+        )
+
+    bd.Method(("GWP", "example")).write([(("bio", "CO2"), 1.0)])
+
+    td_use = TemporalDistribution(
+        date=np.array([5], dtype="timedelta64[Y]"), amount=np.array([1.0])
+    )
+
+    def run_model(reference: str) -> float:
+        bd.Database("foreground").write(
+            {
+                ("foreground", "consumer"): {
+                    "name": "consumer",
+                    "reference product": "unit",
+                    "location": "GLO",
+                    "exchanges": [
+                        {"amount": 1, "type": "production", "input": ("foreground", "consumer")},
+                        {
+                            "amount": 10,
+                            "type": "technosphere",
+                            "input": ("db_2020", "electricity"),
+                            "temporal_distribution": td_use,
+                            "temporal_evolution_factors": {
+                                datetime(2025, 1, 1): 1.0,
+                                datetime(2030, 1, 1): 2.0,
+                            },
+                            "temporal_evolution_reference": reference,
+                        },
+                    ],
+                }
+            }
+        )
+
+        database_dates = {
+            "db_2020": datetime(2020, 1, 1),
+            "db_2030": datetime(2030, 1, 1),
+            "foreground": "dynamic",
+        }
+        tlca = TimexLCA(
+            demand={("foreground", "consumer"): 1},
+            method=("GWP", "example"),
+            database_dates=database_dates,
+        )
+        tlca.build_timeline(starting_datetime=datetime(2025, 1, 1))
+        tlca.lci()
+        tlca.static_lcia()
+        return tlca.static_score
+
+    score_consumer_ref = run_model("consumer")
+    score_producer_ref = run_model("producer")
+
+    assert score_producer_ref == pytest.approx(2 * score_consumer_ref, rel=1e-6)
+
+
+@bw2test
 def test_temporal_evolution_applied_with_bfs_traversal():
     """temporal_evolution_factors must be applied with graph_traversal='bfs' too,
     not only with the default priority traversal.


### PR DESCRIPTION
Adds support for the explicit process/product paradigm: products are bare metadata, processes own all edges, no reference-product field, demand the product directly.

This is a **focused, code-and-docs-only** slice of #186 — the example notebooks are intentionally excluded to keep the diff reviewable (#186 carried ~110k lines of notebook JSON).

## Changes
- **edge_extractor** — temporal-evolution extraction + consumer/producer reference handling
- **timex_lca, matrix_modifier, dynamic_biosphere_builder, timeline_builder, utils, validation** — explicit product/process plumbing
- **docs** — `explicit_process_product_paradigm`, `decisiontree`, temporal-information updates
- **tests** — explicit process/product end-to-end, EV explicit, + fixtures

## Test plan
- `uv run pytest` → 186 passed

Supersedes #186 (notebooks can follow separately).