### PR TITLE
Support temporal distributions in the background system (traverse_background)

### DIFF
--- a/bw_timex/dynamic_biosphere_builder.py
+++ b/bw_timex/dynamic_biosphere_builder.py
@@ -194,8 +194,12 @@ class DynamicBiosphereBuilder:
                 # Get temporal evolution factor for this timestamp
                 temporal_evolution_factor = 1.0
                 if hasattr(row, "temporal_evolution") and row.temporal_evolution is not None:
+                    reference = getattr(row, "temporal_evolution_reference", "producer")
+                    reference_time = (
+                        row.date_consumer if reference == "consumer" else time_in_datetime
+                    )
                     temporal_evolution_factor = get_temporal_evolution_factor(
-                        row.temporal_evolution, time_in_datetime
+                        row.temporal_evolution, reference_time
                     )
 
                 for input_id, exc_amount, temporal_distribution in (

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -11,6 +11,11 @@ from bw2data.backends.schema import ActivityDataset as AD
 from bw2data.backends.schema import ExchangeDataset as ED
 from bw_temporalis import TemporalDistribution, TemporalisLCA, loader_registry
 
+from .utils import get_reference_product_production_amount
+
+if not hasattr(np, "in1d"):
+    np.in1d = np.isin
+
 datetime_type = np.dtype("datetime64[s]")
 timedelta_type = np.dtype("timedelta64[s]")
 
@@ -36,6 +41,7 @@ class Edge:
     abs_td_producer: TemporalDistribution = None
     abs_td_consumer: TemporalDistribution = None
     temporal_evolution: dict = None
+    temporal_evolution_reference: str = "producer"
 
 
 def extract_temporal_evolution(exc_data: dict) -> dict | None:
@@ -133,13 +139,56 @@ class EdgeExtractor(TemporalisLCA):
             self.unique_id
         ]:  # starting at the edges of the functional unit
             node = self.nodes[edge.producer_unique_id]
+            td_producer = edge.amount
+            initial_distribution = self.t0 * edge.amount
+            abs_td_producer = self.t0
+            abs_td_consumer = None
+
+            row_id = self.lca_object.dicts.product.reversed[edge.product_index]
+            col_id = node.activity_datapackage_id
+            exchange = self.get_technosphere_exchange(input_id=row_id, output_id=col_id)
+
+            # In the explicit process/product paradigm, the demanded product is produced
+            # by an off-diagonal production edge. A TD on that edge distributes the
+            # process invocation itself before the process inputs are traversed.
+            if (
+                row_id != col_id
+                and hasattr(exchange, "data")
+                and exchange.data.get("type") == "production"
+            ):
+                production_amount = abs(
+                    get_reference_product_production_amount(
+                        col_id, reference_product=row_id, lca=self.lca_object
+                    )
+                )
+                td_producer = (
+                    self._exchange_value(
+                        exchange=exchange,
+                        row_id=row_id,
+                        col_id=col_id,
+                        matrix_label="technosphere_matrix",
+                    )
+                    / production_amount
+                    * edge.amount
+                )
+                if isinstance(td_producer, Number):
+                    td_producer = TemporalDistribution(
+                        date=np.array([0], dtype="timedelta64[Y]"),
+                        amount=np.array([td_producer]),
+                    )
+                initial_distribution = (self.t0 * td_producer).simplify()
+                abs_td_producer = self.join_datetime_and_timedelta_distributions(
+                    td_producer, self.t0
+                )
+                abs_td_consumer = self.t0
+
             heappush(
                 heap,
                 (
                     1 / node.cumulative_score,
-                    self.t0 * edge.amount,
+                    initial_distribution,
                     self.t0,
-                    self.t0,
+                    abs_td_producer,
                     node,
                 ),
             )
@@ -147,13 +196,14 @@ class EdgeExtractor(TemporalisLCA):
             timeline.append(
                 Edge(
                     edge_type="production",  # FU exchange always type production (?)
-                    distribution=self.t0 * edge.amount,
+                    distribution=initial_distribution,
                     leaf=False,
                     consumer=self.unique_id,
                     producer=node.activity_datapackage_id,
-                    td_producer=edge.amount,
+                    td_producer=td_producer,
                     td_consumer=self.t0,
-                    abs_td_producer=self.t0,
+                    abs_td_producer=abs_td_producer,
+                    abs_td_consumer=abs_td_consumer,
                 )
             )
 
@@ -163,10 +213,17 @@ class EdgeExtractor(TemporalisLCA):
             for edge in self.edge_mapping[node.unique_id]:
                 row_id = self.nodes[edge.producer_unique_id].activity_datapackage_id
                 col_id = node.activity_datapackage_id
+                product_id = self.lca_object.dicts.product.reversed[edge.product_index]
                 exchange = self.get_technosphere_exchange(
-                    input_id=row_id,
+                    input_id=product_id,
                     output_id=col_id,
                 )
+                if not hasattr(exchange, "data"):
+                    exchange = self.get_technosphere_exchange(
+                        input_id=row_id,
+                        output_id=col_id,
+                    )
+                    product_id = row_id
 
                 edge_type = exchange.data[
                     "type"
@@ -174,15 +231,22 @@ class EdgeExtractor(TemporalisLCA):
 
                 # Extract temporal evolution data from exchange
                 temporal_evolution = extract_temporal_evolution(exchange.data)
+                temporal_evolution_reference = exchange.data.get(
+                    "temporal_evolution_reference", "producer"
+                )
 
                 td_producer = (  # td_producer is the TemporalDistribution of the edge
                     self._exchange_value(
                         exchange=exchange,
-                        row_id=row_id,
+                        row_id=product_id,
                         col_id=col_id,
                         matrix_label="technosphere_matrix",
                     )
-                    / abs(node.reference_product_production_amount)
+                    / abs(
+                        get_reference_product_production_amount(
+                            node.activity_datapackage_id, lca=self.lca_object
+                        )
+                    )
                 )
                 producer = self.nodes[edge.producer_unique_id]
                 leaf = self.edge_ff(row_id)
@@ -193,6 +257,38 @@ class EdgeExtractor(TemporalisLCA):
                         date=np.array([0], dtype="timedelta64[Y]"),
                         amount=np.array([td_producer]),
                     )
+
+                if product_id != row_id:
+                    production_exchange = self.get_technosphere_exchange(
+                        input_id=product_id,
+                        output_id=row_id,
+                    )
+                    if (
+                        hasattr(production_exchange, "data")
+                        and production_exchange.data.get("type") == "production"
+                    ):
+                        production_amount = abs(
+                            get_reference_product_production_amount(
+                                row_id,
+                                reference_product=product_id,
+                                lca=self.lca_object,
+                            )
+                        )
+                        production_td = (
+                            self._exchange_value(
+                                exchange=production_exchange,
+                                row_id=product_id,
+                                col_id=row_id,
+                                matrix_label="technosphere_matrix",
+                            )
+                            / production_amount
+                        )
+                        if isinstance(production_td, Number):
+                            production_td = TemporalDistribution(
+                                date=np.array([0], dtype="timedelta64[Y]"),
+                                amount=np.array([production_td]),
+                            )
+                        td_producer = (td_producer * production_td).simplify()
 
                 distribution = (
                     td * td_producer
@@ -212,6 +308,7 @@ class EdgeExtractor(TemporalisLCA):
                         ),
                         abs_td_consumer=abs_td,
                         temporal_evolution=temporal_evolution,
+                        temporal_evolution_reference=temporal_evolution_reference,
                     )
                 )
                 if not leaf:
@@ -368,10 +465,11 @@ class EdgeExtractorBFS:
         return amount, edge_type, temporal_evolution
 
     def _get_production_amount(self, activity_id: int) -> float:
-        """Get the reference product production amount (diagonal of tech matrix)."""
-        product_idx = self.lca_object.dicts.product[activity_id]
-        col_idx = self.lca_object.dicts.activity[activity_id]
-        return self.tech_matrix_csc[product_idx, col_idx]
+        """Get the reference product production amount."""
+        activity = self.lca_object.dicts.activity.reversed[
+            self.lca_object.dicts.activity[activity_id]
+        ]
+        return get_reference_product_production_amount(activity)
 
     def _get_technosphere_inputs(self, activity_id: int) -> list[int]:
         """Get all technosphere input activity IDs for a given activity."""

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -80,7 +80,374 @@ def extract_temporal_evolution(exc_data: dict) -> dict | None:
     return None
 
 
-class EdgeExtractor(TemporalisLCA):
+class VariantBackgroundMixin:
+    """Shared variant-aware (respective-variant) background-descent machinery.
+
+    The base graph traversal (priority or BFS) runs on ``base_lca``, which only
+    contains the *referenced* background variant. When descent continues INTO a
+    background process reached at a date that routes to a NON-referenced variant,
+    the respective variant's exchanges/amounts/TDs must be read from the bw2data
+    activity proxy (``self.bw_node_proxies``) rather than from the
+    (referenced-only) technosphere matrix or graph-traversal node objects.
+
+    Both ``EdgeExtractorBFS`` and the priority ``EdgeExtractor`` mix this in.
+    They differ in how they reach the first background crossing (matrix BFS vs.
+    ``TemporalisLCA`` heap), but the variant split + the proxy-only descent
+    through the resulting variant subtree are identical, so they live here.
+
+    Mixers must provide:
+    - ``self.bw_node_proxies``: ``{activity_id: bw2data Activity proxy}``.
+    - ``self.database_dates_static``, ``self.interpolation_type``,
+      ``self.interdatabase_activity_mapping`` (set by ``TimelineBuilder``).
+    - ``self.static_activity_indices`` (set; empty under traverse_background).
+    - ``self.variant_resolved_producers`` (set, collected during descent).
+    - ``self.cutoff`` and a ``self.edge_ff`` edge-filter callable.
+    """
+
+    def _variant_shares_for_date(self, producer_date) -> dict:
+        """Return ``{db_name: weight}`` interpolation shares for a cohort date.
+
+        Maps the producer's absolute cohort date onto the available static
+        background databases, using the same interpolation as the timeline
+        builder so leaf and descended routing agree.
+        """
+        from datetime import datetime as _dt
+
+        dates_static = getattr(self, "database_dates_static", None) or {}
+        dates_to_db = {v: k for k, v in dates_static.items() if isinstance(v, _dt)}
+        sorted_dates = tuple(sorted(dates_to_db))
+        if not sorted_dates:
+            return {}
+
+        if isinstance(producer_date, np.datetime64):
+            producer_date = producer_date.astype("datetime64[s]").astype(_dt)
+
+        if getattr(self, "interpolation_type", "linear") == "nearest":
+            weights = nearest_date_weight(producer_date, sorted_dates)
+        else:
+            weights = linear_interpolation_weights(producer_date, sorted_dates)
+        return {dates_to_db[d]: w for d, w in (weights or {}).items()}
+
+    def _resolve_in_variant(self, node_id: int, db_name: str) -> int:
+        """Return the id of ``node_id``'s sibling in database ``db_name``.
+
+        If ``node_id`` already lives in ``db_name`` it is returned unchanged;
+        otherwise the sibling is looked up via the interdatabase mapping.
+        """
+        node = self.bw_node_proxies.get(node_id)
+        if node is not None and node["database"] == db_name:
+            return node_id
+        return self.interdatabase_activity_mapping.find_match(node_id, db_name)
+
+    def _proxy_production_amount(self, activity_id: int) -> float:
+        """Production amount of a (possibly non-referenced) variant node, read
+        from its bw2data proxy."""
+        return get_reference_product_production_amount(
+            self.bw_node_proxies[activity_id]
+        )
+
+    def _proxy_technosphere_inputs(self, activity_id: int) -> list[int]:
+        """Technosphere input product ids of a variant node, read from its proxy.
+
+        ``static_activity_indices`` is empty when ``traverse_background`` is set,
+        so no filtering is needed, but it is honoured for symmetry with the
+        matrix path.
+        """
+        inputs = []
+        for exchange in self.bw_node_proxies[activity_id].technosphere():
+            input_id = exchange.input.id
+            if input_id in self.static_activity_indices:
+                continue
+            inputs.append(input_id)
+        return inputs
+
+    def _get_exchange_td_and_type_from_proxy(self, input_id: int, output_id: int):
+        """Read the exchange between ``input_id`` and ``output_id`` directly from
+        the consuming node's bw2data proxy (``self.bw_node_proxies[output_id]``)
+        rather than from the technosphere matrix, because non-referenced variant
+        nodes are absent from ``base_lca``'s matrix. Returns the same
+        ``(td_or_amount, edge_type, temporal_evolution)`` tuple.
+        """
+        consumer = self.bw_node_proxies[output_id]
+        exc = None
+        for candidate in consumer.technosphere():
+            if candidate.input.id == input_id:
+                exc = candidate
+                break
+        if exc is None:
+            for candidate in consumer.exchanges():
+                if (
+                    candidate.input.id == input_id
+                    and candidate.get("type") != "production"
+                ):
+                    exc = candidate
+                    break
+        if exc is None:
+            raise ValueError(
+                f"No exchange from {input_id} to {output_id} found on proxy."
+            )
+
+        edge_type = exc.get("type", "technosphere")
+        amount = exc["amount"]
+        temporal_evolution = extract_temporal_evolution(exc.as_dict())
+
+        td = exc.get("temporal_distribution")
+        if isinstance(td, str) and "__loader__" in td:
+            data = json.loads(td)
+            td = loader_registry[data["__loader__"]](data)
+        if isinstance(td, TemporalDistribution):
+            return td * amount, edge_type, temporal_evolution
+        return amount, edge_type, temporal_evolution
+
+    def _normalized_production_edge_td_from_proxy(self, process_id: int):
+        """Cohort production-edge TD of a variant node, normalized to unit
+        weights, read from its proxy. ``None`` when there is no such TD."""
+        productions = list(self.bw_node_proxies[process_id].production())
+        if not productions:
+            return None
+        production = productions[0]
+        td = production.get("temporal_distribution")
+        if isinstance(td, str) and "__loader__" in td:
+            data = json.loads(td)
+            td = loader_registry[data["__loader__"]](data)
+        if not isinstance(td, TemporalDistribution):
+            return None
+        return td / abs(production["amount"])
+
+    def _producer_process_in_variant(self, product_id: int, db_name: str):
+        """Resolve the process producing ``product_id`` within variant
+        ``db_name`` from the proxy.
+
+        ``product_id`` was read from a variant proxy, so it already lives in
+        ``db_name``. For chimaera nodes the product produces itself; returns
+        ``None`` if the product has no producer (a pure leaf).
+        """
+        node = self.bw_node_proxies.get(product_id)
+        if node is None:
+            return None
+        for _ in node.production():
+            return product_id
+        return product_id
+
+    def _is_static_background(self, node_id: int) -> bool:
+        """True if ``node_id`` lives in one of the static background databases."""
+        dates_static = getattr(self, "database_dates_static", None) or {}
+        node = self.bw_node_proxies.get(node_id)
+        return node is not None and node["database"] in dates_static
+
+    def _emit_variant_split(
+        self,
+        *,
+        node_id: int,
+        producer_process: int,
+        edge_type: str,
+        temporal_evolution,
+        td_producer: TemporalDistribution,
+        distribution: TemporalDistribution,
+        abs_td_producer: TemporalDistribution,
+        abs_td: TemporalDistribution,
+        td_parent,
+        new_supply: float,
+        total_demand: float,
+    ) -> list:
+        """Perform the variant-aware split at the first background crossing.
+
+        For each producer cohort date, route the edge to its temporally
+        appropriate variant database(s), emit one scaled ``Edge`` per variant,
+        record the variant id in ``self.variant_resolved_producers``, and descend
+        the resulting variant subtree via proxy reads. Returns the list of
+        ``Edge`` instances (the split edge + every edge of every variant
+        subtree).
+
+        Shared verbatim by both the BFS and priority engines.
+        """
+        # Route each producer cohort date to its variant(s). The producer cohort
+        # dates live on ``abs_td_producer``; the corresponding edge amounts live
+        # on ``distribution`` (same date axis).
+        variant_keep: dict[str, dict] = {}
+        for date in abs_td_producer.date:
+            for db_name, weight in self._variant_shares_for_date(date).items():
+                variant_keep.setdefault(db_name, {})[date] = weight
+
+        # The variant split routes by absolute producer date. The relative
+        # ``td_producer`` and absolute ``abs_td_producer`` share an index axis
+        # when the consumer has a single absolute date (the case for every
+        # background split: the consuming background process sits at one cohort
+        # date per descent). Mask all three arrays by the same kept indices so
+        # ``extract_edge_data`` can explode consumer/producer dates and amounts
+        # consistently.
+        if len(abs_td) != 1:
+            raise NotImplementedError(
+                "Variant-aware background split with a multi-date "
+                "consumer is not supported."
+            )
+
+        edges = []
+        for db_name, keep in variant_keep.items():
+            keep_idx = [
+                i for i, d in enumerate(abs_td_producer.date) if keep.get(d)
+            ]
+            if not keep_idx:
+                continue
+            weights = np.array([keep[abs_td_producer.date[i]] for i in keep_idx])
+            masked_abs_td_producer = TemporalDistribution(
+                date=abs_td_producer.date[keep_idx],
+                amount=abs_td_producer.amount[keep_idx] * weights,
+            )
+            masked_distribution = TemporalDistribution(
+                date=distribution.date[keep_idx],
+                amount=distribution.amount[keep_idx] * weights,
+            )
+            masked_td_producer = TemporalDistribution(
+                date=td_producer.date[keep_idx],
+                amount=td_producer.amount[keep_idx] * weights,
+            )
+            variant_id = self._resolve_in_variant(producer_process, db_name)
+            self.variant_resolved_producers.add(variant_id)
+
+            edges.append(
+                Edge(
+                    edge_type=edge_type,
+                    distribution=masked_distribution,
+                    leaf=self.edge_ff(producer_process),
+                    consumer=node_id,
+                    producer=variant_id,
+                    td_producer=masked_td_producer,
+                    td_consumer=td_parent,
+                    abs_td_producer=masked_abs_td_producer,
+                    abs_td_consumer=abs_td,
+                    temporal_evolution=temporal_evolution,
+                )
+            )
+
+            child_td, child_abs_td = masked_distribution, masked_abs_td_producer
+            producer_production_td = self._normalized_production_edge_td_from_proxy(
+                variant_id
+            )
+            if producer_production_td is not None:
+                child_td = (masked_distribution * producer_production_td).simplify()
+                child_abs_td = _join_datetime_and_timedelta_distributions(
+                    producer_production_td, masked_abs_td_producer
+                )
+
+            variant_supply = new_supply * sum(keep.values()) / max(len(keep), 1)
+            edges.extend(
+                self._descend_variant_subtree(
+                    node_id=variant_id,
+                    td=child_td,
+                    td_parent=masked_td_producer,
+                    abs_td=child_abs_td,
+                    supply=variant_supply,
+                    variant_db=db_name,
+                    total_demand=total_demand,
+                )
+            )
+        return edges
+
+    def _descend_variant_subtree(
+        self,
+        *,
+        node_id: int,
+        td: TemporalDistribution,
+        td_parent,
+        abs_td: TemporalDistribution,
+        supply: float,
+        variant_db: str,
+        total_demand: float,
+    ) -> list:
+        """Proxy-only BFS descent through a locked background variant subtree.
+
+        Once inside a variant descent the variant is LOCKED: every descendant
+        stays in ``variant_db`` and is read from its bw2data proxy (those nodes
+        are absent from ``base_lca``). No re-splitting happens. Variant-resolved
+        background producers are recorded so the timeline builder temporalizes
+        them (rather than re-interpolating them as temporal markets).
+
+        Engine-agnostic: it does not touch the priority heap or the BFS matrix,
+        so both extractors call it identically after their first-crossing split.
+        """
+        edges = []
+        queue = deque()
+        queue.append((node_id, td, td_parent, abs_td, supply))
+
+        while queue:
+            cur_id, cur_td, cur_parent, cur_abs_td, cur_supply = queue.popleft()
+
+            production_amount = self._proxy_production_amount(cur_id)
+            input_ids = self._proxy_technosphere_inputs(cur_id)
+
+            for input_id in input_ids:
+                leaf = self.edge_ff(input_id)
+                td_producer_raw, edge_type, temporal_evolution = (
+                    self._get_exchange_td_and_type_from_proxy(input_id, cur_id)
+                )
+
+                td_producer = td_producer_raw / abs(production_amount)
+                if isinstance(td_producer, Number):
+                    td_producer = TemporalDistribution(
+                        date=np.array([0], dtype="timedelta64[Y]"),
+                        amount=np.array([td_producer]),
+                    )
+
+                distribution = (cur_td * td_producer).simplify()
+                abs_td_producer = _join_datetime_and_timedelta_distributions(
+                    td_producer, cur_abs_td
+                )
+
+                if isinstance(td_producer_raw, TemporalDistribution):
+                    edge_supply = abs(td_producer_raw.amount.sum())
+                else:
+                    edge_supply = abs(td_producer_raw)
+                new_supply = cur_supply * edge_supply / abs(production_amount)
+
+                producer_process = self._producer_process_in_variant(
+                    input_id, variant_db
+                )
+                will_descend = (
+                    not leaf
+                    and new_supply >= self.cutoff * total_demand
+                    and producer_process is not None
+                )
+
+                # Already routed to its real variant database -> temporalize it.
+                if self._is_static_background(input_id):
+                    self.variant_resolved_producers.add(input_id)
+
+                edges.append(
+                    Edge(
+                        edge_type=edge_type,
+                        distribution=distribution,
+                        leaf=leaf,
+                        consumer=cur_id,
+                        producer=input_id,
+                        td_producer=td_producer,
+                        td_consumer=cur_parent,
+                        abs_td_producer=abs_td_producer,
+                        abs_td_consumer=cur_abs_td,
+                        temporal_evolution=temporal_evolution,
+                    )
+                )
+
+                if not will_descend:
+                    continue
+
+                child_td, child_abs_td = distribution, abs_td_producer
+                producer_production_td = (
+                    self._normalized_production_edge_td_from_proxy(producer_process)
+                )
+                if producer_production_td is not None:
+                    child_td = (distribution * producer_production_td).simplify()
+                    child_abs_td = _join_datetime_and_timedelta_distributions(
+                        producer_production_td, abs_td_producer
+                    )
+
+                queue.append(
+                    (producer_process, child_td, td_producer, child_abs_td, new_supply)
+                )
+        return edges
+
+
+class EdgeExtractor(VariantBackgroundMixin, TemporalisLCA):
     """
     Child class of TemporalisLCA that traverses the supply chain just as the parent class but can create a timeline of edges, in addition timeline of flows or nodes.
 
@@ -111,12 +478,26 @@ class EdgeExtractor(TemporalisLCA):
             stores the output of the TemporalisLCA graph traversal (incl. relation of edges (edge_mapping) and nodes (node_mapping) in the instance of the class.
 
         """
+        # ``cutoff``/``static_activity_indices`` are consumed by TemporalisLCA but
+        # not stored on it; the shared variant-descent mixin needs both, so keep
+        # local copies before delegating.
+        self.cutoff = kwargs.get("cutoff", 5e-4)
+        self.static_activity_indices = kwargs.get("static_activity_indices") or set()
         super().__init__(*args, **kwargs)  # use __init__ of TemporalisLCA
         self.traverse_background = traverse_background
         if edge_filter_function:
             self.edge_ff = edge_filter_function
         else:
             self.edge_ff = lambda x: False
+        # Producer node ids variant-resolved during a variant-aware background
+        # descent (shared with EdgeExtractorBFS via VariantBackgroundMixin). These
+        # are temporalized by the timeline builder, not treated as temporal-market
+        # leaves. ``bw_node_proxies`` (bw2data Activity proxies, keyed by activity
+        # id) is set by the TimelineBuilder; the mixin's proxy reads use it because
+        # the priority engine's own ``self.nodes`` are graph-traversal Node objects
+        # keyed by ``unique_id`` and contain only the referenced variant.
+        self.variant_resolved_producers: set[int] = set()
+        self.bw_node_proxies: dict = {}
 
     def build_edge_timeline(self) -> list:
         """
@@ -141,6 +522,9 @@ class EdgeExtractor(TemporalisLCA):
 
         heap = []
         timeline = []
+        # Total demand drives the cutoff comparison in the shared variant-descent
+        # mixin (same semantics as the BFS engine).
+        total_demand = float(np.abs(self.lca_object.demand_array).sum())
 
         for edge in self.edge_mapping[
             self.unique_id
@@ -301,18 +685,60 @@ class EdgeExtractor(TemporalisLCA):
                     td * td_producer
                 ).simplify()  # convolution-multiplication of TemporalDistribution of consuming node (td) and consumed edge (edge) gives TD of producing node
 
+                abs_td_producer = self.join_datetime_and_timedelta_distributions(
+                    td_producer, abs_td
+                )
+
+                # Variant-aware split at the FIRST crossing from the referenced
+                # traversal into the background. Mirrors EdgeExtractorBFS exactly
+                # (consumer is static background, producer is static background
+                # WITH technosphere inputs); leaves / market frontier fall through
+                # to the existing single-edge + heap path unchanged.
+                consumer_id = node.activity_datapackage_id
+                producer_id = producer.activity_datapackage_id
+                variant_split = (
+                    not leaf
+                    and self.traverse_background
+                    and getattr(self, "interdatabase_activity_mapping", None)
+                    is not None
+                    and self.bw_node_proxies
+                    and self._is_static_background(consumer_id)
+                    and self._is_static_background(producer_id)
+                    and bool(self._proxy_technosphere_inputs(producer_id))
+                )
+
+                if variant_split:
+                    if isinstance(td_producer, TemporalDistribution):
+                        new_supply = abs(td_producer.amount.sum())
+                    else:
+                        new_supply = abs(td_producer)
+                    timeline.extend(
+                        self._emit_variant_split(
+                            node_id=consumer_id,
+                            producer_process=producer_id,
+                            edge_type=edge_type,
+                            temporal_evolution=temporal_evolution,
+                            td_producer=td_producer,
+                            distribution=distribution,
+                            abs_td_producer=abs_td_producer,
+                            abs_td=abs_td,
+                            td_parent=td_parent,
+                            new_supply=new_supply,
+                            total_demand=total_demand,
+                        )
+                    )
+                    continue
+
                 timeline.append(
                     Edge(
                         edge_type=edge_type,
                         distribution=distribution,
                         leaf=leaf,
-                        consumer=node.activity_datapackage_id,
-                        producer=producer.activity_datapackage_id,
+                        consumer=consumer_id,
+                        producer=producer_id,
                         td_producer=td_producer,
                         td_consumer=td_parent,
-                        abs_td_producer=self.join_datetime_and_timedelta_distributions(
-                            td_producer, abs_td
-                        ),
+                        abs_td_producer=abs_td_producer,
                         abs_td_consumer=abs_td,
                         temporal_evolution=temporal_evolution,
                         temporal_evolution_reference=temporal_evolution_reference,
@@ -325,9 +751,7 @@ class EdgeExtractor(TemporalisLCA):
                             1 / node.cumulative_score,
                             distribution,
                             td_producer,
-                            self.join_datetime_and_timedelta_distributions(
-                                td_producer, abs_td
-                            ),
+                            abs_td_producer,
                             producer,
                         ),
                     )
@@ -370,7 +794,7 @@ class EdgeExtractor(TemporalisLCA):
         return _join_datetime_and_timedelta_distributions(td_producer, td_consumer)
 
 
-class EdgeExtractorBFS:
+class EdgeExtractorBFS(VariantBackgroundMixin):
     """
     Breadth-First-Search (BFS) graph traversal for extracting temporal edges from
     the supply chain.
@@ -403,6 +827,9 @@ class EdgeExtractorBFS:
         # {node_id: bw2data Activity proxy} reused from TimexLCA, so production /
         # technosphere exchanges are read without re-fetching nodes.
         self.nodes = nodes or {}
+        # The mixin reads bw2data Activity proxies through ``bw_node_proxies``.
+        # For BFS these are the same node proxies the matrix traversal uses.
+        self.bw_node_proxies = self.nodes
         self.traverse_background = traverse_background
         self.max_calc = max_calc
         self._calc_count = 0
@@ -591,146 +1018,8 @@ class EdgeExtractorBFS:
         # so the alpha scaling is applied only once, on the input side.
         return td / abs(production["amount"])
 
-    # ------------------------------------------------------------------
-    # Variant-aware (respective-variant) reads
-    #
-    # The base traversal runs on ``base_lca``, which only contains the
-    # referenced background variant. When descent continues INTO a background
-    # process reached at a date routing to a NON-referenced variant, the
-    # respective variant's exchanges/amounts/TDs must be read from the bw2data
-    # activity proxy in ``self.nodes`` rather than from the (referenced-only)
-    # technosphere matrix.
-    # ------------------------------------------------------------------
-
-    def _variant_shares_for_date(self, producer_date) -> dict:
-        """Return ``{db_name: weight}`` interpolation shares for a cohort date.
-
-        Maps the producer's absolute cohort date onto the available static
-        background databases, using the same interpolation as the timeline
-        builder so leaf and descended routing agree.
-        """
-        from datetime import datetime as _dt
-
-        dates_static = getattr(self, "database_dates_static", None) or {}
-        dates_to_db = {v: k for k, v in dates_static.items() if isinstance(v, _dt)}
-        sorted_dates = tuple(sorted(dates_to_db))
-        if not sorted_dates:
-            return {}
-
-        if isinstance(producer_date, np.datetime64):
-            producer_date = producer_date.astype("datetime64[s]").astype(_dt)
-
-        if getattr(self, "interpolation_type", "linear") == "nearest":
-            weights = nearest_date_weight(producer_date, sorted_dates)
-        else:
-            weights = linear_interpolation_weights(producer_date, sorted_dates)
-        return {dates_to_db[d]: w for d, w in (weights or {}).items()}
-
-    def _resolve_in_variant(self, node_id: int, db_name: str) -> int:
-        """Return the id of ``node_id``'s sibling in database ``db_name``.
-
-        If ``node_id`` already lives in ``db_name`` it is returned unchanged;
-        otherwise the sibling is looked up via the interdatabase mapping.
-        """
-        node = self.nodes.get(node_id)
-        if node is not None and node["database"] == db_name:
-            return node_id
-        return self.interdatabase_activity_mapping.find_match(node_id, db_name)
-
-    def _proxy_production_amount(self, activity_id: int) -> float:
-        """Production amount of a (possibly non-referenced) variant node, read
-        from its bw2data proxy."""
-        return get_reference_product_production_amount(self.nodes[activity_id])
-
-    def _proxy_technosphere_inputs(self, activity_id: int) -> list[int]:
-        """Technosphere input product ids of a variant node, read from its proxy.
-
-        ``static_activity_indices`` is empty when ``traverse_background`` is set,
-        so no filtering is needed, but it is honoured for symmetry with the
-        matrix path.
-        """
-        inputs = []
-        for exchange in self.nodes[activity_id].technosphere():
-            input_id = exchange.input.id
-            if input_id in self.static_activity_indices:
-                continue
-            inputs.append(input_id)
-        return inputs
-
-    def _get_exchange_td_and_type_from_proxy(self, input_id: int, output_id: int):
-        """Proxy-based counterpart of ``_get_exchange_td_and_type``.
-
-        Reads the exchange between ``input_id`` and ``output_id`` directly from
-        the consuming node's bw2data proxy (``self.nodes[output_id]``) rather
-        than from the technosphere matrix, because non-referenced variant nodes
-        are absent from ``base_lca``'s matrix. Returns the same
-        ``(td_or_amount, edge_type, temporal_evolution)`` tuple.
-        """
-        consumer = self.nodes[output_id]
-        exc = None
-        for candidate in consumer.technosphere():
-            if candidate.input.id == input_id:
-                exc = candidate
-                break
-        if exc is None:
-            for candidate in consumer.exchanges():
-                if (
-                    candidate.input.id == input_id
-                    and candidate.get("type") != "production"
-                ):
-                    exc = candidate
-                    break
-        if exc is None:
-            raise ValueError(
-                f"No exchange from {input_id} to {output_id} found on proxy."
-            )
-
-        edge_type = exc.get("type", "technosphere")
-        amount = exc["amount"]
-        temporal_evolution = extract_temporal_evolution(exc.as_dict())
-
-        td = exc.get("temporal_distribution")
-        if isinstance(td, str) and "__loader__" in td:
-            data = json.loads(td)
-            td = loader_registry[data["__loader__"]](data)
-        if isinstance(td, TemporalDistribution):
-            return td * amount, edge_type, temporal_evolution
-        return amount, edge_type, temporal_evolution
-
-    def _normalized_production_edge_td_from_proxy(self, process_id: int):
-        """Proxy-based counterpart of ``_get_normalized_production_edge_td``."""
-        productions = list(self.nodes[process_id].production())
-        if not productions:
-            return None
-        production = productions[0]
-        td = production.get("temporal_distribution")
-        if isinstance(td, str) and "__loader__" in td:
-            data = json.loads(td)
-            td = loader_registry[data["__loader__"]](data)
-        if not isinstance(td, TemporalDistribution):
-            return None
-        return td / abs(production["amount"])
-
-    def _producer_process_in_variant(self, product_id: int, db_name: str):
-        """Resolve the process producing ``product_id`` within variant
-        ``db_name`` from the proxy.
-
-        ``product_id`` was read from a variant proxy, so it already lives in
-        ``db_name``. For chimaera nodes the product produces itself; returns
-        ``None`` if the product has no producer (a pure leaf).
-        """
-        node = self.nodes.get(product_id)
-        if node is None:
-            return None
-        for _ in node.production():
-            return product_id
-        return product_id
-
-    def _is_static_background(self, node_id: int) -> bool:
-        """True if ``node_id`` lives in one of the static background databases."""
-        dates_static = getattr(self, "database_dates_static", None) or {}
-        node = self.nodes.get(node_id)
-        return node is not None and node["database"] in dates_static
+    # Variant-aware (respective-variant) reads + proxy descent are inherited
+    # from ``VariantBackgroundMixin`` and shared with the priority extractor.
 
     def build_edge_timeline(self) -> list:
         """
@@ -772,7 +1061,7 @@ class EdgeExtractorBFS:
                         abs_td_producer=self.t0,
                     )
                 )
-                queue.append((fu_id, td, self.t0, self.t0, abs(fu_amount), None))
+                queue.append((fu_id, td, self.t0, self.t0, abs(fu_amount)))
             else:
                 # Cohort-spread the FU so the producing process is registered at
                 # every cohort time (each cohort gets its own time-mapped column).
@@ -794,39 +1083,29 @@ class EdgeExtractorBFS:
                     )
                 )
                 queue.append(
-                    (fu_id, seed_td, self.t0, seed_abs_td, abs(fu_amount), None)
+                    (fu_id, seed_td, self.t0, seed_abs_td, abs(fu_amount))
                 )
 
         while queue:
-            node_id, td, td_parent, abs_td, supply, variant_db = queue.popleft()
+            node_id, td, td_parent, abs_td, supply = queue.popleft()
 
             self._calc_count += 1
             if self._calc_count > self.max_calc:
                 break
 
-            # ``variant_db`` is set when this descent is into a respective
-            # (possibly non-referenced) background variant. Those nodes are not
-            # in ``base_lca``'s matrix, so read their exchanges from the proxy.
-            use_proxy = variant_db is not None
-
-            if use_proxy:
-                production_amount = self._proxy_production_amount(node_id)
-                input_ids = self._proxy_technosphere_inputs(node_id)
-            else:
-                production_amount = self._get_production_amount(node_id)
-                input_ids = self._get_technosphere_inputs(node_id)
+            # Reaching a non-referenced background variant is handled entirely by
+            # ``_emit_variant_split`` (shared with the priority engine), which owns
+            # its own proxy descent. The matrix BFS queue therefore only ever holds
+            # ``base_lca`` (referenced-variant) nodes, read from the matrix.
+            production_amount = self._get_production_amount(node_id)
+            input_ids = self._get_technosphere_inputs(node_id)
 
             for input_id in input_ids:
                 leaf = self.edge_ff(input_id)
 
-                if use_proxy:
-                    td_producer_raw, edge_type, temporal_evolution = (
-                        self._get_exchange_td_and_type_from_proxy(input_id, node_id)
-                    )
-                else:
-                    td_producer_raw, edge_type, temporal_evolution = (
-                        self._get_exchange_td_and_type(input_id, node_id)
-                    )
+                td_producer_raw, edge_type, temporal_evolution = (
+                    self._get_exchange_td_and_type(input_id, node_id)
+                )
 
                 td_producer = td_producer_raw / abs(production_amount)
 
@@ -850,12 +1129,7 @@ class EdgeExtractorBFS:
 
                 # Resolve the producing process for this input product.
                 # For chimaera nodes the producer is the product itself.
-                if use_proxy:
-                    producer_process = self._producer_process_in_variant(
-                        input_id, variant_db
-                    )
-                else:
-                    producer_process = self._get_producer_process(input_id)
+                producer_process = self._get_producer_process(input_id)
 
                 will_descend = (
                     not leaf
@@ -870,21 +1144,18 @@ class EdgeExtractorBFS:
                 # producer and a consumer in the timeline and is rebuilt from its
                 # own (real) database. Leaves and foreground producers fall
                 # through to the original single-edge path unchanged.
-                # The variant split routes a background producer's cohorts to the
-                # temporally-appropriate variant(s). It happens only on the FIRST
-                # crossing from the referenced traversal (matrix reads) into the
-                # background. Once inside a variant descent (``use_proxy``), the
-                # variant is locked and every descendant stays in that same
-                # variant database, read via the proxy.
-                # Variant-split only matters when we will actually descend
-                # THROUGH a background process into its own (technosphere) inputs
-                # — that is where the respective variant's exchanges/amounts
-                # differ. A background producer with no technosphere inputs is a
-                # true market leaf (handled by the existing leaf machinery), so it
-                # is left untouched to preserve the Task 4 behaviour exactly.
+                # The variant split happens only on the FIRST crossing from the
+                # referenced matrix traversal into the background; from there the
+                # shared ``_emit_variant_split`` runs the locked-variant subtree
+                # via proxy reads, so the matrix queue never re-enters proxy mode.
+                # Variant-split only matters when we will actually descend THROUGH
+                # a background process into its own (technosphere) inputs — that is
+                # where the respective variant's exchanges/amounts differ. A
+                # background producer with no technosphere inputs is a true market
+                # leaf (handled by the existing leaf machinery), so it is left
+                # untouched to preserve the Task 4 behaviour exactly.
                 variant_split = (
                     will_descend
-                    and not use_proxy
                     and self.traverse_background
                     and getattr(self, "interdatabase_activity_mapping", None)
                     is not None
@@ -894,11 +1165,6 @@ class EdgeExtractorBFS:
                 )
 
                 if not variant_split:
-                    # Inside a variant descent every produced node is already
-                    # routed to its real variant database, so mark it for
-                    # temporalization (not a temporal-market leaf).
-                    if use_proxy and self._is_static_background(input_id):
-                        self.variant_resolved_producers.add(input_id)
                     timeline.append(
                         Edge(
                             edge_type=edge_type,
@@ -918,16 +1184,9 @@ class EdgeExtractorBFS:
                         continue
 
                     child_td, child_abs_td = distribution, abs_td_producer
-                    if use_proxy:
-                        producer_production_td = (
-                            self._normalized_production_edge_td_from_proxy(
-                                producer_process
-                            )
-                        )
-                    else:
-                        producer_production_td = (
-                            self._get_normalized_production_edge_td(producer_process)
-                        )
+                    producer_production_td = self._get_normalized_production_edge_td(
+                        producer_process
+                    )
                     if producer_production_td is not None:
                         child_td = (distribution * producer_production_td).simplify()
                         child_abs_td = _join_datetime_and_timedelta_distributions(
@@ -941,102 +1200,30 @@ class EdgeExtractorBFS:
                             td_producer,
                             child_abs_td,
                             new_supply,
-                            variant_db if use_proxy else None,
                         )
                     )
                     continue
 
-                # --- variant split path ---
-                # Route each producer cohort date to its variant(s). The producer
-                # cohort dates live on ``abs_td_producer``; the corresponding edge
-                # amounts live on ``distribution`` (same date axis).
-                variant_keep: dict[str, dict] = {}
-                for date in abs_td_producer.date:
-                    for db_name, weight in self._variant_shares_for_date(date).items():
-                        variant_keep.setdefault(db_name, {})[date] = weight
-
-                # The variant split routes by absolute producer date. The
-                # relative ``td_producer`` and absolute ``abs_td_producer`` share
-                # an index axis when the consumer has a single absolute date
-                # (the case for every background split: the consuming background
-                # process sits at one cohort date per descent). Mask all three
-                # arrays by the same kept indices so ``extract_edge_data`` can
-                # explode consumer/producer dates and amounts consistently.
-                if len(abs_td) != 1:
-                    raise NotImplementedError(
-                        "Variant-aware background split with a multi-date "
-                        "consumer is not supported."
+                # --- variant split path (shared with the priority engine) ---
+                # Route each producer cohort date to its temporally appropriate
+                # variant(s), emit the scaled edges, and descend each variant
+                # subtree via proxy reads. ``_emit_variant_split`` owns the whole
+                # variant subtree, so the matrix queue never re-enters proxy mode.
+                timeline.extend(
+                    self._emit_variant_split(
+                        node_id=node_id,
+                        producer_process=producer_process,
+                        edge_type=edge_type,
+                        temporal_evolution=temporal_evolution,
+                        td_producer=td_producer,
+                        distribution=distribution,
+                        abs_td_producer=abs_td_producer,
+                        abs_td=abs_td,
+                        td_parent=td_parent,
+                        new_supply=new_supply,
+                        total_demand=total_demand,
                     )
-
-                for db_name, keep in variant_keep.items():
-                    keep_idx = [
-                        i
-                        for i, d in enumerate(abs_td_producer.date)
-                        if keep.get(d)
-                    ]
-                    if not keep_idx:
-                        continue
-                    weights = np.array(
-                        [keep[abs_td_producer.date[i]] for i in keep_idx]
-                    )
-                    masked_abs_td_producer = TemporalDistribution(
-                        date=abs_td_producer.date[keep_idx],
-                        amount=abs_td_producer.amount[keep_idx] * weights,
-                    )
-                    masked_distribution = TemporalDistribution(
-                        date=distribution.date[keep_idx],
-                        amount=distribution.amount[keep_idx] * weights,
-                    )
-                    masked_td_producer = TemporalDistribution(
-                        date=td_producer.date[keep_idx],
-                        amount=td_producer.amount[keep_idx] * weights,
-                    )
-                    variant_id = self._resolve_in_variant(producer_process, db_name)
-                    self.variant_resolved_producers.add(variant_id)
-
-                    timeline.append(
-                        Edge(
-                            edge_type=edge_type,
-                            distribution=masked_distribution,
-                            leaf=leaf,
-                            consumer=node_id,
-                            producer=variant_id,
-                            td_producer=masked_td_producer,
-                            td_consumer=td_parent,
-                            abs_td_producer=masked_abs_td_producer,
-                            abs_td_consumer=abs_td,
-                            temporal_evolution=temporal_evolution,
-                        )
-                    )
-
-                    child_td, child_abs_td = (
-                        masked_distribution,
-                        masked_abs_td_producer,
-                    )
-                    producer_production_td = (
-                        self._normalized_production_edge_td_from_proxy(variant_id)
-                    )
-                    if producer_production_td is not None:
-                        child_td = (
-                            masked_distribution * producer_production_td
-                        ).simplify()
-                        child_abs_td = _join_datetime_and_timedelta_distributions(
-                            producer_production_td, masked_abs_td_producer
-                        )
-
-                    variant_supply = (
-                        new_supply * sum(keep.values()) / max(len(keep), 1)
-                    )
-                    queue.append(
-                        (
-                            variant_id,
-                            child_td,
-                            td_producer,
-                            child_abs_td,
-                            variant_supply,
-                            db_name,
-                        )
-                    )
+                )
 
         return timeline
 

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -85,7 +85,8 @@ class EdgeExtractor(TemporalisLCA):
     using Brightway Datapackages.
     """
 
-    def __init__(self, *args, edge_filter_function: Callable = None, **kwargs) -> None:
+    def __init__(self, *args, edge_filter_function: Callable = None,
+        traverse_background: bool = False, **kwargs) -> None:
         """
         Initialize the EdgeExtractor class and traverses the supply chain using
         functions of the parent class TemporalisLCA.
@@ -96,6 +97,8 @@ class EdgeExtractor(TemporalisLCA):
         edge_filter_function : Callable, optional
             A callable that filters edges. If not provided, a function that always
             returns False is used.
+        traverse_background : bool, optional
+            Flag indicating whether to traverse background databases. Default is False.
         **kwargs : Arbitrary keyword arguments
 
         Returns
@@ -105,7 +108,7 @@ class EdgeExtractor(TemporalisLCA):
 
         """
         super().__init__(*args, **kwargs)  # use __init__ of TemporalisLCA
-
+        self.traverse_background = traverse_background
         if edge_filter_function:
             self.edge_ff = edge_filter_function
         else:
@@ -386,6 +389,7 @@ class EdgeExtractorBFS:
         cutoff: float = 1e-9,
         static_activity_indices: set[int] | None = None,
         nodes: dict | None = None,
+        traverse_background: bool = False,
     ) -> None:
         self.lca_object = lca_object
         self.edge_ff = edge_filter_function if edge_filter_function else lambda x: False
@@ -394,6 +398,7 @@ class EdgeExtractorBFS:
         # {node_id: bw2data Activity proxy} reused from TimexLCA, so production /
         # technosphere exchanges are read without re-fetching nodes.
         self.nodes = nodes or {}
+        self.traverse_background = traverse_background
         self._production_exchange_cache = {}
 
         if isinstance(starting_datetime, str):

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -11,7 +11,11 @@ from bw2data.backends.schema import ActivityDataset as AD
 from bw2data.backends.schema import ExchangeDataset as ED
 from bw_temporalis import TemporalDistribution, TemporalisLCA, loader_registry
 
-from .utils import get_reference_product_production_amount
+from .utils import (
+    get_reference_product_production_amount,
+    linear_interpolation_weights,
+    nearest_date_weight,
+)
 
 if not hasattr(np, "in1d"):
     np.in1d = np.isin
@@ -403,6 +407,11 @@ class EdgeExtractorBFS:
         self.max_calc = max_calc
         self._calc_count = 0
         self._production_exchange_cache = {}
+        # Producer node ids that were variant-resolved during a variant-aware
+        # background descent. These are already routed to their respective
+        # (real) variant database, so the timeline builder must temporalize them
+        # rather than treat them as temporal-market leaves.
+        self.variant_resolved_producers: set[int] = set()
 
         if self.traverse_background:
             # Background is no longer a hard stop; rely on cutoff / max_calc.
@@ -582,6 +591,147 @@ class EdgeExtractorBFS:
         # so the alpha scaling is applied only once, on the input side.
         return td / abs(production["amount"])
 
+    # ------------------------------------------------------------------
+    # Variant-aware (respective-variant) reads
+    #
+    # The base traversal runs on ``base_lca``, which only contains the
+    # referenced background variant. When descent continues INTO a background
+    # process reached at a date routing to a NON-referenced variant, the
+    # respective variant's exchanges/amounts/TDs must be read from the bw2data
+    # activity proxy in ``self.nodes`` rather than from the (referenced-only)
+    # technosphere matrix.
+    # ------------------------------------------------------------------
+
+    def _variant_shares_for_date(self, producer_date) -> dict:
+        """Return ``{db_name: weight}`` interpolation shares for a cohort date.
+
+        Maps the producer's absolute cohort date onto the available static
+        background databases, using the same interpolation as the timeline
+        builder so leaf and descended routing agree.
+        """
+        from datetime import datetime as _dt
+
+        dates_static = getattr(self, "database_dates_static", None) or {}
+        dates_to_db = {v: k for k, v in dates_static.items() if isinstance(v, _dt)}
+        sorted_dates = tuple(sorted(dates_to_db))
+        if not sorted_dates:
+            return {}
+
+        if isinstance(producer_date, np.datetime64):
+            producer_date = producer_date.astype("datetime64[s]").astype(_dt)
+
+        if getattr(self, "interpolation_type", "linear") == "nearest":
+            weights = nearest_date_weight(producer_date, sorted_dates)
+        else:
+            weights = linear_interpolation_weights(producer_date, sorted_dates)
+        return {dates_to_db[d]: w for d, w in (weights or {}).items()}
+
+    def _resolve_in_variant(self, node_id: int, db_name: str) -> int:
+        """Return the id of ``node_id``'s sibling in database ``db_name``.
+
+        If ``node_id`` already lives in ``db_name`` it is returned unchanged;
+        otherwise the sibling is looked up via the interdatabase mapping.
+        """
+        node = self.nodes.get(node_id)
+        if node is not None and node["database"] == db_name:
+            return node_id
+        return self.interdatabase_activity_mapping.find_match(node_id, db_name)
+
+    def _proxy_production_amount(self, activity_id: int) -> float:
+        """Production amount of a (possibly non-referenced) variant node, read
+        from its bw2data proxy."""
+        return get_reference_product_production_amount(self.nodes[activity_id])
+
+    def _proxy_technosphere_inputs(self, activity_id: int) -> list[int]:
+        """Technosphere input product ids of a variant node, read from its proxy.
+
+        ``static_activity_indices`` is empty when ``traverse_background`` is set,
+        so no filtering is needed, but it is honoured for symmetry with the
+        matrix path.
+        """
+        inputs = []
+        for exchange in self.nodes[activity_id].technosphere():
+            input_id = exchange.input.id
+            if input_id in self.static_activity_indices:
+                continue
+            inputs.append(input_id)
+        return inputs
+
+    def _get_exchange_td_and_type_from_proxy(self, input_id: int, output_id: int):
+        """Proxy-based counterpart of ``_get_exchange_td_and_type``.
+
+        Reads the exchange between ``input_id`` and ``output_id`` directly from
+        the consuming node's bw2data proxy (``self.nodes[output_id]``) rather
+        than from the technosphere matrix, because non-referenced variant nodes
+        are absent from ``base_lca``'s matrix. Returns the same
+        ``(td_or_amount, edge_type, temporal_evolution)`` tuple.
+        """
+        consumer = self.nodes[output_id]
+        exc = None
+        for candidate in consumer.technosphere():
+            if candidate.input.id == input_id:
+                exc = candidate
+                break
+        if exc is None:
+            for candidate in consumer.exchanges():
+                if (
+                    candidate.input.id == input_id
+                    and candidate.get("type") != "production"
+                ):
+                    exc = candidate
+                    break
+        if exc is None:
+            raise ValueError(
+                f"No exchange from {input_id} to {output_id} found on proxy."
+            )
+
+        edge_type = exc.get("type", "technosphere")
+        amount = exc["amount"]
+        temporal_evolution = extract_temporal_evolution(exc.as_dict())
+
+        td = exc.get("temporal_distribution")
+        if isinstance(td, str) and "__loader__" in td:
+            data = json.loads(td)
+            td = loader_registry[data["__loader__"]](data)
+        if isinstance(td, TemporalDistribution):
+            return td * amount, edge_type, temporal_evolution
+        return amount, edge_type, temporal_evolution
+
+    def _normalized_production_edge_td_from_proxy(self, process_id: int):
+        """Proxy-based counterpart of ``_get_normalized_production_edge_td``."""
+        productions = list(self.nodes[process_id].production())
+        if not productions:
+            return None
+        production = productions[0]
+        td = production.get("temporal_distribution")
+        if isinstance(td, str) and "__loader__" in td:
+            data = json.loads(td)
+            td = loader_registry[data["__loader__"]](data)
+        if not isinstance(td, TemporalDistribution):
+            return None
+        return td / abs(production["amount"])
+
+    def _producer_process_in_variant(self, product_id: int, db_name: str):
+        """Resolve the process producing ``product_id`` within variant
+        ``db_name`` from the proxy.
+
+        ``product_id`` was read from a variant proxy, so it already lives in
+        ``db_name``. For chimaera nodes the product produces itself; returns
+        ``None`` if the product has no producer (a pure leaf).
+        """
+        node = self.nodes.get(product_id)
+        if node is None:
+            return None
+        for _ in node.production():
+            return product_id
+        return product_id
+
+    def _is_static_background(self, node_id: int) -> bool:
+        """True if ``node_id`` lives in one of the static background databases."""
+        dates_static = getattr(self, "database_dates_static", None) or {}
+        node = self.nodes.get(node_id)
+        return node is not None and node["database"] in dates_static
+
     def build_edge_timeline(self) -> list:
         """
         Breadth-First-Search (BFS) traversal of the supply chain, extracting
@@ -622,7 +772,7 @@ class EdgeExtractorBFS:
                         abs_td_producer=self.t0,
                     )
                 )
-                queue.append((fu_id, td, self.t0, self.t0, abs(fu_amount)))
+                queue.append((fu_id, td, self.t0, self.t0, abs(fu_amount), None))
             else:
                 # Cohort-spread the FU so the producing process is registered at
                 # every cohort time (each cohort gets its own time-mapped column).
@@ -644,25 +794,39 @@ class EdgeExtractorBFS:
                     )
                 )
                 queue.append(
-                    (fu_id, seed_td, self.t0, seed_abs_td, abs(fu_amount))
+                    (fu_id, seed_td, self.t0, seed_abs_td, abs(fu_amount), None)
                 )
 
         while queue:
-            node_id, td, td_parent, abs_td, supply = queue.popleft()
+            node_id, td, td_parent, abs_td, supply, variant_db = queue.popleft()
 
             self._calc_count += 1
             if self._calc_count > self.max_calc:
                 break
 
-            production_amount = self._get_production_amount(node_id)
-            input_ids = self._get_technosphere_inputs(node_id)
+            # ``variant_db`` is set when this descent is into a respective
+            # (possibly non-referenced) background variant. Those nodes are not
+            # in ``base_lca``'s matrix, so read their exchanges from the proxy.
+            use_proxy = variant_db is not None
+
+            if use_proxy:
+                production_amount = self._proxy_production_amount(node_id)
+                input_ids = self._proxy_technosphere_inputs(node_id)
+            else:
+                production_amount = self._get_production_amount(node_id)
+                input_ids = self._get_technosphere_inputs(node_id)
 
             for input_id in input_ids:
                 leaf = self.edge_ff(input_id)
 
-                td_producer_raw, edge_type, temporal_evolution = (
-                    self._get_exchange_td_and_type(input_id, node_id)
-                )
+                if use_proxy:
+                    td_producer_raw, edge_type, temporal_evolution = (
+                        self._get_exchange_td_and_type_from_proxy(input_id, node_id)
+                    )
+                else:
+                    td_producer_raw, edge_type, temporal_evolution = (
+                        self._get_exchange_td_and_type(input_id, node_id)
+                    )
 
                 td_producer = td_producer_raw / abs(production_amount)
 
@@ -678,56 +842,201 @@ class EdgeExtractorBFS:
                     td_producer, abs_td
                 )
 
-                timeline.append(
-                    Edge(
-                        edge_type=edge_type,
-                        distribution=distribution,
-                        leaf=leaf,
-                        consumer=node_id,
-                        producer=input_id,
-                        td_producer=td_producer,
-                        td_consumer=td_parent,
-                        abs_td_producer=abs_td_producer,
-                        abs_td_consumer=abs_td,
-                        temporal_evolution=temporal_evolution,
-                    )
-                )
-
                 if isinstance(td_producer_raw, TemporalDistribution):
                     edge_supply = abs(td_producer_raw.amount.sum())
                 else:
                     edge_supply = abs(td_producer_raw)
                 new_supply = supply * edge_supply / abs(production_amount)
 
-                if leaf or new_supply < self.cutoff * total_demand:
-                    continue
+                # Resolve the producing process for this input product.
+                # For chimaera nodes the producer is the product itself.
+                if use_proxy:
+                    producer_process = self._producer_process_in_variant(
+                        input_id, variant_db
+                    )
+                else:
+                    producer_process = self._get_producer_process(input_id)
 
-                # Bipartite step: descend into the process that produces this
-                # input product. For chimaera nodes the producer is the product
-                # itself; for explicit nodes it is the separate process.
-                producer_process = self._get_producer_process(input_id)
-                if producer_process is None:
-                    continue
-
-                child_td, child_abs_td = distribution, abs_td_producer
-                producer_production_td = self._get_normalized_production_edge_td(
-                    producer_process
+                will_descend = (
+                    not leaf
+                    and new_supply >= self.cutoff * total_demand
+                    and producer_process is not None
                 )
-                if producer_production_td is not None:
-                    child_td = (distribution * producer_production_td).simplify()
-                    child_abs_td = _join_datetime_and_timedelta_distributions(
-                        producer_production_td, abs_td_producer
+
+                # Variant-aware split: when this input's producer is a static
+                # background process that we will descend into, emit one edge per
+                # temporally-appropriate variant (reading the RESPECTIVE variant's
+                # exchanges on descent) so that each variant node is both a
+                # producer and a consumer in the timeline and is rebuilt from its
+                # own (real) database. Leaves and foreground producers fall
+                # through to the original single-edge path unchanged.
+                # The variant split routes a background producer's cohorts to the
+                # temporally-appropriate variant(s). It happens only on the FIRST
+                # crossing from the referenced traversal (matrix reads) into the
+                # background. Once inside a variant descent (``use_proxy``), the
+                # variant is locked and every descendant stays in that same
+                # variant database, read via the proxy.
+                # Variant-split only matters when we will actually descend
+                # THROUGH a background process into its own (technosphere) inputs
+                # — that is where the respective variant's exchanges/amounts
+                # differ. A background producer with no technosphere inputs is a
+                # true market leaf (handled by the existing leaf machinery), so it
+                # is left untouched to preserve the Task 4 behaviour exactly.
+                variant_split = (
+                    will_descend
+                    and not use_proxy
+                    and self.traverse_background
+                    and getattr(self, "interdatabase_activity_mapping", None)
+                    is not None
+                    and self._is_static_background(node_id)
+                    and self._is_static_background(producer_process)
+                    and bool(self._proxy_technosphere_inputs(producer_process))
+                )
+
+                if not variant_split:
+                    # Inside a variant descent every produced node is already
+                    # routed to its real variant database, so mark it for
+                    # temporalization (not a temporal-market leaf).
+                    if use_proxy and self._is_static_background(input_id):
+                        self.variant_resolved_producers.add(input_id)
+                    timeline.append(
+                        Edge(
+                            edge_type=edge_type,
+                            distribution=distribution,
+                            leaf=leaf,
+                            consumer=node_id,
+                            producer=input_id,
+                            td_producer=td_producer,
+                            td_consumer=td_parent,
+                            abs_td_producer=abs_td_producer,
+                            abs_td_consumer=abs_td,
+                            temporal_evolution=temporal_evolution,
+                        )
                     )
 
-                queue.append(
-                    (
-                        producer_process,
-                        child_td,
-                        td_producer,
-                        child_abs_td,
-                        new_supply,
+                    if not will_descend:
+                        continue
+
+                    child_td, child_abs_td = distribution, abs_td_producer
+                    if use_proxy:
+                        producer_production_td = (
+                            self._normalized_production_edge_td_from_proxy(
+                                producer_process
+                            )
+                        )
+                    else:
+                        producer_production_td = (
+                            self._get_normalized_production_edge_td(producer_process)
+                        )
+                    if producer_production_td is not None:
+                        child_td = (distribution * producer_production_td).simplify()
+                        child_abs_td = _join_datetime_and_timedelta_distributions(
+                            producer_production_td, abs_td_producer
+                        )
+
+                    queue.append(
+                        (
+                            producer_process,
+                            child_td,
+                            td_producer,
+                            child_abs_td,
+                            new_supply,
+                            variant_db if use_proxy else None,
+                        )
                     )
-                )
+                    continue
+
+                # --- variant split path ---
+                # Route each producer cohort date to its variant(s). The producer
+                # cohort dates live on ``abs_td_producer``; the corresponding edge
+                # amounts live on ``distribution`` (same date axis).
+                variant_keep: dict[str, dict] = {}
+                for date in abs_td_producer.date:
+                    for db_name, weight in self._variant_shares_for_date(date).items():
+                        variant_keep.setdefault(db_name, {})[date] = weight
+
+                # The variant split routes by absolute producer date. The
+                # relative ``td_producer`` and absolute ``abs_td_producer`` share
+                # an index axis when the consumer has a single absolute date
+                # (the case for every background split: the consuming background
+                # process sits at one cohort date per descent). Mask all three
+                # arrays by the same kept indices so ``extract_edge_data`` can
+                # explode consumer/producer dates and amounts consistently.
+                if len(abs_td) != 1:
+                    raise NotImplementedError(
+                        "Variant-aware background split with a multi-date "
+                        "consumer is not supported."
+                    )
+
+                for db_name, keep in variant_keep.items():
+                    keep_idx = [
+                        i
+                        for i, d in enumerate(abs_td_producer.date)
+                        if keep.get(d)
+                    ]
+                    if not keep_idx:
+                        continue
+                    weights = np.array(
+                        [keep[abs_td_producer.date[i]] for i in keep_idx]
+                    )
+                    masked_abs_td_producer = TemporalDistribution(
+                        date=abs_td_producer.date[keep_idx],
+                        amount=abs_td_producer.amount[keep_idx] * weights,
+                    )
+                    masked_distribution = TemporalDistribution(
+                        date=distribution.date[keep_idx],
+                        amount=distribution.amount[keep_idx] * weights,
+                    )
+                    masked_td_producer = TemporalDistribution(
+                        date=td_producer.date[keep_idx],
+                        amount=td_producer.amount[keep_idx] * weights,
+                    )
+                    variant_id = self._resolve_in_variant(producer_process, db_name)
+                    self.variant_resolved_producers.add(variant_id)
+
+                    timeline.append(
+                        Edge(
+                            edge_type=edge_type,
+                            distribution=masked_distribution,
+                            leaf=leaf,
+                            consumer=node_id,
+                            producer=variant_id,
+                            td_producer=masked_td_producer,
+                            td_consumer=td_parent,
+                            abs_td_producer=masked_abs_td_producer,
+                            abs_td_consumer=abs_td,
+                            temporal_evolution=temporal_evolution,
+                        )
+                    )
+
+                    child_td, child_abs_td = (
+                        masked_distribution,
+                        masked_abs_td_producer,
+                    )
+                    producer_production_td = (
+                        self._normalized_production_edge_td_from_proxy(variant_id)
+                    )
+                    if producer_production_td is not None:
+                        child_td = (
+                            masked_distribution * producer_production_td
+                        ).simplify()
+                        child_abs_td = _join_datetime_and_timedelta_distributions(
+                            producer_production_td, masked_abs_td_producer
+                        )
+
+                    variant_supply = (
+                        new_supply * sum(keep.values()) / max(len(keep), 1)
+                    )
+                    queue.append(
+                        (
+                            variant_id,
+                            child_td,
+                            td_producer,
+                            child_abs_td,
+                            variant_supply,
+                            db_name,
+                        )
+                    )
 
         return timeline
 

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -272,27 +272,92 @@ class VariantBackgroundMixin:
         subtree).
 
         Shared verbatim by both the BFS and priority engines.
+
+        A multi-date consumer (e.g. a foreground ``temporal_distribution``
+        feeding a non-leaf background activity, so the consuming background
+        process is reached at several cohort dates) is handled by splitting it
+        into one single-consumer-date routing per consumer cohort. The join that
+        builds ``abs_td_producer`` is consumer-major, so consumer cohort ``i`` is
+        the contiguous block ``i*M : (i+1)*M``; each block then reduces to the
+        single-consumer-date case, where the relative ``td_producer`` and the
+        absolute ``abs_td_producer`` share one index axis.
         """
-        # Route each producer cohort date to its variant(s). The producer cohort
-        # dates live on ``abs_td_producer``; the corresponding edge amounts live
-        # on ``distribution`` (same date axis).
+        n_consumer = len(abs_td)
+        m_producer = len(abs_td_producer) // n_consumer
+        # ``distribution`` is the (possibly simplify-merged) convolution; it stays
+        # consumer-major and aligned to the N*M ``abs_td_producer`` axis unless two
+        # convolved dates coincided and merged.
+        aligned = len(distribution) == n_consumer * m_producer
+
+        edges = []
+        for i in range(n_consumer):
+            block = slice(i * m_producer, (i + 1) * m_producer)
+            abs_td_producer_i = TemporalDistribution(
+                date=abs_td_producer.date[block],
+                amount=abs_td_producer.amount[block],
+            )
+            if aligned:
+                distribution_i = TemporalDistribution(
+                    date=distribution.date[block],
+                    amount=distribution.amount[block],
+                )
+            else:
+                # Rebuild this cohort's absolute distribution from the join dates.
+                # These amounts feed only cutoff / heap ordering, never emitted
+                # amounts (those come from ``abs_td_producer``), so the rebuild is
+                # safe for the inventory result.
+                distribution_i = TemporalDistribution(
+                    date=abs_td_producer_i.date,
+                    amount=abs_td.amount[i] * td_producer.amount,
+                )
+            abs_td_i = TemporalDistribution(
+                date=abs_td.date[i : i + 1],
+                amount=abs_td.amount[i : i + 1],
+            )
+            edges.extend(
+                self._emit_variant_split_for_consumer_date(
+                    node_id=node_id,
+                    producer_process=producer_process,
+                    edge_type=edge_type,
+                    temporal_evolution=temporal_evolution,
+                    td_producer=td_producer,
+                    distribution=distribution_i,
+                    abs_td_producer=abs_td_producer_i,
+                    abs_td=abs_td_i,
+                    td_parent=td_parent,
+                    new_supply=new_supply,
+                    total_demand=total_demand,
+                )
+            )
+        return edges
+
+    def _emit_variant_split_for_consumer_date(
+        self,
+        *,
+        node_id: int,
+        producer_process: int,
+        edge_type: str,
+        temporal_evolution,
+        td_producer: TemporalDistribution,
+        distribution: TemporalDistribution,
+        abs_td_producer: TemporalDistribution,
+        abs_td: TemporalDistribution,
+        td_parent,
+        new_supply: float,
+        total_demand: float,
+    ) -> list:
+        """Variant split for a single consumer cohort date (``len(abs_td) == 1``).
+
+        With one consumer date the relative ``td_producer`` and the absolute
+        ``abs_td_producer`` share one index axis, so all three arrays mask by the
+        same kept indices and ``extract_edge_data`` can explode the
+        consumer/producer dates and amounts consistently.
+        """
+        # Route each producer cohort date to its variant(s).
         variant_keep: dict[str, dict] = {}
         for date in abs_td_producer.date:
             for db_name, weight in self._variant_shares_for_date(date).items():
                 variant_keep.setdefault(db_name, {})[date] = weight
-
-        # The variant split routes by absolute producer date. The relative
-        # ``td_producer`` and absolute ``abs_td_producer`` share an index axis
-        # when the consumer has a single absolute date (the case for every
-        # background split: the consuming background process sits at one cohort
-        # date per descent). Mask all three arrays by the same kept indices so
-        # ``extract_edge_data`` can explode consumer/producer dates and amounts
-        # consistently.
-        if len(abs_td) != 1:
-            raise NotImplementedError(
-                "Variant-aware background split with a multi-date "
-                "consumer is not supported."
-            )
 
         edges = []
         for db_name, keep in variant_keep.items():

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -385,11 +385,16 @@ class EdgeExtractorBFS:
         edge_filter_function: Callable = None,
         cutoff: float = 1e-9,
         static_activity_indices: set[int] | None = None,
+        nodes: dict | None = None,
     ) -> None:
         self.lca_object = lca_object
         self.edge_ff = edge_filter_function if edge_filter_function else lambda x: False
         self.cutoff = cutoff
         self.static_activity_indices = static_activity_indices or set()
+        # {node_id: bw2data Activity proxy} reused from TimexLCA, so production /
+        # technosphere exchanges are read without re-fetching nodes.
+        self.nodes = nodes or {}
+        self._production_exchange_cache = {}
 
         if isinstance(starting_datetime, str):
             if starting_datetime == "now":
@@ -471,21 +476,97 @@ class EdgeExtractorBFS:
         ]
         return get_reference_product_production_amount(activity)
 
-    def _get_technosphere_inputs(self, activity_id: int) -> list[int]:
-        """Get all technosphere input activity IDs for a given activity."""
-        col_idx = self.lca_object.dicts.activity[activity_id]
-        col = self.tech_matrix_csc[:, col_idx]
-        product_idx = self.lca_object.dicts.product.get(activity_id)
+    def _get_production_exchange(self, process_id: int):
+        """Return the single ``production`` output exchange of ``process_id``,
+        or ``None`` if it has none. Read from the reused node proxy (no extra
+        node fetch) and memoized per process.
 
+        Identifying the output via the exchange type (rather than the matrix
+        sign) matters because a negative-amount technosphere input also produces
+        a positive matrix entry, so sign alone cannot tell them apart.
+        """
+        if process_id in self._production_exchange_cache:
+            return self._production_exchange_cache[process_id]
+
+        productions = list(self.nodes[process_id].production())
+        if len(productions) > 1:
+            raise ValueError(
+                f"Process {process_id} has multiple production outputs "
+                f"(co-production); not supported with graph_traversal='bfs'."
+            )
+        exchange = productions[0] if productions else None
+        self._production_exchange_cache[process_id] = exchange
+        return exchange
+
+    def _get_technosphere_inputs(self, activity_id: int) -> list[int]:
+        """Get the input product IDs consumed by a process.
+
+        Read straight from the node's technosphere exchanges, so the production
+        output is naturally excluded and avoided-burden inputs (which the matrix
+        stores with a flipped sign) are kept.
+        """
         inputs = []
-        for row_idx in col.nonzero()[0]:
-            if row_idx == product_idx:
-                continue
-            input_id = self.lca_object.dicts.product.reversed[row_idx]
+        for exchange in self.nodes[activity_id].technosphere():
+            input_id = exchange.input.id
             if input_id in self.static_activity_indices:
                 continue
             inputs.append(input_id)
         return inputs
+
+    def _get_producer_process(self, product_id: int) -> int | None:
+        """Return the process that produces ``product_id``.
+
+        For a chimaera node this is the node itself; for an explicit ``product``
+        it is the separate ``process`` whose ``production`` edge feeds the
+        product's row. Returns ``None`` if the product has no producer (a leaf).
+        """
+        try:  # chimaera: the product is also its own producing activity
+            self.lca_object.dicts.activity[product_id]
+            return product_id
+        except KeyError:
+            pass
+
+        product_idx = self.lca_object.dicts.product.get(product_id)
+        if product_idx is None:
+            return None
+        # Candidate producer columns come from the product's matrix row (cheap);
+        # the production one is confirmed against the node's production exchange.
+        row = self.tech_matrix_csc.getrow(product_idx).tocoo()
+        producers = []
+        for col_idx in row.col:
+            process_id = self.lca_object.dicts.activity.reversed[col_idx]
+            production = self._get_production_exchange(process_id)
+            if production is not None and production.input.id == product_id:
+                producers.append(process_id)
+        if not producers:
+            return None
+        if len(producers) > 1:
+            raise ValueError(
+                f"Product {product_id} has multiple producing processes "
+                f"({producers}); ambiguous-producer resolution is not supported "
+                f"with graph_traversal='bfs'."
+            )
+        return producers[0]
+
+    def _get_normalized_production_edge_td(self, process_id: int):
+        """Return the cohort ``TemporalDistribution`` on a process's production
+        output edge, normalized to unit weights, or ``None`` if there is none.
+
+        Chimaera self-production edges normally carry no TD, so this returns
+        ``None`` and chimaera traversal is unaffected.
+        """
+        production = self._get_production_exchange(process_id)
+        if production is None:
+            return None
+        td = production.get("temporal_distribution")
+        if isinstance(td, str) and "__loader__" in td:
+            data = json.loads(td)
+            td = loader_registry[data["__loader__"]](data)
+        if not isinstance(td, TemporalDistribution):
+            return None
+        # The TD weights normalize to 1; divide by the production amount (alpha)
+        # so the alpha scaling is applied only once, on the input side.
+        return td / abs(production["amount"])
 
     def build_edge_timeline(self) -> list:
         """
@@ -510,20 +591,47 @@ class EdgeExtractorBFS:
             fu_amount = demand_array[self.lca_object.dicts.activity[fu_id]]
             td = self.t0 * fu_amount
 
-            timeline.append(
-                Edge(
-                    edge_type="production",
-                    distribution=td,
-                    leaf=False,
-                    consumer=-1,
-                    producer=fu_id,
-                    td_producer=fu_amount,
-                    td_consumer=self.t0,
-                    abs_td_producer=self.t0,
+            # Spread the functional unit over the producing process's cohort TD
+            # (the explicit process -> product output edge). Chimaera nodes have
+            # no such TD, so the original behaviour is preserved exactly.
+            production_td = self._get_normalized_production_edge_td(fu_id)
+            if production_td is None:
+                timeline.append(
+                    Edge(
+                        edge_type="production",
+                        distribution=td,
+                        leaf=False,
+                        consumer=-1,
+                        producer=fu_id,
+                        td_producer=fu_amount,
+                        td_consumer=self.t0,
+                        abs_td_producer=self.t0,
+                    )
                 )
-            )
-
-            queue.append((fu_id, td, self.t0, self.t0, abs(fu_amount)))
+                queue.append((fu_id, td, self.t0, self.t0, abs(fu_amount)))
+            else:
+                # Cohort-spread the FU so the producing process is registered at
+                # every cohort time (each cohort gets its own time-mapped column).
+                seed_td = (td * production_td).simplify()
+                seed_abs_td = _join_datetime_and_timedelta_distributions(
+                    production_td, self.t0
+                )
+                timeline.append(
+                    Edge(
+                        edge_type="production",
+                        distribution=seed_td,
+                        leaf=False,
+                        consumer=-1,
+                        producer=fu_id,
+                        td_producer=seed_td,
+                        td_consumer=self.t0,
+                        abs_td_producer=seed_abs_td,
+                        abs_td_consumer=self.t0,
+                    )
+                )
+                queue.append(
+                    (fu_id, seed_td, self.t0, seed_abs_td, abs(fu_amount))
+                )
 
         while queue:
             node_id, td, td_parent, abs_td, supply = queue.popleft()
@@ -573,16 +681,35 @@ class EdgeExtractorBFS:
                     edge_supply = abs(td_producer_raw)
                 new_supply = supply * edge_supply / abs(production_amount)
 
-                if not leaf and new_supply >= self.cutoff * total_demand:
-                    queue.append(
-                        (
-                            input_id,
-                            distribution,
-                            td_producer,
-                            abs_td_producer,
-                            new_supply,
-                        )
+                if leaf or new_supply < self.cutoff * total_demand:
+                    continue
+
+                # Bipartite step: descend into the process that produces this
+                # input product. For chimaera nodes the producer is the product
+                # itself; for explicit nodes it is the separate process.
+                producer_process = self._get_producer_process(input_id)
+                if producer_process is None:
+                    continue
+
+                child_td, child_abs_td = distribution, abs_td_producer
+                producer_production_td = self._get_normalized_production_edge_td(
+                    producer_process
+                )
+                if producer_production_td is not None:
+                    child_td = (distribution * producer_production_td).simplify()
+                    child_abs_td = _join_datetime_and_timedelta_distributions(
+                        producer_production_td, abs_td_producer
                     )
+
+                queue.append(
+                    (
+                        producer_process,
+                        child_td,
+                        td_producer,
+                        child_abs_td,
+                        new_supply,
+                    )
+                )
 
         return timeline
 

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -149,13 +149,19 @@ class VariantBackgroundMixin:
     def _proxy_technosphere_inputs(self, activity_id: int) -> list[int]:
         """Technosphere input product ids of a variant node, read from its proxy.
 
-        ``static_activity_indices`` is empty when ``traverse_background`` is set,
-        so no filtering is needed, but it is honoured for symmetry with the
-        matrix path.
+        ``static_activity_indices`` contains MATRIX INDICES (as used by the
+        priority TemporalisLCA engine), not activity ids. When
+        ``traverse_background=True``, ``TimelineBuilder`` forces
+        ``static_activity_indices = set()`` so this filter is always a no-op on
+        the variant-descent path — filtering here by activity id would be
+        incorrect whenever the set is non-empty.
         """
         inputs = []
         for exchange in self.bw_node_proxies[activity_id].technosphere():
             input_id = exchange.input.id
+            # NOTE: static_activity_indices holds matrix indices, not activity ids;
+            # the filter below is only correct when the set is empty (the invariant
+            # enforced by EdgeExtractor.__init__ when traverse_background=True).
             if input_id in self.static_activity_indices:
                 continue
             inputs.append(input_id)
@@ -225,9 +231,15 @@ class VariantBackgroundMixin:
         node = self.bw_node_proxies.get(product_id)
         if node is None:
             return None
+        # Chimaera nodes have at least one production exchange; for a pure leaf
+        # (no production edge at all) we should return None — but in practice
+        # every node reachable here IS a chimaera and has a self-production edge,
+        # so the loop always returns on the first iteration. The trailing
+        # ``return product_id`` is therefore unreachable; it is kept as a
+        # defensive fallback matching the docstring.
         for _ in node.production():
             return product_id
-        return product_id
+        return None
 
     def _is_static_background(self, node_id: int) -> bool:
         """True if ``node_id`` lives in one of the static background databases."""
@@ -330,6 +342,8 @@ class VariantBackgroundMixin:
                     producer_production_td, masked_abs_td_producer
                 )
 
+            # Cutoff-tracking estimate only — never feeds emitted amounts.
+            # Emitted amounts come from the masked distributions above.
             variant_supply = new_supply * sum(keep.values()) / max(len(keep), 1)
             edges.extend(
                 self._descend_variant_subtree(
@@ -483,6 +497,15 @@ class EdgeExtractor(VariantBackgroundMixin, TemporalisLCA):
         # local copies before delegating.
         self.cutoff = kwargs.get("cutoff", 5e-4)
         self.static_activity_indices = kwargs.get("static_activity_indices") or set()
+        # INVARIANT: static_activity_indices holds TemporalisLCA MATRIX INDICES,
+        # not activity ids. _proxy_technosphere_inputs filters by activity id, so
+        # the two id-spaces must not be mixed. TimelineBuilder enforces the empty-
+        # set precondition when traverse_background=True; assert it here so any
+        # future caller that bypasses TimelineBuilder fails loudly.
+        assert not (self.static_activity_indices and traverse_background), (
+            "static_activity_indices must be empty when traverse_background=True "
+            "(index-space differs across engines)"
+        )
         super().__init__(*args, **kwargs)  # use __init__ of TemporalisLCA
         self.traverse_background = traverse_background
         if edge_filter_function:
@@ -712,6 +735,10 @@ class EdgeExtractor(VariantBackgroundMixin, TemporalisLCA):
                         new_supply = abs(td_producer.amount.sum())
                     else:
                         new_supply = abs(td_producer)
+                    # No per-edge cutoff term here: the priority heap loop has no
+                    # per-edge cutoff at this layer. Cutoff is enforced inside
+                    # ``_descend_variant_subtree`` where the supply is compared
+                    # against ``cutoff * total_demand`` per child edge.
                     timeline.extend(
                         self._emit_variant_split(
                             node_id=consumer_id,

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -390,6 +390,7 @@ class EdgeExtractorBFS:
         static_activity_indices: set[int] | None = None,
         nodes: dict | None = None,
         traverse_background: bool = False,
+        max_calc: int = 1_000_000,
     ) -> None:
         self.lca_object = lca_object
         self.edge_ff = edge_filter_function if edge_filter_function else lambda x: False
@@ -399,7 +400,15 @@ class EdgeExtractorBFS:
         # technosphere exchanges are read without re-fetching nodes.
         self.nodes = nodes or {}
         self.traverse_background = traverse_background
+        self.max_calc = max_calc
+        self._calc_count = 0
         self._production_exchange_cache = {}
+
+        if self.traverse_background:
+            # Background is no longer a hard stop; rely on cutoff / max_calc.
+            # A user-supplied edge_filter_function is still respected.
+            if edge_filter_function is None:
+                self.edge_ff = lambda x: False
 
         if isinstance(starting_datetime, str):
             if starting_datetime == "now":
@@ -640,6 +649,10 @@ class EdgeExtractorBFS:
 
         while queue:
             node_id, td, td_parent, abs_td, supply = queue.popleft()
+
+            self._calc_count += 1
+            if self._calc_count > self.max_calc:
+                break
 
             production_amount = self._get_production_amount(node_id)
             input_ids = self._get_technosphere_inputs(node_id)

--- a/bw_timex/matrix_modifier.py
+++ b/bw_timex/matrix_modifier.py
@@ -7,7 +7,10 @@ import numpy as np
 import pandas as pd
 
 from .helper_classes import InterDatabaseMapping
-from .utils import get_temporal_evolution_factor
+from .utils import (
+    get_reference_product_production_amount,
+    get_temporal_evolution_factor,
+)
 
 
 class MatrixModifier:
@@ -220,7 +223,9 @@ class MatrixModifier:
 
         if row.consumer == -1:  # functional unit
             new_producer_id = row.time_mapped_producer
-            fu_production_amount = self.nodes[row.producer].rp_exchange().amount
+            fu_production_amount = get_reference_product_production_amount(
+                self.nodes[row.producer]
+            )
             new_nodes.add((new_producer_id, fu_production_amount))
             self.temporalized_process_ids.add(
                 new_producer_id
@@ -233,15 +238,21 @@ class MatrixModifier:
         previous_producer_id = row.producer
         previous_producer_node = self.nodes[previous_producer_id]
 
-        production_exchange_amount = self.nodes[row.consumer].rp_exchange().amount
+        production_exchange_amount = get_reference_product_production_amount(
+            self.nodes[row.consumer], reference_product=row.consumer
+        )
         scaled_amount = row.amount * abs(
             production_exchange_amount
         )  # abs value used for scaling to preserve the sign of the exchange
 
         # Apply temporal evolution scaling if present
         if hasattr(row, "temporal_evolution") and row.temporal_evolution is not None:
+            reference = getattr(row, "temporal_evolution_reference", "producer")
+            reference_date = (
+                row.date_consumer if reference == "consumer" else row.date_producer
+            )
             factor = get_temporal_evolution_factor(
-                row.temporal_evolution, row.date_producer
+                row.temporal_evolution, reference_date
             )
             scaled_amount *= factor
 
@@ -316,8 +327,8 @@ class MatrixModifier:
                         "The producer activity is of type IOTableActivity, but has more than one production exchange. This is currently not supported."
                     )
             elif isinstance(previous_producer_node, bd.backends.proxies.Activity):
-                producer_production_amount = (
-                    self.nodes[row.producer].rp_exchange().amount
+                producer_production_amount = get_reference_product_production_amount(
+                    self.nodes[row.producer], reference_product=row.producer
                 )
             else:
                 raise ValueError(

--- a/bw_timex/matrix_modifier.py
+++ b/bw_timex/matrix_modifier.py
@@ -275,10 +275,6 @@ class MatrixModifier:
         is_temporal_market = bool(getattr(row, "temporal_market_shares", None))
         if is_temporal_market:
             # Create new edges based on temporal_market_shares from the row
-            if not row.temporal_market_shares:
-                raise ValueError(
-                    f"Row {row} has no temporal market shares, but the previous producer {previous_producer_node['name']} is from a background database."
-                )
             for database, db_share in row.temporal_market_shares.items():
                 # Get the producer activity in the corresponding background database
                 try:

--- a/bw_timex/matrix_modifier.py
+++ b/bw_timex/matrix_modifier.py
@@ -268,8 +268,12 @@ class MatrixModifier:
             flip_array=np.array([True], dtype=bool),
         )
 
-        # Check if previous producer comes from background database -> temporal market
-        if previous_producer_node["database"] in self.database_dates_static.keys():
+        # A row is a temporal market iff it carries temporal_market_shares.
+        # Leaf producers (background frontier) carry shares; producers traversed
+        # into (e.g. background processes descended into with traverse_background)
+        # do not, so they are rebuilt as temporalized processes (no double-count).
+        is_temporal_market = bool(getattr(row, "temporal_market_shares", None))
+        if is_temporal_market:
             # Create new edges based on temporal_market_shares from the row
             if not row.temporal_market_shares:
                 raise ValueError(

--- a/bw_timex/matrix_modifier.py
+++ b/bw_timex/matrix_modifier.py
@@ -155,31 +155,40 @@ class MatrixModifier:
 
         for producer in unique_producers:
             original_producer_node = self.nodes[producer[0]]
-            if (
-                original_producer_node["database"]
-                not in self.database_dates_static.keys()  # skip temporal markets
-            ):
-                new_producer_id = producer[1]
-                indices = (
-                    []
-                )  # list of (biosphere, technosphere) indices for the biosphere flow exchanges
-                amounts = []  # list of amounts corresponding to the bioflows
-                for exc in original_producer_node.biosphere():
-                    indices.append(
-                        (exc.input.id, new_producer_id)
-                    )  # directly build a list of tuples to pass into the datapackage, the new_producer_id is the new column index
-                    amounts.append(exc.amount)
+            new_producer_id = producer[1]
+            # Foreground producers and temporalized background producers (the
+            # latter descended into / variant-resolved with traverse_background)
+            # carry their own biosphere flows. Temporal markets do not — they
+            # only split a technosphere amount between databases, sourcing
+            # biosphere from the real background nodes they link to.
+            if new_producer_id in self.temporal_market_ids:
+                # Temporal markets source biosphere from the real background
+                # nodes they link to, so they get no biosphere of their own.
+                continue
 
-                datapackage_biosphere.add_persistent_vector(
-                    matrix="biosphere_matrix",
-                    name=uuid.uuid4().hex,
-                    data_array=np.array(amounts, dtype=float),
-                    indices_array=np.array(
-                        indices,
-                        dtype=bwp.INDICES_DTYPE,
-                    ),
-                    flip_array=np.array([False], dtype=bool),
-                )
+            indices = (
+                []
+            )  # list of (biosphere, technosphere) indices for the biosphere flow exchanges
+            amounts = []  # list of amounts corresponding to the bioflows
+            for exc in original_producer_node.biosphere():
+                indices.append(
+                    (exc.input.id, new_producer_id)
+                )  # directly build a list of tuples to pass into the datapackage, the new_producer_id is the new column index
+                amounts.append(exc.amount)
+
+            if not indices:
+                continue
+
+            datapackage_biosphere.add_persistent_vector(
+                matrix="biosphere_matrix",
+                name=uuid.uuid4().hex,
+                data_array=np.array(amounts, dtype=float),
+                indices_array=np.array(
+                    indices,
+                    dtype=bwp.INDICES_DTYPE,
+                ),
+                flip_array=np.array([False], dtype=bool),
+            )
         return datapackage_biosphere
 
     def add_row_to_technosphere_datapackage(

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -222,6 +222,7 @@ class TimelineBuilder:
                     "producer",
                     "consumer",
                     "_te_key",
+                    "temporal_evolution_reference",
                 ],
                 dropna=False,
             )
@@ -314,6 +315,7 @@ class TimelineBuilder:
                 "amount",
                 "temporal_market_shares",
                 "temporal_evolution",
+                "temporal_evolution_reference",
             ]
         ]
 
@@ -363,6 +365,7 @@ class TimelineBuilder:
             "amount": edge.abs_td_producer.amount,
             "edge_type": edge.edge_type,
             "temporal_evolution": edge.temporal_evolution,
+            "temporal_evolution_reference": edge.temporal_evolution_reference,
         }
 
     def adjust_sign_of_amount_based_on_edge_type(self, edge_type):

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -42,6 +42,7 @@ class TimelineBuilder:
         cutoff: float = 1e-9,
         max_calc: int = 2000,
         graph_traversal: str = "priority",
+        traverse_background: bool = False,
         *args,
         **kwargs,
     ) -> None:
@@ -89,6 +90,7 @@ class TimelineBuilder:
         self.interpolation_type = interpolation_type
         self.cutoff = cutoff
         self.max_calc = max_calc
+        self.traverse_background = traverse_background
         self._logged_reference_date_below_range = False
         self._logged_reference_date_above_range = False
 
@@ -109,6 +111,7 @@ class TimelineBuilder:
                 cutoff=self.cutoff,
                 static_activity_indices=set(static_background_activity_ids),
                 nodes=self.nodes,
+                traverse_background=self.traverse_background,
             )
         elif graph_traversal == "priority":
             self.edge_extractor = EdgeExtractor(
@@ -119,6 +122,7 @@ class TimelineBuilder:
                 cutoff=self.cutoff,
                 max_calc=self.max_calc,
                 static_activity_indices=set(static_background_activity_ids),
+                traverse_background=self.traverse_background,
                 **kwargs,
             )
         else:

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -14,6 +14,8 @@ from .utils import (
     convert_date_string_to_datetime,
     extract_date_as_integer,
     extract_date_as_string,
+    linear_interpolation_weights,
+    nearest_date_weight,
     round_datetime,
 )
 
@@ -43,6 +45,7 @@ class TimelineBuilder:
         max_calc: int = 2000,
         graph_traversal: str = "priority",
         traverse_background: bool = False,
+        interdatabase_activity_mapping=None,
         *args,
         **kwargs,
     ) -> None:
@@ -91,6 +94,7 @@ class TimelineBuilder:
         self.cutoff = cutoff
         self.max_calc = max_calc
         self.traverse_background = traverse_background
+        self.interdatabase_activity_mapping = interdatabase_activity_mapping
         self._logged_reference_date_below_range = False
         self._logged_reference_date_above_range = False
 
@@ -117,6 +121,11 @@ class TimelineBuilder:
                 nodes=self.nodes,
                 traverse_background=self.traverse_background,
             )
+            self.edge_extractor.database_dates_static = self.database_dates_static
+            self.edge_extractor.interdatabase_activity_mapping = (
+                self.interdatabase_activity_mapping
+            )
+            self.edge_extractor.interpolation_type = self.interpolation_type
         elif graph_traversal == "priority":
             self.edge_extractor = EdgeExtractor(
                 base_lca,
@@ -440,10 +449,19 @@ class TimelineBuilder:
         background db. These are the temporal-market frontier."""
         consumers = set(edges_df["consumer"].unique())
         static_dbs = set(self.database_dates_static.keys())
+        # Producers that the BFS already resolved to their respective variant
+        # database during a variant-aware descent are temporalized (rebuilt from
+        # their own real db), not temporal markets — otherwise their already
+        # variant-routed amounts would be re-interpolated.
+        variant_resolved = getattr(
+            self.edge_extractor, "variant_resolved_producers", set()
+        )
         leaves = set()
         for producer in edges_df["producer"].unique():
             if producer in consumers:
                 continue  # traversed into -> temporalized, not a market
+            if producer in variant_resolved:
+                continue  # already variant-resolved -> temporalized
             node = self.nodes.get(producer)
             if node is not None and node["database"] in static_dbs:
                 leaves.add(producer)
@@ -556,24 +574,7 @@ class TimelineBuilder:
             Dictionary with the key as the closest datetime.datetime object from the list and a value of 1.
         """
 
-        # If the list is empty, return None
-        if not dates:
-            return None
-
-        position = bisect_left(dates, target)
-        if position == 0:
-            closest = dates[0]
-        elif position == len(dates):
-            closest = dates[-1]
-        else:
-            lower_date = dates[position - 1]
-            higher_date = dates[position]
-            if abs(target - lower_date) <= abs(higher_date - target):
-                closest = lower_date
-            else:
-                closest = higher_date
-
-        return {closest: 1}
+        return nearest_date_weight(target, dates)
 
     def get_weights_for_interpolation_between_nearest_years(
         self,
@@ -600,41 +601,30 @@ class TimelineBuilder:
             Dictionary with datetimes of the available closest databases as keys and the weights for interpolation as values.
         """
         interpolation_type = interpolation_type or self.interpolation_type
+        if interpolation_type != "linear":
+            raise ValueError(
+                f"Sorry, but {interpolation_type} interpolation is not available yet."
+            )
+
         position = bisect_left(dates_list, reference_date)
-
-        if position < len(dates_list) and dates_list[position] == reference_date:
-            return {dates_list[position]: 1}
-
-        if position == 0:
+        if position == 0 and not (
+            position < len(dates_list) and dates_list[position] == reference_date
+        ):
             if not getattr(self, "_logged_reference_date_below_range", False):
                 logger.info(
                     "Reference date {} is lower than all provided dates. Data will be taken from the closest higher year.",
                     reference_date,
                 )
                 self._logged_reference_date_below_range = True
-            return {dates_list[0]: 1}
-
-        if position == len(dates_list):
+        elif position == len(dates_list):
             if not getattr(self, "_logged_reference_date_above_range", False):
                 logger.info(
                     "Reference date {} is higher than all provided dates. Data will be taken from the closest lower year.",
                     reference_date,
                 )
                 self._logged_reference_date_above_range = True
-            return {dates_list[-1]: 1}
 
-        closest_lower = dates_list[position - 1]
-        closest_higher = dates_list[position]
-
-        if interpolation_type == "linear":
-            weight = int((reference_date - closest_lower).total_seconds()) / int(
-                (closest_higher - closest_lower).total_seconds()
-            )
-        else:
-            raise ValueError(
-                f"Sorry, but {interpolation_type} interpolation is not available yet."
-            )
-        return {closest_lower: round(1 - weight, 3), closest_higher: round(weight, 3)}
+        return linear_interpolation_weights(reference_date, dates_list)
 
     def add_interpolation_weights_at_intersection_to_background(
         self, row

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -96,11 +96,14 @@ class TimelineBuilder:
 
         # Finding indices of activities from the connected background databases that are known to be static, i.e. have no temporal distributions connecting to them.
         # These will be be skipped in the graph traversal.
-        static_background_activity_ids = {
-            node_id
-            for node_id in self.node_collections["background"]
-            if node_id not in self.node_collections["first_level_background_static"]
-        }
+        if self.traverse_background:
+            static_background_activity_ids = set()
+        else:
+            static_background_activity_ids = {
+                node_id
+                for node_id in self.node_collections["background"]
+                if node_id not in self.node_collections["first_level_background_static"]
+            }
 
         logger.info("Traversing supply chain graph...")
         if graph_traversal == "bfs":
@@ -265,10 +268,18 @@ class TimelineBuilder:
         grouped_edges["hash_consumer"] = grouped_edges["date_consumer"].map(hash_cache)
 
         # add new processes to activity_time_mapping
+        static_dbs = set(self.database_dates_static.keys()) if self.traverse_background else set()
         for row in grouped_edges.itertuples():
+            producer_node = self.nodes[row.producer]
+            if self.traverse_background and producer_node["database"] in static_dbs:
+                # Traversed background node: store with actual db so the downstream
+                # biosphere exchange lookup can identify it unambiguously.
+                db_key = producer_node["database"]
+            else:
+                db_key = "temporalized"
             self.activity_time_mapping.add(
                 (
-                    ("temporalized", self.nodes[row.producer]["code"]),
+                    (db_key, producer_node["code"]),
                     row.hash_producer,
                 )
             )
@@ -423,6 +434,20 @@ class TimelineBuilder:
         except KeyError:
             return self.activity_time_mapping[((self.nodes[node_id].key), node_hash)]
 
+    def _leaf_background_producers(self, edges_df: pd.DataFrame) -> set:
+        """Producers that are leaves (never traversed into) and live in a static
+        background db. These are the temporal-market frontier."""
+        consumers = set(edges_df["consumer"].unique())
+        static_dbs = set(self.database_dates_static.keys())
+        leaves = set()
+        for producer in edges_df["producer"].unique():
+            if producer in consumers:
+                continue  # traversed into -> temporalized, not a market
+            node = self.nodes.get(producer)
+            if node is not None and node["database"] in static_dbs:
+                leaves.add(producer)
+        return leaves
+
     def add_column_temporal_market_shares_to_timeline(
         self,
         tl_df: pd.DataFrame,
@@ -491,9 +516,11 @@ class TimelineBuilder:
                 f"Sorry, but {interpolation_type} interpolation is not available yet."
             )
 
-        first_level_background_static = self.node_collections[
-            "first_level_background_static"
-        ]
+        if self.traverse_background:
+            market_producers = self._leaf_background_producers(tl_df)
+        else:
+            market_producers = self.node_collections["first_level_background_static"]
+
         remapped_interpolation_weights = {
             producer_date: {
                 self.reversed_database_dates[date]: share
@@ -504,7 +531,7 @@ class TimelineBuilder:
 
         tl_df["temporal_market_shares"] = [
             remapped_interpolation_weights[producer_date]
-            if producer in first_level_background_static
+            if producer in market_producers
             else None
             for producer, producer_date in zip(tl_df["producer"], tl_df["date_producer"])
         ]

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -138,6 +138,15 @@ class TimelineBuilder:
                 traverse_background=self.traverse_background,
                 **kwargs,
             )
+            # Same variant-aware descent inputs as the BFS extractor. The priority
+            # engine's own ``self.nodes`` are graph-traversal Node objects, so the
+            # shared mixin reads bw2data Activity proxies through ``bw_node_proxies``.
+            self.edge_extractor.bw_node_proxies = self.nodes
+            self.edge_extractor.database_dates_static = self.database_dates_static
+            self.edge_extractor.interdatabase_activity_mapping = (
+                self.interdatabase_activity_mapping
+            )
+            self.edge_extractor.interpolation_type = self.interpolation_type
         else:
             raise ValueError(
                 f"Unknown graph_traversal '{graph_traversal}'. Use 'priority' or 'bfs'."

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -108,6 +108,7 @@ class TimelineBuilder:
                 edge_filter_function=edge_filter_function,
                 cutoff=self.cutoff,
                 static_activity_indices=set(static_background_activity_ids),
+                nodes=self.nodes,
             )
         elif graph_traversal == "priority":
             self.edge_extractor = EdgeExtractor(

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -112,6 +112,7 @@ class TimelineBuilder:
                 starting_datetime=self.starting_datetime,
                 edge_filter_function=edge_filter_function,
                 cutoff=self.cutoff,
+                max_calc=self.max_calc,
                 static_activity_indices=set(static_background_activity_ids),
                 nodes=self.nodes,
                 traverse_background=self.traverse_background,

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -333,6 +333,13 @@ class TimexLCA:
         # Doing this here because we need the temporal grouping for consistent time resolution.
         self.add_static_activities_to_activity_time_mapping()
 
+        # When descending into the background, the BFS extractor must be able to
+        # resolve any background activity to its sibling in every other static
+        # variant database, so it can read the respective (non-referenced)
+        # variant's exchanges. Build the full mapping up front.
+        if traverse_background:
+            self.add_full_interdatabase_activity_mapping()
+
         # Create timeline builder that does the graph traversal (similar to bw_temporalis) and
         # extracts all edges with their temporal information. Can later be used to build a timeline
         # with the TimelineBuilder.build_timeline() method.
@@ -351,6 +358,7 @@ class TimexLCA:
             self.max_calc,
             graph_traversal=graph_traversal,
             traverse_background=traverse_background,
+            interdatabase_activity_mapping=self.interdatabase_activity_mapping,
             *args,
             **kwargs,
         )
@@ -1385,6 +1393,37 @@ class TimexLCA:
         self.node_collections["first_level_background_static"] = (
             first_level_background_static
         )
+
+    def add_full_interdatabase_activity_mapping(self) -> None:
+        """
+        Populate ``interdatabase_activity_mapping`` for every background activity
+        across all static variant databases.
+
+        Unlike ``add_interdatabase_activity_mapping_from_timeline`` (which only
+        maps producers that appear in the finished timeline), this pre-pass maps
+        every static-database node to its sibling in every other static database,
+        so the BFS extractor can resolve and read the respective (non-referenced)
+        variant's exchanges while it is still traversing.
+        """
+        static_dbs = set(self.database_dates_static.keys())
+        tuples_dict = {}
+        for node in self.nodes.values():
+            if node["database"] not in static_dbs:
+                continue
+            key = (node["name"], node.get("reference product"), node["location"])
+            tuples_dict.setdefault(key, node.id)
+        # Build the anchor -> {db: id} mapping in a plain dict first; indexing
+        # the InterDatabaseMapping itself would prematurely trigger
+        # make_reciprocal() before every entry has been added.
+        built = {}
+        for node in self.nodes.values():
+            if node["database"] not in static_dbs:
+                continue
+            key = (node["name"], node.get("reference product"), node["location"])
+            anchor = tuples_dict[key]
+            built.setdefault(anchor, {})[node["database"]] = node.id
+        self.interdatabase_activity_mapping.update(built)
+        self.interdatabase_activity_mapping.make_reciprocal()
 
     def add_interdatabase_activity_mapping_from_timeline(self) -> None:
         """

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -300,7 +300,7 @@ class TimexLCA:
                 ]
             ]
 
-        if edge_filter_function is None:
+        if edge_filter_function is None and not traverse_background:
             logger.info(
                 "No edge filter function provided. Skipping all edges in background databases."
             )
@@ -310,8 +310,11 @@ class TimexLCA:
                     skippable.update(node.id for node in bd.Database(db))
                 self._default_edge_filter_function = skippable.__contains__
             self.edge_filter_function = self._default_edge_filter_function
-        else:
+        elif edge_filter_function is not None:
             self.edge_filter_function = edge_filter_function
+        else:
+            # traverse_background=True with no user filter: BFS descends freely
+            self.edge_filter_function = lambda x: False
 
         self.starting_datetime = starting_datetime
         self.temporal_grouping = temporal_grouping

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -1459,11 +1459,17 @@ class TimexLCA:
             .index.values
         )
 
+        market_time_mapped = set(
+            self.timeline.loc[
+                self.timeline.temporal_market_shares.notnull(),
+                "time_mapped_producer",
+            ]
+        )
+
         temporal_market_ids = set()
         temporalized_process_ids = set()
-
         for producer, time_mapped_producer in unique_producers:
-            if self.nodes[producer]["database"] in self.database_dates_static.keys():
+            if time_mapped_producer in market_time_mapped:
                 temporal_market_ids.add(time_mapped_producer)
             else:
                 temporalized_process_ids.add(time_mapped_producer)

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -277,6 +277,15 @@ class TimexLCA:
         interpolation_type = validated.interpolation_type
         graph_traversal = validated.graph_traversal
 
+        if traverse_background and graph_traversal == "priority":
+            logger.warning(
+                "traverse_background=True with graph_traversal='priority': heap "
+                "ordering uses base_lca scores as an approximation for nodes in "
+                "non-referenced background variants. Edge exploration order under "
+                "max_calc/cutoff may differ slightly; explored amounts are correct. "
+                "Use graph_traversal='bfs' to avoid the approximation."
+            )
+
         timeline_cache_key = (
             str(validated.starting_datetime),
             temporal_grouping,

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -396,7 +396,14 @@ class TimexLCA:
         )
 
         self.timeline = self.timeline_builder.build_timeline()
-        self.add_interdatabase_activity_mapping_from_timeline()
+        if not traverse_background:
+            # When traverse_background=True the full interdatabase mapping was
+            # already built by add_full_interdatabase_activity_mapping() above,
+            # covering every background activity. Running this again would reset
+            # entries via update({producer: {} ...}) before repopulating them,
+            # producing the same final result but wasting work and creating a
+            # fragile transient inconsistency. Skip it.
+            self.add_interdatabase_activity_mapping_from_timeline()
         self._last_timeline_build_key = timeline_cache_key
         self._cached_timeline = self.timeline
         self._dynamic_lcia_inventory_cache.clear()

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -211,6 +211,7 @@ class TimexLCA:
         cutoff: float = 1e-9,
         max_calc: int = 2000,
         graph_traversal: str = "priority",
+        traverse_background: bool = False,
         *args,
         **kwargs,
     ) -> pd.DataFrame:
@@ -271,6 +272,7 @@ class TimexLCA:
             cutoff=cutoff,
             max_calc=max_calc,
             graph_traversal=graph_traversal,
+            traverse_background=traverse_background,
         )
         interpolation_type = validated.interpolation_type
         graph_traversal = validated.graph_traversal
@@ -282,6 +284,7 @@ class TimexLCA:
             cutoff,
             max_calc,
             graph_traversal,
+            traverse_background,
             "default" if edge_filter_function is None else id(edge_filter_function),
         )
         if timeline_cache_key == self._last_timeline_build_key:
@@ -344,6 +347,7 @@ class TimexLCA:
             self.cutoff,
             self.max_calc,
             graph_traversal=graph_traversal,
+            traverse_background=traverse_background,
             *args,
             **kwargs,
         )

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -1300,27 +1300,10 @@ class TimexLCA:
 
         if demands:
             indexed_demand = [
-                {
-                    self.activity_time_mapping[
-                        (
-                            bd.get_node(id=bd.get_id(k)).key,
-                            self.demand_timing[bd.get_id(k)],
-                        )
-                    ]: v
-                    for k, v in dct.items()
-                }
-                for dct in demands
+                self._build_indexed_demand(dct) for dct in demands
             ]
         elif demand:
-            indexed_demand = {
-                self.activity_time_mapping[
-                    (
-                        ("temporalized", bd.get_node(id=bd.get_id(k))["code"]),
-                        self.demand_timing[bd.get_id(k)],
-                    )
-                ]: v
-                for k, v in demand.items()
-            }
+            indexed_demand = self._build_indexed_demand(demand)
         else:
             indexed_demand = None
 
@@ -1529,11 +1512,11 @@ class TimexLCA:
 
     def create_demand_timing(self) -> dict:
         """
-        Generate a dictionary that maps producer (key) to timing (value) for the demands in the
-        product system. It searches the timeline for those rows that contain the functional units
-        (demand-processes as producer and -1 as consumer) and returns the time of the demand as an
-        integer. Time of demand can have flexible resolution (year=YYYY, month=YYYYMM, day=YYYYMMDD,
-        hour=YYYYMMDDHH) defined in `temporal_grouping`.
+        Generate a dictionary that maps demand id (key) to timing (value) for the demands in the
+        product system. It searches the timeline for the FU rows (consumer == -1) and looks up the
+        timing of the producing process. For demands keyed by an explicit product node, the producer
+        in the timeline is the process producing that product, so we resolve the product → process
+        relationship via the production exchange.
 
         Parameters
         ----------
@@ -1542,31 +1525,107 @@ class TimexLCA:
         Returns
         -------
         dict
-            Dictionary mapping producer ids to reference timing for the specified demands.
+            Dictionary mapping demand ids to reference timing for the specified demands.
         """
-        demand_ids = [bd.get_id(key) for key in self.demand.keys()]
-        demand_rows = self.timeline[
-            self.timeline["producer"].isin(demand_ids)
-            & (self.timeline["consumer"] == -1)
-        ]
+        process_id_by_demand_id = {
+            bd.get_activity(key).id: self._resolve_demand_to_process_id(key)
+            for key in self.demand.keys()
+        }
+        fu_rows = self.timeline[self.timeline["consumer"] == -1]
+        timing_by_process_id = {
+            row.producer: row.hash_producer for row in fu_rows.itertuples()
+        }
 
-        missing_demand_ids = sorted(set(demand_ids) - set(demand_rows["producer"]))
-        if missing_demand_ids:
-            functional_unit_producers = sorted(
-                set(self.timeline.loc[self.timeline["consumer"] == -1, "producer"])
-            )
+        missing_process_ids = sorted(
+            set(process_id_by_demand_id.values()) - set(timing_by_process_id)
+        )
+        if missing_process_ids:
+            functional_unit_producers = sorted(set(timing_by_process_id))
             raise ValueError(
-                "Could not find functional-unit timing rows for demand id(s) "
-                f"{missing_demand_ids}. The existing timeline contains functional-unit "
+                "Could not find functional-unit timing rows for producing process id(s) "
+                f"{missing_process_ids}. The existing timeline contains functional-unit "
                 f"producer id(s) {functional_unit_producers}. This usually means the "
                 "Brightway database or demand nodes changed after build_timeline(); "
                 "recreate the TimexLCA object and rebuild the timeline before calling lci()."
             )
 
+
         self.demand_timing = {
-            row.producer: row.hash_producer for row in demand_rows.itertuples()
+            demand_id: timing_by_process_id[process_id]
+            for demand_id, process_id in process_id_by_demand_id.items()
+            if process_id in timing_by_process_id
         }
         return self.demand_timing
+
+    def _build_indexed_demand(self, demand_dict) -> dict:
+        """Map a demand dict to time-mapped producer ids, distributed across
+        every install-vintage cohort produced by an output-side temporal
+        distribution.
+
+        Each FU row in the timeline corresponds to one cohort of the demand's
+        producing process; ``row.amount`` is the cohort's share of the
+        original demand value. Summing the FU rows reproduces the user's
+        demand magnitude while preserving the cohort split, so that
+        downstream matrix-modifier logic (which keys temporal markets by
+        ``time_mapped_producer``) routes each cohort's inputs to the
+        appropriate background database.
+        """
+        if not hasattr(self, "timeline"):
+            raise AttributeError(
+                "Timeline not yet built. Call TimexLCA.build_timeline() first."
+            )
+
+        fu_rows = self.timeline[self.timeline["consumer"] == -1]
+        indexed = {}
+        for k, v in demand_dict.items():
+            process_id = self._resolve_demand_to_process_id(k)
+            cohort_rows = fu_rows[fu_rows["producer"] == process_id]
+            if cohort_rows.empty:
+                raise ValueError(
+                    f"No functional-unit rows in timeline for demand `{k}` "
+                    f"(process id {process_id}). Did you call build_timeline?"
+                )
+            cohort_total = float(cohort_rows["amount"].sum())
+            if cohort_total == 0:
+                raise ValueError(
+                    f"Functional-unit rows for demand `{k}` sum to zero amount."
+                )
+            scale = float(v) / cohort_total
+            for row in cohort_rows.itertuples():
+                indexed[row.time_mapped_producer] = (
+                    indexed.get(row.time_mapped_producer, 0.0)
+                    + float(row.amount) * scale
+                )
+        return indexed
+
+    def _resolve_demand_to_process_id(self, key) -> int:
+        """Return the id of the process producing ``key``.
+
+        For demands keyed by a process node this is the demand id itself. For demands keyed by a
+        product node (explicit process/product paradigm) we look up the process via the production
+        exchange targeting that product.
+        """
+        node = bd.get_activity(key) if not hasattr(key, "id") else key
+        if node.get("type") != "product":
+            return node.id
+        for exc in node.upstream(kinds=["production"]):
+            return exc.output.id
+        raise ValueError(
+            f"Could not resolve product `{node}` to its producing process: no production "
+            "exchange targets it."
+        )
+
+    def _resolve_demand_to_process_key(self, key):
+        """Return the (database, code) key of the process producing ``key``."""
+        node = bd.get_activity(key) if not hasattr(key, "id") else key
+        if node.get("type") != "product":
+            return node.key
+        for exc in node.upstream(kinds=["production"]):
+            return exc.output.key
+        raise ValueError(
+            f"Could not resolve product `{node}` to its producing process: no production "
+            "exchange targets it."
+        )
 
     ######################################
     # For creating human-friendly output #

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -279,11 +279,12 @@ class TimexLCA:
 
         if traverse_background and graph_traversal == "priority":
             logger.warning(
-                "traverse_background=True with graph_traversal='priority': heap "
-                "ordering uses base_lca scores as an approximation for nodes in "
-                "non-referenced background variants. Edge exploration order under "
-                "max_calc/cutoff may differ slightly; explored amounts are correct. "
-                "Use graph_traversal='bfs' to avoid the approximation."
+                "traverse_background=True with graph_traversal='priority': "
+                "non-referenced background variants are not placed on the priority "
+                "heap; each variant subtree is walked in full via proxy reads when its "
+                "parent edge is reached. The referenced-system heap exploration order is "
+                "unchanged and explored amounts are exact (identical to graph_traversal='bfs' "
+                "for these subtrees)."
             )
 
         timeline_cache_key = (

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -245,6 +245,28 @@ class TimexLCA:
             The graph traversal algorithm to use. Default is 'priority' (priority-first,
             using bw_temporalis TemporalisLCA). Alternative is 'bfs' (Breadth-First-Search,
             independent of TemporalisLCA, avoids per-subgraph LCA overhead).
+        traverse_background : bool, optional
+            If True, the graph traversal descends into background databases instead of
+            stopping at the first-level background frontier. Temporal distributions defined
+            on exchanges inside background databases are then honored: time-spread flows are
+            sourced from the temporally-appropriate background-db variant(s). Bounded by
+            ``cutoff`` and ``max_calc``. Default is False (background treated as static,
+            as before).
+
+            With ``graph_traversal='priority'``, non-referenced background variants are NOT
+            placed on the priority heap. Instead, each variant's subtree is walked in full
+            via proxy reads when the parent edge is reached. The referenced-system heap
+            exploration order is unchanged and explored amounts are exact (identical to
+            ``graph_traversal='bfs'`` for those subtrees). A one-time warning is emitted
+            when this combination is used.
+
+            .. note::
+                **Known limitation:** if a background process with further background
+                technosphere inputs is reached at *more than one cohort date* (e.g. via a
+                foreground ``temporal_distribution`` feeding into a non-leaf background
+                activity), the variant split raises ``NotImplementedError``. This
+                multi-date-consumer case fails loudly and only occurs under
+                ``traverse_background=True``.
         *args : iterable
             Positional arguments for the graph traversal, for `bw_temporalis.TemporalisLCA` passed
             to the `EdgeExtractor` class, which inherits from `TemporalisLCA`. See `bw_temporalis`

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -259,14 +259,6 @@ class TimexLCA:
             exploration order is unchanged and explored amounts are exact (identical to
             ``graph_traversal='bfs'`` for those subtrees). A one-time warning is emitted
             when this combination is used.
-
-            .. note::
-                **Known limitation:** if a background process with further background
-                technosphere inputs is reached at *more than one cohort date* (e.g. via a
-                foreground ``temporal_distribution`` feeding into a non-leaf background
-                activity), the variant split raises ``NotImplementedError``. This
-                multi-date-consumer case fails loudly and only occurs under
-                ``traverse_background=True``.
         *args : iterable
             Positional arguments for the graph traversal, for `bw_temporalis.TemporalisLCA` passed
             to the `EdgeExtractor` class, which inherits from `TemporalisLCA`. See `bw_temporalis`

--- a/bw_timex/utils.py
+++ b/bw_timex/utils.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime, timedelta
 from typing import Callable, List, Optional, Union
 
+import bw2data as bd
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -34,6 +35,49 @@ time_res_mapping_strftime = {
     "day": "%Y%m%d",
     "hour": "%Y%m%d%H",
 }
+
+
+def get_reference_product_production_amount(
+    node, *, reference_product=None, lca=None
+) -> float:
+    """Return a node's production amount in a paradigm-agnostic way.
+
+    Supports chimaera activities via ``rp_exchange`` and explicit process/product
+    setups via production exchanges.
+    """
+    if isinstance(node, (int, np.integer)):
+        node = bd.get_activity(id=int(node))
+
+    if hasattr(node, "rp_exchange"):
+        rp_exc = node.rp_exchange()
+        if rp_exc is not None:
+            return rp_exc.amount
+
+    productions = list(node.production())
+    if not productions:
+        raise ValueError(
+            f"Could not determine production amount for node `{node}`: no production exchanges found."
+        )
+
+    if reference_product is not None:
+        ref_id = (
+            reference_product.id
+            if hasattr(reference_product, "id")
+            else int(reference_product)
+        )
+        for exc in productions:
+            if exc.input.id == ref_id:
+                return exc.amount
+        raise ValueError(
+            f"Could not find production exchange from `{node}` to reference product id `{ref_id}`."
+        )
+
+    if len(productions) == 1:
+        return productions[0].amount
+
+    raise ValueError(
+        f"Node `{node}` has multiple production exchanges; pass `reference_product` to disambiguate."
+    )
 
 
 def extract_date_as_integer(dt_obj: datetime, time_res: Optional[str] = "year") -> int:
@@ -503,6 +547,7 @@ def add_temporal_distribution_to_exchange(
 def add_temporal_evolution_to_exchange(
     temporal_evolution_factors: dict = None,
     temporal_evolution_amounts: dict = None,
+    temporal_evolution_reference: str = "producer",
     **kwargs,
 ):
     """Add temporal evolution data to an exchange specified by kwargs.
@@ -513,6 +558,8 @@ def add_temporal_evolution_to_exchange(
         Dictionary mapping datetime keys to scaling factors.
     temporal_evolution_amounts : dict, optional
         Dictionary mapping datetime keys to absolute amounts.
+    temporal_evolution_reference : {"producer", "consumer"}, optional
+        Whether temporal evolution is evaluated at producer or consumer timestamps.
     **kwargs :
         Arguments to specify an exchange (same as get_exchange).
 
@@ -526,12 +573,14 @@ def add_temporal_evolution_to_exchange(
     TemporalEvolutionExchangeInputs(
         temporal_evolution_factors=temporal_evolution_factors,
         temporal_evolution_amounts=temporal_evolution_amounts,
+        temporal_evolution_reference=temporal_evolution_reference,
     )
     exchange = get_exchange(**kwargs)
     if temporal_evolution_factors is not None:
         exchange["temporal_evolution_factors"] = temporal_evolution_factors
     if temporal_evolution_amounts is not None:
         exchange["temporal_evolution_amounts"] = temporal_evolution_amounts
+    exchange["temporal_evolution_reference"] = temporal_evolution_reference
     exchange.save()
     logger.info(f"Added temporal evolution to exchange {exchange}.")
 

--- a/bw_timex/utils.py
+++ b/bw_timex/utils.py
@@ -1,5 +1,6 @@
 import functools
 import json
+from bisect import bisect_left
 from datetime import datetime, timedelta
 from typing import Callable, List, Optional, Union
 
@@ -35,6 +36,65 @@ time_res_mapping_strftime = {
     "day": "%Y%m%d",
     "hour": "%Y%m%d%H",
 }
+
+
+def linear_interpolation_weights(
+    date: datetime, sorted_dates: tuple
+) -> dict:
+    """Return ``{date: weight}`` linear-interpolation weights for ``date``.
+
+    ``sorted_dates`` is an ascending tuple of the available (background-database)
+    dates. The weights are split between the two nearest bracketing dates,
+    proportional to temporal proximity. If ``date`` falls on or outside the
+    range of ``sorted_dates``, the single nearest in-range date gets weight 1.
+
+    Mirrors ``TimelineBuilder.get_weights_for_interpolation_between_nearest_years``
+    and is shared by both the timeline builder and the graph-traversal extractors.
+    """
+    if not sorted_dates:
+        return {}
+
+    position = bisect_left(sorted_dates, date)
+
+    if position < len(sorted_dates) and sorted_dates[position] == date:
+        return {sorted_dates[position]: 1}
+    if position == 0:
+        return {sorted_dates[0]: 1}
+    if position == len(sorted_dates):
+        return {sorted_dates[-1]: 1}
+
+    closest_lower = sorted_dates[position - 1]
+    closest_higher = sorted_dates[position]
+    weight = int((date - closest_lower).total_seconds()) / int(
+        (closest_higher - closest_lower).total_seconds()
+    )
+    return {closest_lower: round(1 - weight, 3), closest_higher: round(weight, 3)}
+
+
+def nearest_date_weight(date: datetime, sorted_dates: tuple) -> dict:
+    """Return ``{date: 1}`` for the single date in ``sorted_dates`` closest to
+    ``date``.
+
+    ``sorted_dates`` is an ascending tuple of available dates. Mirrors
+    ``TimelineBuilder.find_closest_date`` and is shared by the timeline builder
+    and the graph-traversal extractors.
+    """
+    if not sorted_dates:
+        return None
+
+    position = bisect_left(sorted_dates, date)
+    if position == 0:
+        closest = sorted_dates[0]
+    elif position == len(sorted_dates):
+        closest = sorted_dates[-1]
+    else:
+        lower_date = sorted_dates[position - 1]
+        higher_date = sorted_dates[position]
+        if abs(date - lower_date) <= abs(higher_date - date):
+            closest = lower_date
+        else:
+            closest = higher_date
+    return {closest: 1}
 
 
 def get_reference_product_production_amount(

--- a/bw_timex/validation.py
+++ b/bw_timex/validation.py
@@ -177,6 +177,7 @@ class TemporalEvolutionExchangeInputs(BaseModel):
 
     temporal_evolution_factors: Optional[dict] = None
     temporal_evolution_amounts: Optional[dict] = None
+    temporal_evolution_reference: Literal["producer", "consumer"] = "producer"
 
     @model_validator(mode="after")
     def validate_mutual_exclusivity(self) -> "TemporalEvolutionExchangeInputs":

--- a/bw_timex/validation.py
+++ b/bw_timex/validation.py
@@ -98,6 +98,7 @@ class BuildTimelineInputs(BaseModel):
     cutoff: float = Field(default=1e-9, gt=0)
     max_calc: int = Field(default=2000, gt=0)
     graph_traversal: Literal["priority", "bfs"] = "priority"
+    traverse_background: bool = False
 
     @field_validator("starting_datetime")
     @classmethod

--- a/docs/content/decisiontree.md
+++ b/docs/content/decisiontree.md
@@ -43,3 +43,97 @@ flowchart TD
     BackgroundDecision -- "no" --> CodeDynamicLCIA
     BackgroundDecision -- "yes" --> CodeDisaggregatedLCIA
 ```
+
+## Modeling paradigm option: chimaera vs explicit process/product
+
+Brightway supports more than one way to represent inventory data. See the Brightway inventory
+overview on [processes, products, and something in between](https://docs.brightway.dev/en/latest/content/overview/inventory.html#processes-products-and-something-in-between)
+for the broader data-model discussion. In short:
+
+- **Explicit process/product** (`type="process"` + `type="product"`): products are separate
+  nouns, processes are separate verbs, and production edges connect processes to products.
+- **Chimaera** (`type="processwithreferenceproduct"`): one node acts as both process and
+  reference product. This is common in existing LCI databases and compact for many models.
+
+Both paradigms are valid modelling choices. `bw_timex` aims to support both when building
+timelines and expanding matrices. The right choice depends on what you need to express and on the
+data you start from.
+
+### Terms used below
+
+A **production-time group** is a set of product units supplied or produced at the same time. In
+fleet and stock modelling, this is often called a **cohort**; for example, all vehicles produced in
+2030 are the 2030 cohort. A **process/product version date** is the date that fixes a foreground
+property of that group, such as vehicle efficiency or a material requirement. Some literature calls
+this a **vintage**.
+
+### When chimaera nodes are often pragmatic
+
+Use chimaera activities when your data already comes this way, when each process has one clear
+reference product, and when you do not need to attach separate temporal meaning to the product
+output edge itself. Most conventional Brightway examples and many imported databases follow this
+style.
+
+For production-time group timing in a chimaera model, you usually add an intermediary foreground
+activity and put the temporal distribution on a normal technosphere edge, e.g.:
+
+```text
+fleet_service -- production-time group TD --> fleet_driving
+fleet_driving -- age TD --> electricity
+```
+
+This is a structural modelling pattern: `fleet_service` exists to give the production-time group
+timing a place to live.
+
+### When explicit process/product nodes are often clearer
+
+Use explicit process/product nodes when distinguishing the demanded product from the operation
+that produces it helps the model. This is especially useful when timing belongs naturally to the
+production output edge, such as production of multiple production-time groups, delayed delivery, service availability, or
+multi-output process modelling.
+
+For production-time group timing in an explicit model, put the temporal distribution directly on
+the production edge:
+
+```text
+fleet_process -- production-time group TD --> fleet_product
+fleet_process -- age TD --> electricity
+```
+
+This makes production timing part of the graph topology instead of introducing a wrapper activity.
+It also makes the two timeline dates easier to interpret:
+
+- `date_consumer`: the process/product version date or demand-side process instance date.
+- `date_producer`: the actual exchange event date.
+
+### How this relates to temporal evolution
+
+The modelling paradigm does not decide whether you use `consumer` or `producer` for temporal
+evolution. That choice depends on what the evolving exchange amount means:
+
+- Use `consumer` when the amount is a property of the consuming foreground process/product
+  version date.
+- Use `producer` when the amount is a property of the calendar year in which the exchange event
+  happens.
+
+Explicit process/product models often make this distinction more visible because a production-edge
+temporal distribution can create distinct product/process version dates without an intermediary
+node.
+But the same conceptual rule applies in chimaera models if your graph structure creates meaningful
+consumer and producer dates.
+
+### Which temporal evolution reference should I use?
+
+Foreground temporal evolution can be keyed to either the consumer timestamp or the producer timestamp. The names are graph terms:
+
+- `temporal_evolution_reference="consumer"` means the factor is evaluated at `date_consumer`: the time of the foreground process instance using the exchange. In production-time group models, this is usually the **process/product version date**.
+- `temporal_evolution_reference="producer"` means the factor is evaluated at `date_producer`: the time when the exchanged input/output event actually happens. This is the **calendar event date**.
+
+Use `consumer` for version-locked properties, e.g. a vehicle produced in 2025 keeps its 2025 kWh/km in 2035. Use `producer` for calendar-year properties, e.g. a repair operation becomes more efficient for all active vehicles in 2035.
+
+Rule of thumb:
+
+```text
+Property of the foreground process/product version date? -> consumer
+Property of the exchange event year?                -> producer
+```

--- a/docs/content/dev/explicit_process_product_paradigm.md
+++ b/docs/content/dev/explicit_process_product_paradigm.md
@@ -1,0 +1,258 @@
+# Implementation plan: explicit `process` + `product` node support
+
+| Field | Value |
+| --- | --- |
+| Status | Proposed (not yet scheduled) |
+| Audience | `bw_timex` maintainers and contributors |
+| Scope | Add full support for Brightway's explicit `process` / `product` node paradigm, including `temporal_distribution` on production-typed output edges |
+| Related issues | TBD (file when prioritised) |
+| Related notebook | `notebooks/example_electric_vehicle_fleet.ipynb` (motivating use case) |
+
+This document captures the analysis behind that scope and the concrete changes needed in `bw_timex` (and one upstream dependency). It is intended to be read end-to-end before any of the changes below are picked up; the order, rationale and out-of-scope items matter.
+
+## 1. Motivation
+
+`bw_timex` distributes exchanges in time via `TemporalDistribution` (TD) attached to *technosphere* edges. When a model needs to inject a *cohort* distribution — i.e., a temporal pattern on the **output** of an activity rather than on any single input — the only working pattern today is to insert an aggregator node:
+
+```text
+FU = {fleet_service: 1}
+fleet_service ──[TD = cohort distribution]──▶ fleet_driving
+                                               ├──[TD = age survival]──▶ electricity
+                                               └──[TD = age retirement PDF]──▶ used_ev
+```
+
+This works (it is the pattern used in `example_electric_vehicle_fleet.ipynb`), but the `fleet_service` node is purely structural: it exists to give the cohort TD a technosphere edge to live on. In Brightway's explicit paradigm — `process` and `product` as separate nodes connected by an off-diagonal output edge — the cohort TD has a natural home on the `process → product` edge, and the aggregator disappears:
+
+```text
+FU = {fleet_driving_product: 1}
+fleet_driving_process ──[output edge, type="production", TD = cohort]──▶ fleet_driving_product
+fleet_driving_process ←──[input edge,  type="technosphere",  TD = age]── electricity_product
+fleet_driving_process ←──[input edge,  type="technosphere",  TD = retirement]── used_ev_product
+```
+
+Same math, three nodes instead of four, and the topology says what it means. The barrier today is that `bw_timex`'s graph traversal silently fails on this paradigm; the aim of this plan is to remove that barrier.
+
+## 2. Background: how Brightway represents activities
+
+`bw2data ≥ 4.0` defines two complementary node-type families (`bw2data/configuration.py`):
+
+```python
+process_node_types  = ["process", "processwithreferenceproduct"]
+product_node_types  = ["product"]
+chimaera_node_default = "processwithreferenceproduct"
+```
+
+Two relevant paradigms emerge:
+
+1. **Chimaera (default).** A single `processwithreferenceproduct` node represents both the activity and its reference product. The technosphere matrix has one column per node and one row per node; each chimaera contributes one diagonal entry (the production self-loop) and zero or more off-diagonal entries (technosphere consumption from other chimaeras).
+2. **Explicit.** Two distinct nodes — a `process` and a `product` — connected by a `type="production"` exchange. Process columns and product rows are decoupled; the production exchange is a real off-diagonal entry whose `amount` is the output coefficient. Multi-product processes (co-production) are expressible by adding more `process → product` output edges from the same process.
+
+The chimaera paradigm is by far the most common in published Brightway practice; explicit nodes appear in input-output and SUT-style models, in some `bonsai`-style supply-chain models, and in any modelling style that wants to attach TDs (or other metadata) to the act of producing the reference product.
+
+`bw2calc.LCA` accepts both paradigms: it requires the FU to be a **product** (`"LCA can only be performed on products, not activities"`), but the producer can be either a chimaera or an explicit process. Static LCAs over explicit graphs work today.
+
+## 3. Current `bw_timex` behaviour on explicit graphs
+
+A minimal repro (electricity-only model, FU = `{fleet_driving_product: 1}`, cohort TD on the `process → product` output edge, age TD on the electricity input):
+
+```python
+import bw2calc as bc
+bc.LCA({fd_product: 1}, method).lci();  bc.LCA(...).lcia()
+# → static_score = 5.0 (correct)
+
+from bw_timex import TimexLCA
+tlca = TimexLCA({fd_product: 1}, method, database_dates)
+tlca.build_timeline(starting_datetime=datetime(2030,1,1), temporal_grouping="year")
+# → timeline rows: 1
+#    only the FU placeholder, no supply chain walk
+tlca.lci()
+# → KeyError on the product id (not in demand_timing / activity_time_mapping)
+```
+
+Three independent failures stack up:
+
+1. **`bw_graph_tools.matrix_tools.gpe_second_heuristic` crashes on NumPy 2** because of a `np.in1d` call (removed in NumPy 2.0; replaced by `np.isin`). This heuristic only fires when the production-exchange diagonal is ambiguous, which is exactly the explicit-paradigm case. A `np.in1d = np.isin` shim unblocks this layer but is *not* a fix.
+2. **The graph traversal terminates at the demanded product.** Both the `EdgeExtractor` (priority traversal, inheriting from `bw_temporalis.TemporalisLCA`) and the BFS variant (`EdgeExtractorBFS._get_technosphere_inputs` in `bw_timex/edge_extractor.py:390`) assume `dicts.product[activity_id]` resolves — i.e., that each tech-matrix column corresponds to a single product on the diagonal. With explicit nodes, `dicts.product.get(process_id)` is `None`, and:
+   - The "skip self-loop" filter (`if row_idx == product_idx: continue`) becomes a no-op, so the *output* row is treated as just another input with the wrong sign.
+   - With a `Product` as FU, `bw_graph_tools` does not perform the bipartite step "find producing process for this product, then descend into its inputs."
+3. **`prepare_bw_timex_inputs` fails** because the demanded `Product` was never registered in `demand_timing` / `activity_time_mapping` (the traversal didn't reach it). This surfaces as a `KeyError` in `timex_lca.py:1133`.
+
+In addition, the matrix-modifier layer assumes chimaera-shaped activities:
+
+- `edge_extractor.py:178` — `node.reference_product_production_amount`
+- `matrix_modifier.py:223` — `self.nodes[row.producer].rp_exchange().amount` (FU branch)
+- `matrix_modifier.py:236` — `self.nodes[row.consumer].rp_exchange().amount` (general branch)
+- `matrix_modifier.py:314-321` — already special-cases `IOTableActivity`; the explicit `process` case must be added alongside.
+
+For a pure `process` node, `rp_exchange()` returns `None` or raises depending on the bw2data branch; either way the call site needs to look up the production-typed output edge to the reference product instead.
+
+## 4. Theoretical model: TD on the production output edge
+
+Notation: process column `P`, product row `Q`, output coefficient `α` (entry of the tech matrix at row `Q`, column `P`), input coefficient `β` from another product `R` (row `R`, column `P`).
+
+Static LCA: scaling factor for `P` to satisfy `{Q: 1}` = `1/α`. Each unit of `P` consumes `β/α` of `R`.
+
+Now decorate the output edge with a cohort TD `{c_i: w_i}` (offsets relative to the FU date, weights summing to 1) and the input edge with an age TD `{a_j: v_j}` (offsets relative to each cohort instance):
+
+- Each cohort `c_i` invokes `P` at scale `w_i / α`.
+- For each cohort instance, the input from `R` is consumed at age `a_j` with weight `v_j × β × w_i / α` at calendar year `c_i + a_j`.
+- `date_consumer` of the input edge is the cohort year `c_i` (because the consumer-side date is the date of the producing process invocation).
+
+This is exactly the cohort × age decomposition we want from the `fleet_service` intermediary today, with two architectural simplifications:
+
+1. The cohort TD lives on a single edge of `fleet_driving_process`, not on a foreign edge from a structural placeholder. The model reads as the system that exists.
+2. `temporal_evolution_factors` with `reference="consumer"` evaluates at `c_i` directly — vintage locking is the natural reading, not a thing one has to argue for.
+
+The output-edge TD is a *first-class temporal modifier on the production decision*, not a workaround. This is the abstraction we want long-term.
+
+## 5. Required changes
+
+Ordered shallow → deep. Each phase is independently testable and ships value on its own.
+
+### Phase 0 — unblock `bw_graph_tools` on NumPy 2
+
+**Type:** upstream / dependency hygiene. Not strictly part of this plan, but blocks anyone trying explicit graphs today.
+
+- Either pin `bw_graph_tools` to a version known to work, or upstream a one-line patch replacing `np.in1d` with `np.isin` in `bw_graph_tools/matrix_tools.py:132` (and any other call sites). The latter is preferable.
+- No new test in `bw_timex` until phase 1 is in; the failure mode is masked by an `AttributeError` on import paths users don't normally hit.
+
+### Phase 1 — replace chimaera-only production-amount lookups with a paradigm-aware helper
+
+**Files:** `bw_timex/edge_extractor.py`, `bw_timex/matrix_modifier.py`.
+**Effort:** ~half a day, mostly mechanical.
+**User-visible behaviour:** static LCAs over explicit graphs (single-product processes only) start to produce sensible *base_lca* results inside `TimexLCA`, even before any traversal changes. Multi-output / cohort-TD use cases still won't work; that's later phases.
+
+Add one helper:
+
+```python
+# bw_timex/utils.py (new function)
+def get_reference_product_production_amount(node, *, reference_product=None):
+    """Return the production amount for `node`'s reference product, paradigm-agnostic.
+
+    - chimaera (`processwithreferenceproduct`): self-loop production exchange amount.
+    - explicit `process`: amount of the production-typed output edge into the
+      requested `reference_product` (or, if the process has exactly one
+      production output, that one).
+    - explicit `product`: production amount of the producing process for this
+      product; raises if multiple producers exist (caller must disambiguate).
+    - `IOTableActivity`: existing branch, kept.
+    """
+```
+
+Replace these call sites with the helper (preserving the existing `IOTableActivity` special-case):
+
+- `edge_extractor.py:178` (priority traversal) — `node.reference_product_production_amount`
+- `edge_extractor.py:447` (BFS traversal, `_get_production_amount`) — `tech_matrix[product_idx, col_idx]`
+- `matrix_modifier.py:223` (FU branch)
+- `matrix_modifier.py:236, 324` (general branches)
+
+`_get_technosphere_inputs` (`edge_extractor.py:390`) needs to learn about explicit nodes too: for an explicit `process` column, the *output* row carries a positive amount and is **not** an input. The current `if row_idx == product_idx: continue` heuristic must be generalised to "skip any row connected by a `type="production"` exchange to this column," not "skip the diagonal."
+
+**Tests to add (`tests/test_explicit_paradigm.py`):**
+
+- A four-node fixture: one explicit `process` + `product` pair in the foreground and one chimaera background process. Static `TimexLCA(...).base_lca.score` matches `bw2calc.LCA(...).score`.
+- A multi-output process fixture (one process, two products with different output amounts) where the FU asks for product A and product B respectively. Each demand gives the correct static score; the helper picks the right `α` per product.
+
+### Phase 2 — bipartite supply-chain traversal
+
+**Files:** `bw_timex/edge_extractor.py` (priority + BFS variants); coordinated with `bw_temporalis` if the change is upstreamed.
+**Effort:** several days. The substantive work in this plan.
+**User-visible behaviour:** explicit graphs produce non-trivial timelines; supply chain is fully walked; demand-timing is populated.
+
+The traversal needs three concrete behaviours added:
+
+1. **From a Product node, find producing Process(es).** Look up the product's row in the tech matrix; for each negative entry (sign convention: production rows are negative in BW), the column index is a producing process. Most foregrounds will have exactly one producer per product; the API needs to handle (and warn? error? attribute-resolve?) the multi-producer case, mirroring how `bw2calc` does activity selection. *Open question — see §7.*
+2. **From a Process node, walk both directions.** Output edges (`type="production"`, the off-diagonal positive entries in the process column) carry the production amount and may carry a `temporal_distribution`. Input edges (`type="technosphere"`, off-diagonal negative entries) are the existing case. The `Edge` dataclass already has `edge_type`; the convolution needs to fire correctly for *both* directions.
+3. **Timeline rows for output edges.** Today only one synthetic FU edge has `edge_type="production"` (the placeholder created in `edge_extractor.py:431`). Real production output edges need their own rows in the timeline, with `producer = product_id`, `consumer = process_id`, and `td_producer` carrying the cohort TD. Downstream input rows then inherit `abs_td_consumer` from this row's `abs_td_producer`, exactly as they inherit from technosphere rows today.
+
+Two variants need parallel changes (the priority `EdgeExtractor` inheriting from `TemporalisLCA`, and the BFS `EdgeExtractorBFS`). Either keep the variants in step manually (current convention) or refactor the shared logic into a paradigm-aware mixin first; we recommend the latter, in a small refactor PR before Phase 2's main work.
+
+Recommended approach for *where* the bipartite walk lives:
+
+- **Preferred — push it upstream into `bw_graph_tools`/`bw_temporalis`.** Both libraries already have to detect explicit production exchanges (`bw_graph_tools.matrix_tools.guess_production_exchanges`); extending that detection to drive the traversal is in-scope upstream and benefits other consumers. `bw_timex` then receives the correctly-walked edge graph and only needs Phase 3 work below.
+- **Fallback — pre-process in `bw_timex`.** Before invoking `TemporalisLCA`, synthesise a chimaera-shaped view of the technosphere (one virtual chimaera per `(process, product)` pair, inputs union'd from the process's input edges, self-loop production amount equal to the output edge's `α`). The TD on the output edge becomes a TD on the synthetic self-loop — but production-self-loop TDs are silently ignored today (see §6, *known footgun*), so this fallback only buys backward-compat for *static* explicit graphs, not the cohort-injection use case. Therefore: viable as a stopgap for Phase 1 testing only.
+
+**Tests to add:**
+
+- The repro from §3: explicit `fleet_driving_process / fleet_driving_product` with cohort TD on the output edge and age TD on the electricity input. Timeline has the expected `cohort × age` row count; per-row dates and amounts match the `cohort_TD ⊛ age_TD` convolution; `date_consumer` of every input row is the cohort year.
+- Same fixture as Phase 1 multi-output; assert that the timeline correctly attributes inputs across products by output coefficient.
+- Direct port of the cohort+age fleet model (the `fleet_service` notebook), refactored to explicit paradigm. Total static and dynamic scores match the chimaera version within numerical tolerance.
+
+### Phase 3 — honour TDs on production-typed output edges
+
+**Files:** `bw_timex/edge_extractor.py` (convolution), `bw_timex/matrix_modifier.py`, `bw_timex/timeline_builder.py`.
+**Effort:** smaller than Phase 2 if the traversal is correct; the math is a sign-flip away from the input case. Mostly tests + matrix-side correctness.
+
+Once Phase 2 produces timeline rows for production output edges, the matrix-modifier layer needs to interpret `temporal_distribution` on them correctly:
+
+- The output edge's role in the matrix is to set the production coefficient `α` at the time-mapped process instance. The time mapping must place one process column per cohort year, each with its own `α` (potentially equal, since the TD weights normalise to 1). The cohort-share scaling enters through the `td_producer.amount` on the output row.
+- `temporal_evolution_factors` semantics: `reference="producer"` evaluates at the production calendar date (cohort year, since that's when the process is invoked). `reference="consumer"` evaluates at the consumer (the FU, in our use case) date. For most cohort use cases the relevant reference is `consumer`, applied via the *input* edge from the process to a downstream product — same as today. Output-edge `temporal_evolution_factors` would represent something like "how the act of producing changes over time" — semantically valid but rare; we should support it but it's a niche.
+
+**Tests:** vintage-locked efficiency test on the explicit fleet model, mirroring the existing isolation test in the notebook. Verify the per-cohort-year electricity factor lands at the right rows.
+
+### Phase 4 — surface the abstraction and clean up
+
+**Files:** `bw_timex/utils.py` (`add_temporal_distribution_to_exchange`), `bw_timex/validation.py`, `docs/`.
+**Effort:** half a day.
+
+- Add explicit checks in `add_temporal_distribution_to_exchange` that warn if a TD is being attached to a chimaera self-production edge: under the current implementation it is *silently ignored* (this is the §6 footgun). The same TD on an explicit `process → product` output edge **does** fire after Phases 1-3 — message should explain the difference.
+- Add a "Modeling paradigms and TD placement" section to the docs decision tree (`docs/content/decisiontree.md`) covering the three patterns explored in the fleet notebook (intermediary, self-loop, explicit) and which one to use when.
+- Optional but valuable: support `TemporalDistribution` as an FU-dict value (`{product: TD(1)}`) by translating it into a synthetic intermediary at construction time. Closes the "inject a cohort TD without restructuring the foreground" gap. Validation currently rejects it (`validation.py`); change to accept and dispatch to the synthesizer.
+
+## 6. Known footgun: silent ignore of TDs on chimaera production self-loops
+
+Independent of explicit-node support, the chimaera paradigm has a quiet failure mode that we should fix in passing.
+
+A `temporal_distribution` set on a chimaera's self-production exchange (`fleet_driving → fleet_driving`, `type="production"`) is silently dropped by the traversal — `edge_mapping[node.unique_id]` only includes consumption edges into the node, not the diagonal self-loop. Empirically:
+
+| Variant | Outcome |
+| --- | --- |
+| Cohort TD on `fleet_service → fleet_driving` (intermediary) | Honoured. 13 timeline rows. |
+| Cohort TD on `fleet_driving → fleet_driving` (self-loop) | Silently ignored. 4 timeline rows. Wrong dynamic timing; *correct static total* by accident. |
+| Cohort TD as `{fleet_driving: TD(1)}` in FU dict | `ValidationError: demand values must be numeric`. |
+
+The static total being correct masks the bug — a user doing development with `tlca.static_score` will see the expected number, only finding the problem later when `dynamic_lcia` or `temporal_evolution_reference="consumer"` reveals the missing cohort spread.
+
+Recommended fix in Phase 4:
+
+- `bw_timex/utils.py:add_temporal_distribution_to_exchange` — if the target is a chimaera's production self-loop, raise a `NotImplementedError` (or warn loudly) pointing the user at the intermediary or explicit pattern.
+- `bw_timex/validation.py` — same check via the structured-input validator path.
+
+Doing this without explicit-paradigm support is fine: the warning still applies once explicit support lands (the explicit *output* edge is a different beast and remains valid).
+
+## 7. Open design questions
+
+These need a decision before Phase 2 ships and should be collected into the issue when filed.
+
+1. **Multi-producer products.** When a foreground product has more than one producing process (e.g., `electricity_product` produced by both gas and wind processes in the foreground), how does `bw_timex` resolve the producer for traversal? Options:
+   - Replicate `bw2calc` behaviour (which uses `dicts.product` to pick by `(database, code)` mapping; in practice ambiguity is rare because foreground graphs are usually injective).
+   - Aggregate via temporal-market-shares (analogous to the existing background interpolation code). This is the more powerful answer but requires a foreground-side market-share concept that doesn't exist today.
+2. **Co-products.** A single process with multiple output edges (each carrying its own `α` and possibly its own TD). Each TD must be honoured per-product, which means per-product time-mapping of the *same* process column. Doable but it complicates `activity_time_mapping` (today: one entry per `(activity, time)`; needed: one per `(activity, product, time)`).
+3. **TD type compatibility.** Should we constrain `temporal_distribution` on production output edges to *datetime* TDs (so the cohort dimension is calendar-time) versus *timedelta* TDs (relative to the consumer)? The current code accepts both forms; for cohort use cases datetime TDs are usually wanted, but enforcing it would complicate the FU-relative anchoring.
+4. **Backward compatibility.** Phases 1-3 should be additive — chimaera workflows must continue to work exactly as they do today. The Phase 4 footgun fix changes one previously-silent path into a loud failure. Should it be opt-in via a config flag for one minor version, or hard-error immediately?
+
+## 8. Out of scope
+
+- **Substitution exchanges (`type="substitution"`)** beyond what's already supported. The convolution math is the same, but interaction with co-products + TDs deserves its own design pass.
+- **Non-foreground explicit graphs.** Background databases can be in either paradigm independently of the foreground; this plan implicitly assumes the foreground is the explicit one. Phase 1's helper should still work on background nodes (it's paradigm-agnostic by design), but full traversal of explicit *backgrounds* is not a goal here — backgrounds are leaves and are not traversed beyond temporal-market-share lookup.
+- **`prospective_*` waterfall plumbing.** The fleet notebook's prospective comparison (`example_electric_vehicle_fleet.ipynb`, cell 74) walks `fleet_driving.technosphere()` and copies activities. This walk needs to be paradigm-aware too, but is a notebook concern more than a `bw_timex` API concern — leave for a notebook update once Phases 1-3 are usable.
+
+## 9. Estimated total effort
+
+| Phase | Effort | Risk |
+| --- | --- | --- |
+| 0 — `np.in1d` upstream patch | <1h | None |
+| 1 — paradigm-aware production-amount helper | 0.5d | Low |
+| 2 — bipartite traversal | 3-5d | Medium-high (touches upstream `bw_graph_tools` / `bw_temporalis`) |
+| 3 — honour TDs on output edges | 1-2d | Medium |
+| 4 — surface + footgun fix + docs | 0.5d | Low |
+
+Total: roughly one to two weeks of focused work, plus review cycles. Phase 1 is a sensible first PR; it ships small visible value (static scoring works on explicit graphs) and forces the helper abstraction that Phases 2-3 will lean on.
+
+## 10. References
+
+- `notebooks/example_electric_vehicle_fleet.ipynb` — current fleet model using the chimaera + intermediary pattern.
+- `bw2data/configuration.py` — node-type taxonomy.
+- `bw_graph_tools/matrix_tools.py` — production-exchange detection heuristics.
+- `bw_temporalis/lca.py:115` — supply-chain traversal entry point.
+- Empirical scripts used during this analysis (kept under `/tmp/` during exploration; reproduce by setting up a minimal explicit-paradigm foreground and demanding the product as FU).

--- a/docs/content/getting_started/adding_temporal_information.md
+++ b/docs/content/getting_started/adding_temporal_information.md
@@ -104,6 +104,19 @@ bd.Method(("our", "method")).write(
 
 Now, if you want to consider time in your LCA, you need to somehow add temporal information. For time-explicit LCA, we consider two kinds of temporal information, that will be discussed in the following.
 
+:::{note}
+Brightway can represent inventory data either with separate process and product nodes or with
+chimaera process+product nodes. See the Brightway inventory overview on
+[processes, products, and something in between](https://docs.brightway.dev/en/latest/content/overview/inventory.html#processes-products-and-something-in-between).
+
+This getting-started page uses the common chimaera style, where Process A is also its reference
+product. The temporal concepts below also apply to explicit process/product models; the main
+difference is where output-side timing can be attached. If you want to represent several
+production-time groups of the same product, you can do this in either paradigm. In a chimaera
+model, this timing is often represented with an intermediary foreground edge. In an explicit
+model, it can live directly on the process→product production edge.
+:::
+
 ## Temporal distributions
 To determine the timing of the exchanges within the production system, we add the `temporal_distribution` attribute to the respective exchanges. To carry the temporal information, we use the [`TemporalDistribution`](https://docs.brightway.dev/projects/bw-temporalis/en/stable/content/api/bw_temporalis/temporal_distribution/index.html#bw_temporalis.temporal_distribution.TemporalDistribution) class from [`bw_temporalis`](https://github.com/brightway-lca/bw_temporalis). This class is a *container for a series of amount spread over time*, so it tells you what share of an exchange happens at what point in time. So, let's include this information in our production system - first visually:
 ```{mermaid}
@@ -287,7 +300,59 @@ exchange["temporal_evolution_amounts"] = {
 }
 ```
 
-For dates between the specified points, values are linearly interpolated. For dates outside the range, the nearest boundary value is used. You can specify either `temporal_evolution_amounts` or `temporal_evolution_amounts` for the same exchange, but not both.
+For dates between the specified points, values are linearly interpolated. For dates outside the range, the nearest boundary value is used. You can specify either `temporal_evolution_factors` or `temporal_evolution_amounts` for the same exchange, but not both.
+
+This mechanism can represent **production-version-specific efficiency** if the exchange is
+evaluated at the timestamp of the process/product version. Here, "version" means the production or
+design date that fixes a foreground exchange amount. This fixed production/design date is often
+called a **vintage**. For example, with factors `{2025: 1.0, 2030: 1.1}`, a unit produced in
+2025 uses the 2025 vintage factor and a unit produced in 2030 uses the 2030 vintage factor (with
+interpolation in-between). If a single foreground exchange represents a mixed fleet over multiple
+production years, that one exchange still has just one amount at each event time; to model distinct
+production-time groups explicitly, create separate exchanges or processes for each group (e.g.,
+EV_2025, EV_2030) and assign their temporal distributions accordingly.
+
+### Choosing `temporal_evolution_reference`
+
+Temporal evolution factors need a timestamp. In a time-explicit foreground exchange, `bw_timex` can carry two relevant timestamps:
+
+- `date_consumer`: when the consuming foreground process instance exists. If the model splits a
+  product into production-time groups, read this as the **process/product version date** of the
+  process using the exchange. In fleet and stock models, this is usually the **vintage**.
+- `date_producer`: when the exchanged input/output event actually happens. Read this as the **calendar event date** of the exchange.
+
+Use `temporal_evolution_reference="consumer"` when the exchange amount is a property of the
+consuming process or product version. The factor is locked to `date_consumer`.
+
+Examples:
+
+- A vehicle built in 2025 keeps its 2025 electricity consumption per km when it drives in 2035.
+- A building built in 2020 keeps its 2020 insulation standard during later operation.
+- A 2030 production line needs less material because of its design, and keeps that efficiency for all later maintenance or use-phase exchanges.
+
+Use `temporal_evolution_reference="producer"` when the exchange amount is a property of the calendar year in which the exchange happens. The factor follows `date_producer`.
+
+Examples:
+
+- A maintenance operation uses less solvent in 2035 because maintenance practice improved by then, regardless of when the serviced asset was built.
+- A foreground repair process becomes more efficient over calendar time.
+- A foreground input is reduced by a retrofit or operational learning that applies to all active product/process versions in that year.
+
+Rule of thumb:
+
+```text
+Is the change a property of the foreground process/product version date?
+-> use consumer
+
+Is the change a property of the calendar year when the exchange happens?
+-> use producer
+```
+
+This choice is independent of whether you model with chimaera nodes or explicit process/product
+nodes. Explicit process/product models can make the distinction easier to see because a product can
+have a production-edge temporal distribution, creating clear product/process version dates. Chimaera
+models can represent the same idea by adding a foreground intermediary activity whose exchange
+creates those version dates.
 
 A convenience function is available to add temporal evolution to an existing exchange:
 
@@ -299,6 +364,7 @@ add_temporal_evolution_to_exchange(
         datetime(2020, 1, 1): 1.0,
         datetime(2030, 1, 1): 0.75,
     },
+    temporal_evolution_reference="consumer",
     input_code="B",
     input_database="background",
     output_code="A",

--- a/docs/content/theory.md
+++ b/docs/content/theory.md
@@ -116,6 +116,39 @@ of the exchange.
 
 
 
+### Traversing into background databases (`traverse_background`)
+
+By default the graph traversal stops at the boundary between the foreground and
+background systems: background databases are treated as static, and temporal
+distributions on their internal exchanges are ignored. Setting
+``traverse_background=True`` in ``build_timeline`` lifts this restriction.
+
+When enabled, the traversal descends into background databases (bounded by
+``cutoff`` and ``max_calc``). Exchanges inside background databases that carry a
+``temporal_distribution`` are honored: time-spread flows are sourced from the
+temporally-appropriate background-db variant — reading that variant's own
+exchanges, amounts, and temporal distributions.
+
+**Graph-traversal engine behavior under ``traverse_background=True``:**
+
+- With ``graph_traversal='bfs'`` (breadth-first search): all variant subtrees
+  are explored in standard BFS order.
+- With ``graph_traversal='priority'`` (the default): non-referenced background
+  variants are **not** placed on the priority heap. Each variant's subtree is
+  instead walked in full via proxy reads when the parent edge is reached. The
+  referenced-system heap exploration order is unchanged and explored amounts are
+  exact (identical to ``graph_traversal='bfs'`` for those subtrees). A one-time
+  warning is emitted when this combination is used.
+
+```{note}
+**Known limitation:** if a background process that has further background
+technosphere inputs is reached at *more than one cohort date* — for example
+via a foreground ``temporal_distribution`` feeding into a non-leaf background
+activity — the variant split raises ``NotImplementedError``. This
+multi-date-consumer case fails loudly and only occurs under
+``traverse_background=True``.
+```
+
 ## Temporal evolution in the foreground system
 `bw_timex` (>0.3.4) allows you to also implement time-dependent modifications to the foreground exchanges. This optional feature is useful if you want to simulate changes in the foreground system over time, such as technological learning, efficiency improvements or changing market structures. Such changes are not covered by the linking to time-specific background processes. 
 

--- a/docs/content/theory.md
+++ b/docs/content/theory.md
@@ -140,14 +140,9 @@ exchanges, amounts, and temporal distributions.
   exact (identical to ``graph_traversal='bfs'`` for those subtrees). A one-time
   warning is emitted when this combination is used.
 
-```{note}
-**Known limitation:** if a background process that has further background
-technosphere inputs is reached at *more than one cohort date* — for example
-via a foreground ``temporal_distribution`` feeding into a non-leaf background
-activity — the variant split raises ``NotImplementedError``. This
-multi-date-consumer case fails loudly and only occurs under
-``traverse_background=True``.
-```
+A background process reached at several cohort dates (for example via a foreground
+``temporal_distribution`` feeding into a non-leaf background activity) is split per
+consumer cohort, so multi-date consumers are routed correctly.
 
 ## Temporal evolution in the foreground system
 `bw_timex` (>0.3.4) allows you to also implement time-dependent modifications to the foreground exchanges. This optional feature is useful if you want to simulate changes in the foreground system over time, such as technological learning, efficiency improvements or changing market structures. Such changes are not covered by the linking to time-specific background processes. 

--- a/docs/superpowers/plans/2026-06-19-background-temporal-distributions.md
+++ b/docs/superpowers/plans/2026-06-19-background-temporal-distributions.md
@@ -570,6 +570,22 @@ git commit -m "BFS: descend into background under traverse_background (no-TD equ
 
 ---
 
+> **COURSE CORRECTION (2026-06-19, after Task 4).** During Task 5 we verified that
+> Tasks 3+4 ALREADY route a background TD whose endpoint is a *leaf* (e.g. the
+> emission-only `bg_B` in the shallow `background_td_db` fixture) to the correct
+> variants — referenced-variant TD propagation spreads the flow in time and the
+> existing leaf `temporal_market_shares` interpolation routes each cohort to the
+> right variant by date. The genuinely new work (respective-variant lookup) only
+> matters for **deeper** chains: when descent continues *into* a background process
+> reached at a shifted date routing to a NON-referenced variant. Tasks 5–7 below are
+> therefore executed against a NEW deeper fixture `background_td_deep_db`
+> (`bg_A→bg_B→bg_C`, with `bg_B→bg_C` differing per variant) and the corrected,
+> self-contained briefs in `.git/sdd/task-5-brief.md`, `task-6-brief.md`,
+> `task-7-brief.md`. The numeric expectations and exact code in those briefs
+> supersede the original Task 5–7 text below where they differ. The shallow
+> `background_td_db` fixture and its leaf-routing behavior remain valid and are kept
+> as regression coverage.
+
 ### Task 5: BFS variant-aware split at background entry + TD edges
 
 Make the BFS descent split a producer into its date-interpolated variants at background entry and at TD-carrying edges, reading each branch's exchanges/amounts/TDs from the respective variant db. This is the core feature: a background TD spreads its downstream flow across variants.

--- a/docs/superpowers/plans/2026-06-19-background-temporal-distributions.md
+++ b/docs/superpowers/plans/2026-06-19-background-temporal-distributions.md
@@ -1,0 +1,1096 @@
+# Background Temporal Distributions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let temporal distributions defined on exchanges *inside* background databases take effect, by optionally descending into the background during traversal and sourcing time-spread flows from the temporally-appropriate background-db variants.
+
+**Architecture:** A new opt-in flag `traverse_background` on `TimexLCA.build_timeline` removes the static-background traversal stop. When set, both the priority (`EdgeExtractor`) and BFS (`EdgeExtractorBFS`) traversals descend into background dbs, propagate background TDs by convolution, and at background-entry + TD-carrying edges split a producer into its date-interpolated variants — reading each branch's exchanges/amounts/TDs from the *respective* variant db (via `interdatabase_activity_mapping` + bw2data). Downstream, the temporal-market-vs-temporalized decision keys on the presence of `temporal_market_shares` (leaf ⇒ market) instead of database membership, so traversed background processes are temporalized rather than double-counted.
+
+**Tech Stack:** Python, bw2data, bw2calc, bw_temporalis, numpy, pandas, pydantic, pytest.
+
+## Global Constraints
+
+- Default behavior MUST be unchanged: `traverse_background=False` is the default and every existing test must keep passing.
+- TDD: write the failing test first, confirm it fails, then implement. (Project rule.)
+- No Claude attribution in commit messages; no `Co-Authored-By` trailer. (Project rule.)
+- Do not filter or mention the bw2calc scikit-umfpack `UserWarning`. (Project rule.)
+- Both `graph_traversal="priority"` and `graph_traversal="bfs"` must support `traverse_background`.
+- The `interpolation_type` values are `"linear"` and `"nearest"` (`"closest"` normalizes to `"nearest"`).
+- Run a single test with: `pytest tests/<file>::<test> -v` (use `-p no:cacheprovider` not required).
+
+---
+
+### Task 1: Plumb the `traverse_background` flag (no behavior change)
+
+Adds the flag to validation, `build_timeline`, `TimelineBuilder`, and both extractor constructors. The flag is accepted and stored but not yet used, so behavior is identical.
+
+**Files:**
+- Modify: `bw_timex/validation.py:89-100` (`BuildTimelineInputs`)
+- Modify: `bw_timex/timex_lca.py:205-346` (`TimexLCA.build_timeline`)
+- Modify: `bw_timex/timeline_builder.py:30-128` (`TimelineBuilder.__init__`)
+- Modify: `bw_timex/edge_extractor.py:88-112` (`EdgeExtractor.__init__`)
+- Modify: `bw_timex/edge_extractor.py:381-411` (`EdgeExtractorBFS.__init__`)
+- Test: `tests/test_timeline_builder.py`
+
+**Interfaces:**
+- Produces: `TimexLCA.build_timeline(..., traverse_background: bool = False)`; `TimelineBuilder(..., traverse_background: bool = False)`; `EdgeExtractor(..., traverse_background: bool = False)`; `EdgeExtractorBFS(..., traverse_background: bool = False)`. Each stores `self.traverse_background`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_timeline_builder.py` (use the existing `process_at_base_database_time_db` fixture already imported via conftest):
+
+```python
+def test_traverse_background_flag_accepted_and_stored(process_at_base_database_time_db):
+    from bw_timex import TimexLCA
+
+    method = ("GWP", "example")
+    database_dates = {
+        "background_2020": datetime.strptime("2020", "%Y"),
+        "background_2030": datetime.strptime("2030", "%Y"),
+        "foreground": "dynamic",
+    }
+    tlca = TimexLCA({("foreground", "fu"): 1}, method, database_dates)
+    tlca.build_timeline(starting_datetime="2024-01-01", traverse_background=False)
+    assert tlca.timeline_builder.traverse_background is False
+```
+
+Ensure `from datetime import datetime` is present at the top of the test file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_timeline_builder.py::test_traverse_background_flag_accepted_and_stored -v`
+Expected: FAIL — `build_timeline() got an unexpected keyword argument 'traverse_background'`.
+
+- [ ] **Step 3: Implement the plumbing**
+
+In `bw_timex/validation.py`, add to `BuildTimelineInputs` (after `graph_traversal`):
+
+```python
+    traverse_background: bool = False
+```
+
+In `bw_timex/timex_lca.py` `build_timeline` signature (after `graph_traversal: str = "priority",`):
+
+```python
+        traverse_background: bool = False,
+```
+
+Pass it into the validator call:
+
+```python
+        validated = BuildTimelineInputs(
+            starting_datetime=starting_datetime,
+            temporal_grouping=temporal_grouping,
+            interpolation_type=interpolation_type,
+            edge_filter_function=edge_filter_function,
+            cutoff=cutoff,
+            max_calc=max_calc,
+            graph_traversal=graph_traversal,
+            traverse_background=traverse_background,
+        )
+```
+
+Add `traverse_background` to the `timeline_cache_key` tuple (so a changed flag invalidates the cache):
+
+```python
+        timeline_cache_key = (
+            str(validated.starting_datetime),
+            temporal_grouping,
+            interpolation_type,
+            cutoff,
+            max_calc,
+            graph_traversal,
+            traverse_background,
+        )
+```
+
+Pass it to the `TimelineBuilder(...)` construction (add as a keyword near `graph_traversal=graph_traversal,`):
+
+```python
+            graph_traversal=graph_traversal,
+            traverse_background=traverse_background,
+```
+
+In `bw_timex/timeline_builder.py` `TimelineBuilder.__init__`, add `traverse_background: bool = False,` to the signature (before `*args,`) and store `self.traverse_background = traverse_background` near the other `self.* =` assignments. Pass it into BOTH extractor constructions:
+
+```python
+        if graph_traversal == "bfs":
+            self.edge_extractor = EdgeExtractorBFS(
+                lca_object=base_lca,
+                starting_datetime=self.starting_datetime,
+                edge_filter_function=edge_filter_function,
+                cutoff=self.cutoff,
+                static_activity_indices=set(static_background_activity_ids),
+                nodes=self.nodes,
+                traverse_background=self.traverse_background,
+            )
+        elif graph_traversal == "priority":
+            self.edge_extractor = EdgeExtractor(
+                base_lca,
+                starting_datetime=self.starting_datetime,
+                *args,
+                edge_filter_function=edge_filter_function,
+                cutoff=self.cutoff,
+                max_calc=self.max_calc,
+                static_activity_indices=set(static_background_activity_ids),
+                traverse_background=self.traverse_background,
+                **kwargs,
+            )
+```
+
+In `bw_timex/edge_extractor.py` `EdgeExtractor.__init__`, accept and store the flag without passing it to `super().__init__` (TemporalisLCA does not know it):
+
+```python
+    def __init__(
+        self, *args, edge_filter_function: Callable = None,
+        traverse_background: bool = False, **kwargs
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.traverse_background = traverse_background
+        if edge_filter_function:
+            self.edge_ff = edge_filter_function
+        else:
+            self.edge_ff = lambda x: False
+```
+
+In `bw_timex/edge_extractor.py` `EdgeExtractorBFS.__init__`, add `traverse_background: bool = False,` to the signature and store `self.traverse_background = traverse_background`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_timeline_builder.py::test_traverse_background_flag_accepted_and_stored -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite to confirm no regression**
+
+Run: `pytest -q`
+Expected: all pass (flag is unused).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bw_timex/validation.py bw_timex/timex_lca.py bw_timex/timeline_builder.py bw_timex/edge_extractor.py tests/test_timeline_builder.py
+git commit -m "Add traverse_background flag plumbing"
+```
+
+---
+
+### Task 2: Background-chain multi-variant test fixture
+
+A fixture with a two-step background chain (`bg_A → bg_B`) in two dated variants, with a `temporal_distribution` on the `bg_A → bg_B` exchange. Used by all later behavior tests.
+
+**Files:**
+- Create: `tests/fixtures/background_td_db_fixture.py`
+- Modify: `tests/conftest.py:1-19` (add import)
+
+**Interfaces:**
+- Produces: pytest fixture `background_td_db`. Databases: `foreground`, `background_2020`, `background_2030`, `biosphere`. Activities: `fu` (foreground) → `bg_A` (background_2020, "electricity"-like, amount 2) ; `bg_A` → `bg_B` ("fuel"-like, amount 5) with a TD; `bg_B` → 1 kg CO2. Both variants identical except `bg_A→bg_B` amount and TD may differ. Method `("GWP", "example")`, CF CO2 = 1.
+
+- [ ] **Step 1: Write the fixture (this IS the deliverable; its "test" is being importable + usable)**
+
+Create `tests/fixtures/background_td_db_fixture.py`:
+
+```python
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def background_td_db():
+    """foreground.fu -> background.bg_A -> background.bg_B -> CO2.
+
+    Two dated background variants (2020, 2030). The bg_A -> bg_B exchange
+    carries a temporal_distribution so that, when traversed, bg_B is spread
+    over time and sourced from the temporally-appropriate variant.
+    """
+    biosphere = bd.Database("biosphere")
+    biosphere.write(
+        {
+            ("biosphere", "CO2"): {"type": "emission", "name": "carbon dioxide"},
+        }
+    )
+    node_co2 = biosphere.get("CO2")
+
+    foreground = bd.Database("foreground")
+    foreground.register()
+
+    background_2020 = bd.Database("background_2020")
+    background_2020.register()
+    background_2030 = bd.Database("background_2030")
+    background_2030.register()
+
+    # --- foreground ---
+    fu = foreground.new_node("fu", name="fu", unit="unit")
+    fu["reference product"] = "fu"
+    fu.save()
+    fu.new_edge(input=fu, amount=1, type="production").save()
+
+    # --- build both background variants identically (structure) ---
+    # bg_A -> bg_B TD: spread 60% at +0y, 40% at +10y from bg_A's time.
+    td_a_to_b = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+
+    variant_nodes = {}
+    for db, dbname in [(background_2020, "background_2020"), (background_2030, "background_2030")]:
+        bg_a = db.new_node("bg_A", name="bg_A", unit="kWh")
+        bg_a["reference product"] = "bg_A"
+        bg_a.save()
+        bg_b = db.new_node("bg_B", name="bg_B", unit="kg")
+        bg_b["reference product"] = "bg_B"
+        bg_b.save()
+
+        bg_a.new_edge(input=bg_a, amount=1, type="production").save()
+        bg_b.new_edge(input=bg_b, amount=1, type="production").save()
+
+        a_to_b = bg_a.new_edge(input=bg_b, amount=5, type="technosphere")
+        a_to_b["temporal_distribution"] = td_a_to_b
+        a_to_b.save()
+
+        bg_b.new_edge(input=node_co2, amount=1, type="biosphere").save()
+        variant_nodes[dbname] = (bg_a, bg_b)
+
+    # --- foreground -> background_2020.bg_A ---
+    bg_a_2020 = variant_nodes["background_2020"][0]
+    fu.new_edge(input=bg_a_2020, amount=2, type="technosphere").save()
+
+    bd.Method(("GWP", "example")).write([(("biosphere", "CO2"), 1)])
+
+    for dbn in bd.databases:
+        bd.Database(dbn).process()
+
+    return variant_nodes
+```
+
+- [ ] **Step 2: Register the fixture**
+
+In `tests/conftest.py`, add after the other fixture imports:
+
+```python
+from .fixtures.background_td_db_fixture import background_td_db
+```
+
+- [ ] **Step 3: Write a smoke test that the fixture loads and a static TimexLCA runs**
+
+Create `tests/test_background_traversal.py`:
+
+```python
+from datetime import datetime
+
+import bw2data as bd
+
+from bw_timex import TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+
+
+def test_fixture_loads(background_td_db):
+    assert "background_2020" in bd.databases
+    assert "background_2030" in bd.databases
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2024-01-01", traverse_background=False)
+    tlca.lci()
+    tlca.static_lca.lcia()
+    assert tlca.static_lca.score > 0
+```
+
+- [ ] **Step 4: Run the smoke test**
+
+Run: `pytest tests/test_background_traversal.py::test_fixture_loads -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/background_td_db_fixture.py tests/conftest.py tests/test_background_traversal.py
+git commit -m "Add background-chain multi-variant test fixture"
+```
+
+---
+
+### Task 3: Key temporal-market classification on `temporal_market_shares`, not db membership
+
+Switch the three places that decide "temporal market vs temporalized" from database membership to the presence of `temporal_market_shares`. In `traverse_background=False` mode the two are equivalent, so this is behavior-preserving and unlocks correct handling of traversed background processes later.
+
+**Files:**
+- Modify: `bw_timex/matrix_modifier.py:271-315` (`process_edge` branch)
+- Modify: `bw_timex/timex_lca.py:1452-1468` (`collect_temporalized_processes_from_timeline`)
+- Test: `tests/test_background_traversal.py`
+
+**Interfaces:**
+- Consumes: timeline rows with column `temporal_market_shares` (dict or `None`), from Task 1.
+- Produces: classification rule "row is a temporal market iff `row.temporal_market_shares` is truthy".
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_background_traversal.py`:
+
+```python
+def test_classification_keys_on_shares_not_db(background_td_db):
+    """With traverse_background=False, results are unchanged by the refactor."""
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2024-01-01", traverse_background=False)
+    tlca.lci()
+    tlca.dynamic_lcia(metric="GWP")  # or whichever LCIA the suite uses
+    # bg_A is the only first-level background producer -> exactly one temporal market.
+    assert len(tlca.node_collections["temporal_markets"]) == 1
+```
+
+(If `dynamic_lcia` requires extra args in this codebase, replace with `tlca.static_lca.lcia()` after `tlca.lci()`; the assertion on `node_collections["temporal_markets"]` is the point.)
+
+- [ ] **Step 2: Run test to verify current behavior**
+
+Run: `pytest tests/test_background_traversal.py::test_classification_keys_on_shares_not_db -v`
+Expected: PASS already (sanity baseline). If it errors on `dynamic_lcia` signature, fix the call, re-run until it passes. This pins the invariant the refactor must preserve.
+
+- [ ] **Step 3: Refactor `matrix_modifier.process_edge`**
+
+In `bw_timex/matrix_modifier.py`, change the branch condition (currently `if previous_producer_node["database"] in self.database_dates_static.keys():`) to:
+
+```python
+        # A row is a temporal market iff it carries temporal_market_shares.
+        # Leaf producers (background frontier) carry shares; producers traversed
+        # into (e.g. background processes descended into with traverse_background)
+        # do not, so they are rebuilt as temporalized processes (no double-count).
+        is_temporal_market = bool(getattr(row, "temporal_market_shares", None))
+        if is_temporal_market:
+```
+
+Leave the `else:` temporalized branch as-is.
+
+- [ ] **Step 4: Refactor `collect_temporalized_processes_from_timeline`**
+
+In `bw_timex/timex_lca.py`, replace the db-membership classification loop. Build a set of `time_mapped_producer`s that carry shares from the timeline, then classify:
+
+```python
+        market_time_mapped = set(
+            self.timeline.loc[
+                self.timeline.temporal_market_shares.notnull(),
+                "time_mapped_producer",
+            ]
+        )
+
+        temporal_market_ids = set()
+        temporalized_process_ids = set()
+        for producer, time_mapped_producer in unique_producers:
+            if time_mapped_producer in market_time_mapped:
+                temporal_market_ids.add(time_mapped_producer)
+            else:
+                temporalized_process_ids.add(time_mapped_producer)
+```
+
+- [ ] **Step 5: Run the refactor test + full suite**
+
+Run: `pytest tests/test_background_traversal.py::test_classification_keys_on_shares_not_db -v`
+Expected: PASS.
+Run: `pytest -q`
+Expected: all pass (behavior-preserving in `False` mode).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bw_timex/matrix_modifier.py bw_timex/timex_lca.py tests/test_background_traversal.py
+git commit -m "Key temporal-market classification on temporal_market_shares"
+```
+
+---
+
+### Task 4: BFS descent into background (equivalence when no background TDs)
+
+When `traverse_background=True`, the BFS extractor stops excluding background nodes and descends, bounded by `cutoff` and a new `max_calc` guard. `build_timeline` assigns `temporal_market_shares` to leaf producers (not in the consumer set) instead of the hardcoded `first_level_background_static`. This task establishes the descent and the invariant: with **no** background TDs, `traverse_background=True` equals `False`.
+
+**Files:**
+- Modify: `bw_timex/edge_extractor.py:381-714` (`EdgeExtractorBFS`)
+- Modify: `bw_timex/timeline_builder.py:95-128` (static-index gating) and `:422-508` (`add_column_temporal_market_shares_to_timeline`)
+- Test: `tests/test_background_traversal.py`
+
+**Interfaces:**
+- Consumes: `self.traverse_background` (Task 1), classification-on-shares (Task 3).
+- Produces: BFS traversal that descends into background when the flag is set; `EdgeExtractorBFS.__init__` gains `max_calc: int = 1_000_000`. `build_timeline` assigns shares to leaf producers via a new helper `_leaf_background_producers(edges_df)` returning a `set[int]`.
+
+- [ ] **Step 1: Write the failing equivalence test**
+
+Add to `tests/test_background_traversal.py` a helper + test. Use a fixture variant with NO background TD: build it inline by deleting the TD before running.
+
+```python
+import numpy as np
+from bw_temporalis import TemporalDistribution
+
+
+def _strip_background_tds():
+    """Remove the temporal_distribution on every background bg_A->bg_B exchange."""
+    for dbname in ("background_2020", "background_2030"):
+        for act in bd.Database(dbname):
+            for exc in act.technosphere():
+                if "temporal_distribution" in exc:
+                    del exc["temporal_distribution"]
+                    exc.save()
+        bd.Database(dbname).process()
+
+
+def _score(traverse_background):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal="bfs",
+        traverse_background=traverse_background,
+    )
+    tlca.lci()
+    tlca.static_lca.lcia()
+    return tlca.static_lca.score, tlca.timeline
+
+
+def test_bfs_equivalence_without_background_tds(background_td_db):
+    _strip_background_tds()
+    score_static, tl_static = _score(False)
+    score_traverse, tl_traverse = _score(True)
+    assert score_traverse == pytest.approx(score_static, rel=1e-9)
+```
+
+Add `import pytest` at the top of the test file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_background_traversal.py::test_bfs_equivalence_without_background_tds -v`
+Expected: FAIL — with `traverse_background=True` the background is still excluded (flag unused in BFS), so either an exception or a mismatched score. Capture the actual failure.
+
+- [ ] **Step 3: Gate the static exclusion in `TimelineBuilder`**
+
+In `bw_timex/timeline_builder.py`, where `static_background_activity_ids` is computed (lines ~97-101), short-circuit it when traversing:
+
+```python
+        if self.traverse_background:
+            static_background_activity_ids = set()
+        else:
+            static_background_activity_ids = {
+                node_id
+                for node_id in self.node_collections["background"]
+                if node_id not in self.node_collections["first_level_background_static"]
+            }
+```
+
+(Move the assignment of `self.traverse_background` above this block in `__init__`.)
+
+- [ ] **Step 4: Make BFS descend when the flag is set**
+
+In `bw_timex/edge_extractor.py` `EdgeExtractorBFS.__init__`, add `max_calc: int = 1_000_000,` to the signature and `self.max_calc = max_calc`. Initialize a counter `self._calc_count = 0` and, when `traverse_background` is set, neutralize the default leaf filter so background nodes are descended into:
+
+```python
+        if self.traverse_background:
+            # Background is no longer a hard stop; rely on cutoff / max_calc.
+            # A user-supplied edge_filter_function is still respected.
+            if edge_filter_function is None:
+                self.edge_ff = lambda x: False
+```
+
+In `_get_technosphere_inputs`, the `static_activity_indices` set is already empty when traversing (Task 4 Step 3), so deeper background inputs are no longer skipped — no change needed there.
+
+In `build_edge_timeline`, add a `max_calc` guard inside the `while queue:` loop, right after `node_id, td, ... = queue.popleft()`:
+
+```python
+            self._calc_count += 1
+            if self._calc_count > self.max_calc:
+                break
+```
+
+- [ ] **Step 5: Assign `temporal_market_shares` to leaf producers**
+
+In `bw_timex/timeline_builder.py`, add a helper method to `TimelineBuilder`:
+
+```python
+    def _leaf_background_producers(self, edges_df: pd.DataFrame) -> set:
+        """Producers that are leaves (never traversed into) and live in a static
+        background db. These are the temporal-market frontier."""
+        consumers = set(edges_df["consumer"].unique())
+        static_dbs = set(self.database_dates_static.keys())
+        leaves = set()
+        for producer in edges_df["producer"].unique():
+            if producer in consumers:
+                continue  # traversed into -> temporalized, not a market
+            node = self.nodes.get(producer)
+            if node is not None and node["database"] in static_dbs:
+                leaves.add(producer)
+        return leaves
+```
+
+In `add_column_temporal_market_shares_to_timeline`, replace the use of
+`self.node_collections["first_level_background_static"]` with the leaf set when
+traversing. Compute once near the top of the method:
+
+```python
+        if self.traverse_background:
+            market_producers = self._leaf_background_producers(tl_df)
+        else:
+            market_producers = self.node_collections["first_level_background_static"]
+```
+
+Then in the final assignment, use `market_producers` in place of
+`first_level_background_static`:
+
+```python
+        tl_df["temporal_market_shares"] = [
+            remapped_interpolation_weights[producer_date]
+            if producer in market_producers
+            else None
+            for producer, producer_date in zip(tl_df["producer"], tl_df["date_producer"])
+        ]
+```
+
+Note: `add_column_temporal_market_shares_to_timeline` receives `tl_df` after the
+`producer`/`date_producer` columns exist, so `_leaf_background_producers` can read
+them. Confirm `tl_df` has a `consumer` column at that point (it does — see
+`build_timeline` column ordering); if not, pass the pre-grouped frame's consumer
+set in instead.
+
+- [ ] **Step 6: Run the equivalence test**
+
+Run: `pytest tests/test_background_traversal.py::test_bfs_equivalence_without_background_tds -v`
+Expected: PASS — descending with no background TDs reproduces the static result.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `pytest -q`
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add bw_timex/edge_extractor.py bw_timex/timeline_builder.py tests/test_background_traversal.py
+git commit -m "BFS: descend into background under traverse_background (no-TD equivalence)"
+```
+
+---
+
+### Task 5: BFS variant-aware split at background entry + TD edges
+
+Make the BFS descent split a producer into its date-interpolated variants at background entry and at TD-carrying edges, reading each branch's exchanges/amounts/TDs from the respective variant db. This is the core feature: a background TD spreads its downstream flow across variants.
+
+**Files:**
+- Modify: `bw_timex/edge_extractor.py` (`EdgeExtractorBFS.build_edge_timeline` + helpers)
+- Modify: `bw_timex/timex_lca.py` (ensure `interdatabase_activity_mapping` is available to the extractor; see Interfaces)
+- Test: `tests/test_background_traversal.py`
+
+**Interfaces:**
+- Consumes: `interdatabase_activity_mapping` (an `InterDatabaseMapping`, `helper_classes.py:146`) mapping `producer_id -> {db_name: id}`; `database_dates_static` (`dict[str, datetime]`); `self.nodes` (`{id: Activity}`); the interpolation helpers on `TimelineBuilder` (`get_weights_for_interpolation_between_nearest_years`, `find_closest_date`).
+- Produces: timeline `Edge`s whose `producer` is the variant-resolved background node, each carrying the accumulated branch share folded into `td_producer.amount`. Leaves resolve to `{resolved_variant_db: 1}` shares downstream.
+
+**Design note on where the split lives:** The cleanest implementation keeps the *amount scaling* (share) in the convolved `distribution`/`td_producer` and emits one `Edge` per (variant, cohort). The branch's variant determines which db's `bg_B` node id is recorded as the `producer`, so the existing `_leaf_background_producers` + `temporal_market_shares = {db: 1}` path wires each branch to its own variant's static inventory.
+
+- [ ] **Step 1: Write the failing spread test**
+
+Add to `tests/test_background_traversal.py`. Hand-computation for the fixture:
+
+- FU demands 2 units of `bg_A` (background_2020) at 2024.
+- `bg_A → bg_B` amount 5, TD: 60% at +0y (2024), 40% at +10y (2034).
+- So `bg_B` demand = 2 × 5 = 10 kg, split: 6 kg at 2024, 4 kg at 2034.
+- `bg_B → CO2` = 1 kg CO2 / kg. Each kg bg_B ⇒ 1 kg CO2.
+- 2024 lies between variant dates 2020 and 2030 → linear weights {2020: 0.6, 2030: 0.4}.
+- 2034 is above all dates → clamps to nearest variant 2030 → {2030: 1.0}.
+- All variants emit the same 1 kg CO2/kg here, so the **total** CO2 = 10 kg
+  regardless of variant choice, but the **temporal/variant split** differs.
+
+Assert on the timeline's variant routing rather than only total score (total is
+invariant in this symmetric fixture by construction — that is intentional so the
+test isolates routing):
+
+```python
+def test_bfs_background_td_spreads_bg_b_across_variants(background_td_db):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal="bfs",
+        traverse_background=True,
+    )
+    tl = tlca.timeline
+    # bg_B must now appear as a producer at two distinct producer dates (2024 & 2034)
+    bg_b_rows = tl[tl["producer_name"] == "bg_B"]
+    producer_years = sorted({d.year for d in bg_b_rows["date_producer"]})
+    assert producer_years == [2024, 2034]
+    # the 2034 cohort routes entirely to the 2030 variant
+    row_2034 = bg_b_rows[[d.year == 2034 for d in bg_b_rows["date_producer"]]].iloc[0]
+    assert set(row_2034["temporal_market_shares"].keys()) == {"background_2030"}
+    # the summed bg_B amount equals 10 kg (2*5)
+    assert bg_b_rows["amount"].abs().sum() == pytest.approx(10.0, rel=1e-9)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_background_traversal.py::test_bfs_background_td_spreads_bg_b_across_variants -v`
+Expected: FAIL — without variant splitting, `bg_B` appears at a single date / single variant, or the descent reads only the referenced variant.
+
+- [ ] **Step 3: Give the BFS extractor access to interpolation + variant mapping**
+
+In `bw_timex/timeline_builder.py`, after constructing `EdgeExtractorBFS`, hand it the data it needs for variant resolution (these already exist on the builder / are passed in):
+
+```python
+            self.edge_extractor.database_dates_static = self.database_dates_static
+            self.edge_extractor.interdatabase_activity_mapping = (
+                self.interdatabase_activity_mapping
+            )
+            self.edge_extractor.interpolation_type = self.interpolation_type
+```
+
+`TimelineBuilder` must therefore receive `interdatabase_activity_mapping`. It is
+already built on `TimexLCA` (`add_interdatabase_activity_mapping_from_timeline`)
+**after** the timeline today; for traversal-time variant resolution it must exist
+**before**. Add a pre-pass: in `TimexLCA.build_timeline`, before constructing
+`TimelineBuilder`, when `traverse_background` is set, call a new method
+`self.add_full_interdatabase_activity_mapping()` that populates the mapping for all
+background activities (name/reference product/location across
+`database_dates_static`). Implement it by generalizing the existing
+`add_interdatabase_activity_mapping_from_timeline` to iterate all background nodes
+rather than only timeline producers:
+
+```python
+    def add_full_interdatabase_activity_mapping(self) -> None:
+        static_dbs = set(self.database_dates_static.keys())
+        tuples_dict = {}
+        for node in self.nodes.values():
+            if node["database"] not in static_dbs:
+                continue
+            key = (node["name"], node.get("reference product"), node["location"])
+            tuples_dict.setdefault(key, node.id)
+        for node in self.nodes.values():
+            if node["database"] not in static_dbs:
+                continue
+            key = (node["name"], node.get("reference product"), node["location"])
+            anchor = tuples_dict[key]
+            self.interdatabase_activity_mapping.setdefault(anchor, {})
+            self.interdatabase_activity_mapping[anchor][node["database"]] = node.id
+        self.interdatabase_activity_mapping.make_reciprocal()
+```
+
+Pass `self.interdatabase_activity_mapping` into the `TimelineBuilder(...)` call as a
+new keyword `interdatabase_activity_mapping=self.interdatabase_activity_mapping` and
+store it on the builder.
+
+- [ ] **Step 4: Implement variant resolution + split in BFS**
+
+In `bw_timex/edge_extractor.py`, add helpers to `EdgeExtractorBFS`:
+
+```python
+    def _variant_shares_for_date(self, producer_date) -> dict:
+        """Return {db_name: share} for a datetime producer_date over the static
+        background variant dates, using the configured interpolation."""
+        from datetime import datetime as _dt
+
+        dates_to_db = {
+            v: k
+            for k, v in self.database_dates_static.items()
+            if isinstance(v, _dt)
+        }
+        sorted_dates = tuple(sorted(dates_to_db))
+        if getattr(self, "interpolation_type", "linear") == "nearest":
+            weights = _nearest_weight(producer_date, sorted_dates)
+        else:
+            weights = _linear_weights(producer_date, sorted_dates)
+        return {dates_to_db[d]: w for d, w in weights.items()}
+
+    def _resolve_in_variant(self, node_id: int, db_name: str) -> int:
+        """Map node_id to its counterpart in db_name (identity if already there)."""
+        node = self.nodes.get(node_id)
+        if node is not None and node["database"] == db_name:
+            return node_id
+        return self.interdatabase_activity_mapping.find_match(node_id, db_name)
+```
+
+Add module-level `_linear_weights` / `_nearest_weight` mirroring
+`TimelineBuilder.get_weights_for_interpolation_between_nearest_years` and
+`find_closest_date` (copy the bisect logic; return `{date: weight}` dicts). Keep
+them as free functions so both the builder and extractor can share intent (DRY:
+prefer importing the existing builder methods if feasible — if you extract the
+bisect logic into `bw_timex/utils.py` as `linear_interpolation_weights(date,
+sorted_dates)` and `nearest_date_weight(date, sorted_dates)`, have the
+`TimelineBuilder` methods call them too, and import them here).
+
+In `build_edge_timeline`, when descending into a background producer, branch on the
+producer's resolved date vs. the consumer's current variant:
+
+```python
+                producer_node = self.nodes.get(input_id)
+                producer_is_background = (
+                    producer_node is not None
+                    and producer_node["database"] in self.database_dates_static
+                )
+
+                if self.traverse_background and producer_is_background:
+                    # Determine the producer's absolute date(s). For a single-cohort
+                    # abs_td_producer this is one datetime; for multi-cohort, iterate.
+                    producer_dates = np.atleast_1d(abs_td_producer.date)
+                    producer_amounts = np.atleast_1d(abs_td_producer.amount)
+                    current_db = (
+                        producer_node["database"]
+                        if not isinstance(td_producer_raw, TemporalDistribution)
+                        else None
+                    )
+                    for p_date, p_amount in zip(producer_dates, producer_amounts):
+                        shares = self._variant_shares_for_date(
+                            p_date.astype("datetime64[s]").astype(object)
+                        )
+                        for db_name, share in shares.items():
+                            variant_id = self._resolve_in_variant(input_id, db_name)
+                            # enqueue a branch in this variant, scaled by share*p_amount
+                            ... build a per-branch Edge + queue item ...
+```
+
+Implementation details for the inner branch:
+- Build a single-cohort `TemporalDistribution` for this branch:
+  `branch_td = TemporalDistribution(date=np.array([p_date]), amount=np.array([share * p_amount]))`.
+- Emit an `Edge(producer=variant_id, consumer=node_id, ...)` with
+  `abs_td_producer=branch_td`, `td_producer` scaled by `share`, `edge_type` from the
+  exchange, `temporal_evolution` as read.
+- Compute `new_supply` as today but multiplied by `share`.
+- If not a leaf and above cutoff, descend into `variant_id` **in db `db_name`**,
+  reading that variant's exchanges. Because `self.nodes` and the matrix are keyed by
+  global ids, descend using `variant_id` directly; `_get_technosphere_inputs`,
+  `_get_exchange_td_and_type`, and `_get_production_amount` already resolve by id, so
+  reading `variant_id`'s own exchanges yields the respective variant's TDs/amounts.
+  NOTE: `variant_id` may not be in `base_lca`'s matrix (only the referenced variant
+  is). Read amounts/TDs from the **bw2data activity proxy** (`self.nodes[variant_id]`
+  if present, else `bd.get_activity(variant_id)`), NOT from `tech_matrix_csc`. Add a
+  `_get_exchange_td_and_type_from_proxy(variant_id)` that iterates
+  `self.nodes[variant_id].technosphere()`/`.substitution()` and reads
+  `exc["amount"]`, `exc.get("temporal_distribution")`, and
+  `extract_temporal_evolution(exc.data)` directly. Ensure such variant nodes are in
+  `self.nodes` by having `TimelineBuilder` populate `nodes` for all background
+  variant activities when `traverse_background` is set (extend the `nodes` dict
+  construction accordingly).
+
+The sticky (no-split) case — when the producer's date resolves to the same single
+variant as the consumer context — falls out naturally: `shares` has one entry equal
+to the current db with weight 1.
+
+- [ ] **Step 5: Run the spread test**
+
+Run: `pytest tests/test_background_traversal.py::test_bfs_background_td_spreads_bg_b_across_variants -v`
+Expected: PASS.
+
+- [ ] **Step 6: Re-run equivalence + full suite**
+
+Run: `pytest tests/test_background_traversal.py -v && pytest -q`
+Expected: all pass — including `test_bfs_equivalence_without_background_tds` (no-TD ⇒ single sticky variant per branch).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add bw_timex/edge_extractor.py bw_timex/timeline_builder.py bw_timex/timex_lca.py bw_timex/utils.py tests/test_background_traversal.py
+git commit -m "BFS: variant-aware split for background temporal distributions"
+```
+
+---
+
+### Task 6: Per-variant background TD + no-double-count tests (BFS)
+
+Lock in two behaviors with dedicated tests: (a) a TD defined differently across variants produces variant-dependent spreads; (b) a traversed background process contributes its explicit edges, not its full static inventory.
+
+**Files:**
+- Modify: `tests/fixtures/background_td_db_fixture.py` (parametrizable TD per variant) OR a second fixture
+- Test: `tests/test_background_traversal.py`
+
+**Interfaces:**
+- Consumes: Task 5 behavior.
+- Produces: regression coverage; no new production code expected (if a test fails, fix the smallest cause in `edge_extractor.py`).
+
+- [ ] **Step 1: Write the per-variant TD test**
+
+Add a fixture `background_td_db_per_variant` (copy `background_td_db`, give
+`background_2030`'s `bg_A→bg_B` a different TD, e.g. 100% at +0y), register it in
+`conftest.py`, then:
+
+```python
+def test_per_variant_td_changes_spread(background_td_db_per_variant):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal="bfs",
+        traverse_background=True,
+    )
+    tl = tlca.timeline
+    bg_b = tl[tl["producer_name"] == "bg_B"]
+    # The 2020-variant branch spreads to 2034; the 2030-variant branch does not.
+    years = sorted({d.year for d in bg_b["date_producer"]})
+    assert 2024 in years and 2034 in years
+```
+
+(Adjust the precise assertion to the fixture's TDs once observed; the invariant is
+that the spread differs by which variant the branch reads.)
+
+- [ ] **Step 2: Run it**
+
+Run: `pytest tests/test_background_traversal.py::test_per_variant_td_changes_spread -v`
+Expected: PASS (or reveals a bug to fix minimally in `edge_extractor.py`).
+
+- [ ] **Step 3: Write the no-double-count test**
+
+```python
+def test_traversed_background_not_double_counted(background_td_db):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal="bfs",
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lca.lcia()
+    # bg_A is traversed into -> it must be a temporalized process, NOT a temporal market.
+    bg_a_id = background_td_db["background_2020"][0].id
+    tl = tlca.timeline
+    bg_a_rows = tl[tl["producer"] == bg_a_id]
+    assert bg_a_rows["temporal_market_shares"].isnull().all()
+    # total CO2 is 10 kg (2*5*1), not doubled.
+    tlca.static_lca.lcia()
+    assert tlca.static_lca.score == pytest.approx(10.0, rel=1e-9)
+```
+
+- [ ] **Step 4: Run it**
+
+Run: `pytest tests/test_background_traversal.py::test_traversed_background_not_double_counted -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite**
+
+Run: `pytest -q`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/background_td_db_fixture.py tests/conftest.py tests/test_background_traversal.py bw_timex/edge_extractor.py
+git commit -m "Tests: per-variant background TD and no-double-count (bfs)"
+```
+
+---
+
+### Task 7: Priority-engine descent + variant hopping + documented score approximation
+
+Bring the priority `EdgeExtractor` to parity: descend into background, split at variant frontiers, and read respective-variant exchanges. Heap ordering uses `base_lca` scores for hopped-variant nodes (accepted approximation), with a one-time warning.
+
+**Files:**
+- Modify: `bw_timex/edge_extractor.py:114-327` (`EdgeExtractor.build_edge_timeline`)
+- Modify: `bw_timex/timex_lca.py` `build_timeline` (warning emission)
+- Test: `tests/test_background_traversal.py`
+
+**Interfaces:**
+- Consumes: same variant-resolution helpers as Task 5 (share-by-date, `_resolve_in_variant`); reuse them — extract the shared logic into `bw_timex/utils.py` if not already done in Task 5, and call from both extractors.
+- Produces: priority-mode parity; `EdgeExtractor` gains `database_dates_static`, `interdatabase_activity_mapping`, `interpolation_type` attributes (set by `TimelineBuilder`, mirroring Task 5 Step 3).
+
+- [ ] **Step 1: Write the parametrized parity test**
+
+Add to `tests/test_background_traversal.py`:
+
+```python
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_background_td_parity_across_engines(background_td_db, graph_traversal):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal=graph_traversal,
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lca.lcia()
+    tl = tlca.timeline
+    bg_b = tl[tl["producer_name"] == "bg_B"]
+    assert sorted({d.year for d in bg_b["date_producer"]}) == [2024, 2034]
+    assert tlca.static_lca.score == pytest.approx(10.0, rel=1e-9)
+```
+
+- [ ] **Step 2: Run it (priority case fails)**
+
+Run: `pytest "tests/test_background_traversal.py::test_background_td_parity_across_engines[priority]" -v`
+Expected: FAIL — priority does not yet split/descend into background variants.
+
+- [ ] **Step 3: Set extractor attributes for priority**
+
+In `bw_timex/timeline_builder.py`, after building the `EdgeExtractor` (priority
+branch), set the same three attributes as Task 5 Step 3:
+
+```python
+            self.edge_extractor.database_dates_static = self.database_dates_static
+            self.edge_extractor.interdatabase_activity_mapping = (
+                self.interdatabase_activity_mapping
+            )
+            self.edge_extractor.interpolation_type = self.interpolation_type
+```
+
+- [ ] **Step 4: Implement descent + split in priority `build_edge_timeline`**
+
+In `bw_timex/edge_extractor.py` `EdgeExtractor.build_edge_timeline`, inside the
+`while heap:` loop where each child edge produces an `Edge` and (if `not leaf`) is
+pushed to the heap, add a variant-split branch analogous to BFS:
+
+```python
+                producer_node = self.nodes_proxy_for(producer.activity_datapackage_id)
+                producer_is_background = (
+                    producer_node is not None
+                    and producer_node["database"] in self.database_dates_static
+                )
+                if self.traverse_background and producer_is_background:
+                    shares = variant_shares_for_date(
+                        abs_td_producer_date, self.database_dates_static,
+                        self.interpolation_type,
+                    )
+                    for db_name, share in shares.items():
+                        variant_id = resolve_in_variant(
+                            producer.activity_datapackage_id, db_name,
+                            self.interdatabase_activity_mapping, self.nodes_lookup,
+                        )
+                        # emit a scaled Edge for (variant_id -> node) and, if not leaf
+                        # and above cutoff, push variant_id with the approximated score:
+                        approx_score = node.cumulative_score  # base_lca proxy
+                        heappush(heap, (1 / approx_score, scaled_distribution,
+                                        td_producer, scaled_abs_td, variant_node))
+                    continue  # replaced the single non-split push
+```
+
+Key adaptations vs BFS:
+- The priority extractor uses `self.nodes` keyed by `unique_id` (bw_temporalis
+  node objects), not by activity id. Add a small lookup
+  `self.nodes_lookup = {n.activity_datapackage_id: n for n in self.nodes.values()}`
+  built once in `__init__` (after `super().__init__`). For a hopped `variant_id`
+  that has no bw_temporalis node (not in `base_lca`), construct a lightweight stand-in
+  carrying `.activity_datapackage_id = variant_id`, `.cumulative_score =
+  node.cumulative_score` (the approximation), and `.unique_id` unique — OR, simpler,
+  represent hopped variants as **leaf** edges that get `temporal_market_shares =
+  {db: 1}` downstream and do not require further heap descent. **Prefer the leaf
+  approach for variants whose subgraph is not in `base_lca`:** it avoids fabricating
+  scores and matches the spec's "leaves resolve to {variant: 1}". Only the
+  referenced variant (present in `base_lca`) is descended deeper; non-referenced
+  variants of a node are emitted as leaf temporal markets at the split. Reading the
+  *referenced* variant's own deeper TDs is what continues the chain.
+- Read amounts/TDs for emitted variant edges from the bw2data proxy (as in BFS
+  `_get_exchange_td_and_type_from_proxy`), since non-referenced variants are not in
+  `base_lca`.
+
+Reuse the shared helpers `variant_shares_for_date`, `resolve_in_variant`,
+`get_exchange_td_and_type_from_proxy` (factor these into `bw_timex/utils.py` in
+Task 5 and import in both extractors — DRY).
+
+- [ ] **Step 5: Emit the one-time priority warning**
+
+In `bw_timex/timex_lca.py` `build_timeline`, after `graph_traversal` is resolved:
+
+```python
+        if traverse_background and graph_traversal == "priority":
+            logger.warning(
+                "traverse_background=True with graph_traversal='priority': heap "
+                "ordering uses base_lca scores as an approximation for nodes in "
+                "non-referenced background variants. Edge exploration order under "
+                "max_calc/cutoff may differ slightly; explored amounts are correct. "
+                "Use graph_traversal='bfs' to avoid the approximation."
+            )
+```
+
+(`logger` is already imported in `timex_lca.py`.)
+
+- [ ] **Step 6: Run the parity test (both engines)**
+
+Run: `pytest tests/test_background_traversal.py::test_background_td_parity_across_engines -v`
+Expected: PASS for both `priority` and `bfs`.
+
+- [ ] **Step 7: Full suite**
+
+Run: `pytest -q`
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add bw_timex/edge_extractor.py bw_timex/timeline_builder.py bw_timex/timex_lca.py bw_timex/utils.py tests/test_background_traversal.py
+git commit -m "Priority: descend into background with variant splitting (base_lca score approx)"
+```
+
+---
+
+### Task 8: Documentation
+
+Document the flag and its semantics in the `build_timeline` docstring and (if present) the user-facing docs.
+
+**Files:**
+- Modify: `bw_timex/timex_lca.py:217-264` (`build_timeline` docstring)
+- Modify: `docs/` user guide if a relevant page exists (search first)
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Add the `traverse_background` parameter to the docstring**
+
+In `bw_timex/timex_lca.py` `build_timeline`, document:
+
+```
+        traverse_background : bool, optional
+            If True, the graph traversal descends into background databases instead
+            of stopping at the first-level background frontier. Temporal
+            distributions defined on exchanges inside background databases are then
+            honored: time-spread flows are sourced from the temporally-appropriate
+            background-db variant(s). Bounded by ``cutoff`` and ``max_calc``.
+            Default is False (background treated as static, as before). With
+            ``graph_traversal='priority'`` the heap ordering uses base_lca scores as
+            an approximation for non-referenced variant nodes; use
+            ``graph_traversal='bfs'`` for exact ordering.
+```
+
+- [ ] **Step 2: Check for a docs page to update**
+
+Run: `grep -rl "build_timeline\|temporal market" docs/ 2>/dev/null`
+If a relevant `.md`/`.rst` exists, add a short subsection describing
+`traverse_background`. If none, skip.
+
+- [ ] **Step 3: Build docs if the project does so (optional sanity)**
+
+Run: `grep -q "sphinx\|mkdocs" pyproject.toml setup.cfg 2>/dev/null && echo "has docs tooling" || echo "no docs build"`
+If docs tooling exists and is quick, build; otherwise skip.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bw_timex/timex_lca.py docs/
+git commit -m "Document traverse_background flag"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- API flag `traverse_background` → Task 1. ✓
+- Remove static exclusion, bound by cutoff/max_calc (+ BFS max_calc guard) → Task 4. ✓
+- Split rule (entry + TD edges, sticky otherwise) → Tasks 5 (bfs), 7 (priority). ✓
+- Read respective variant's exchanges/amounts/TDs → Task 5 Step 4, Task 7 Step 4. ✓
+- Priority base_lca score approximation + one-time warning → Task 7 Steps 4–5. ✓
+- `build_timeline` leaf-based `temporal_market_shares` → Task 4 Step 5. ✓
+- `matrix_modifier` + `collect_temporalized` key on shares (no double-count) → Task 3, tested Task 6. ✓
+- `interdatabase_activity_mapping` available pre-traversal → Task 5 Step 3. ✓
+- Tests: equivalence (Task 4), spread (Task 5), no-double-count (Task 6), per-variant (Task 6), both engines (Task 7). ✓
+- Backward compatibility (default unchanged) → asserted by full-suite runs in every task. ✓
+
+**Known implementation risks (call out to reviewer, resolve during execution):**
+- The priority `EdgeExtractor` internals (`self.nodes` keyed by `unique_id`,
+  `node.cumulative_score`, `edge_mapping`) come from `bw_temporalis`. Task 7 Step 4
+  proposes the **leaf approach** for non-referenced variants to avoid fabricating
+  scores; if descent into non-referenced variants deeper than one hop is required by
+  a failing test, revisit. The referenced variant is descended normally.
+- `abs_td_producer` may be multi-cohort; the BFS split iterates cohorts. Confirm the
+  date dtype handling (`datetime64[s]` → python `datetime`) when calling the
+  interpolation helpers.
+- `_leaf_background_producers` reads `consumer`/`producer` columns; verify they exist
+  at the call site in `add_column_temporal_market_shares_to_timeline` (Task 4 Step 5
+  note).
+
+**Placeholder scan:** Test code is concrete; production steps show concrete code or
+exact structural edits against named functions. The few "adjust assertion once
+observed" notes are in tests where the exact numeric split is fixture-dependent — the
+invariant being tested is stated explicitly.
+
+**Type consistency:** Helper names used consistently across tasks
+(`variant_shares_for_date`, `resolve_in_variant`,
+`get_exchange_td_and_type_from_proxy`, `_leaf_background_producers`); shared helpers
+are factored into `utils.py` in Task 5 and imported in Task 7.

--- a/docs/superpowers/specs/2026-06-19-background-temporal-distributions-design.md
+++ b/docs/superpowers/specs/2026-06-19-background-temporal-distributions-design.md
@@ -1,0 +1,172 @@
+# Background temporal distributions (`traverse_background`)
+
+**Date:** 2026-06-19
+**Branch:** `background-temporal-distributions`
+**Status:** Design approved, pending implementation
+
+## Goal
+
+Today `bw_timex` only honors temporal distributions (`temporal_distribution`) and
+`temporal_evolution` on exchanges in the **foreground** system. Background databases
+are treated as static time-snapshots: traversal stops at the first-level background
+frontier, and each background flow is mapped to the temporally-appropriate background
+db variant(s) via the "temporal market" interpolation.
+
+This feature lets temporal distributions defined **inside background databases** take
+effect. The traversal descends into the background, propagates those TDs by
+convolution exactly like foreground TDs, and the resulting time-spread flows are
+sourced from the temporally-appropriate variant of each background database. Because
+the TD is read from the *respective* variant being traversed, background temporal
+behavior can change over time (a 2030 variant may define a different TD than the 2020
+variant of the same exchange).
+
+The feature is gated behind a new opt-in flag; default behavior is unchanged.
+
+## Public API
+
+New keyword argument on `TimexLCA.build_timeline(...)`:
+
+```python
+traverse_background: bool = False
+```
+
+- `False` (default): exact current behavior. Background databases are excluded from
+  traversal; the first-level background frontier is the stop.
+- `True`: traversal descends into background databases, bounded only by `cutoff` and
+  `max_calc`. Background TDs are honored. Variant-aware descent (below) applies.
+
+The flag is plumbed through `TimexLCA.build_timeline` → `TimelineBuilder.__init__` →
+both `EdgeExtractor` (priority) and `EdgeExtractorBFS` (bfs).
+
+## Core mechanism: variant-aware descent
+
+### Removing the static exclusion
+
+Two knobs currently halt the traversal at the background:
+
+1. `edge_filter_function` / `edge_ff`: the default marks every node in a static
+   background db as a **leaf** (recorded as an edge, not descended into).
+2. `static_activity_indices`: in BFS, inputs in this set are skipped entirely; in
+   priority it is passed to `TemporalisLCA`.
+
+When `traverse_background=True`:
+
+- `static_activity_indices` for background nodes is **empty** (background is no longer
+  pre-excluded).
+- The **default** `edge_filter_function` becomes "nothing is a leaf"
+  (`lambda _: False`) instead of "all background nodes are leaves". A user-supplied
+  `edge_filter_function` is still respected.
+- Traversal is bounded purely by `cutoff` (and `max_calc`). BFS gains a `max_calc`
+  guard for parity and safety, since unbounded background descent is dangerous.
+
+### The split rule (replaces the fixed first-level frontier)
+
+There is no longer a single static frontier. Instead, a producer is **split into
+interpolated variants by its resolved date** whenever that date selects different
+variant(s) than the **consumer's current variant context**:
+
+- **Background entry** — consumer is in the foreground (no variant context), producer
+  is in a background db: the producer date `T` selects interpolated variants
+  (e.g. `{V_2020: 0.6, V_2030: 0.4}`). Descend into each branch, weighted by its share.
+- **Inside a variant, no-TD edge** — the producer date equals the consumer date, so it
+  resolves to the **same** variant. **Sticky**: stay in that single variant, no split.
+  This is numerically identical to today's static background inventory.
+- **Inside a variant, TD edge** — the TD shifts the producer date. Re-evaluate the
+  variant selection for the new date and split again among the variants appropriate for
+  it. Descend into each branch.
+
+Consequences:
+
+- Branching happens only at background entry and at TD-carrying edges. Because TDs are
+  rare in the background, the branch count per path is bounded (≈ `2^(#TD edges on the
+  path)`); `cutoff`/`max_calc` prune the rest.
+- **Backward compatibility:** with zero background TDs, the producer splits once at
+  entry and stays sticky forever — reproducing today's behavior exactly.
+
+### Reading the respective variant
+
+Each traversal branch carries the **variant db** it is currently in. When descending a
+branch in, say, `V_2030`, the node's technosphere/substitution exchanges, their
+amounts, the reference-product production amount, **and their TDs** are read from
+`V_2030`'s activity proxy. The mapping from a node to its counterpart in another variant
+db reuses `interdatabase_activity_mapping` (matched on name / reference product /
+location) plus direct bw2data exchange reads.
+
+Each terminal leaf is a node-in-`V` mapped to `V`'s static inventory with share
+`{V: 1}`. The full inter-variant distribution is carried by the **branch shares**
+accumulated during descent, not by a per-leaf interpolation.
+
+### Priority-mode caveat (accepted)
+
+`EdgeExtractor` inherits from `TemporalisLCA`, whose heap ordering uses per-subgraph
+**LCA scores computed from `base_lca`**. The other variants' subgraphs are not in
+`base_lca` (the foreground links only one variant), so when descent hops into another
+variant there is no exact subgraph score available. For hopped-variant nodes the heap
+score is **approximated from the nominal node's `base_lca` score**.
+
+This can slightly misorder the priority heap, which only affects *which* edges are
+explored first under `max_calc`/`cutoff` — not the correctness of explored amounts.
+This is an accepted limitation. It is documented and a **one-time warning** is emitted
+when `traverse_background=True` with `graph_traversal="priority"`. BFS has no score
+dependency and is unaffected.
+
+## Downstream changes
+
+### `build_timeline` (TimelineBuilder)
+
+- `temporal_market_shares` is assigned per **leaf** producer as `{resolved_variant: 1}`.
+  Inter-variant distribution is already carried by the branch shares from descent.
+- The hardcoded reliance on `node_collections["first_level_background_static"]` for
+  deciding which producers get `temporal_market_shares` is replaced by the dynamic
+  leaf/split logic. A background producer is a temporal-market leaf iff it is **not
+  traversed into** (never appears as a consumer in the edge timeline).
+- In `False` mode these reduce to the existing behavior, so the current code path is
+  preserved.
+
+### `matrix_modifier`
+
+The temporal-market-vs-temporalized branch currently keys on
+`previous_producer_node["database"] in database_dates_static`. Change it to key on the
+**presence of `temporal_market_shares`** on the row:
+
+- Row has `temporal_market_shares` ⇒ leaf ⇒ wire as a temporal market to the variant's
+  static inventory.
+- Row has no `temporal_market_shares` ⇒ traversed-into ⇒ rebuild as a temporalized
+  process from its explicit child edges (its full static inventory is **not** pulled in).
+
+This prevents double-counting a background process that was descended into (it would
+otherwise contribute both its full static inventory *and* its explicit child edges).
+In `False` mode "has shares" ⇔ "is a static background producer", so behavior is
+identical.
+
+### Untouched
+
+`interdatabase_activity_mapping` population (keyed on
+`temporal_market_shares.notnull()`), dynamic biosphere construction, and `lci()` are all
+generic over the leaf set and require no changes.
+
+## Testing (TDD — failing test first for each)
+
+New fixture: `foreground → bg_A → bg_B`, with two dated variants of the background
+databases and a `temporal_distribution` on the `bg_A → bg_B` exchange.
+
+1. **Equivalence / regression** — `traverse_background=True` with **no** background TDs
+   produces a timeline and LCA score identical to `traverse_background=False`.
+2. **Spread** — with the `bg_A → bg_B` TD, `traverse_background=True` spreads `bg_B`
+   across the variants per the TD; assert against a hand-computed expected
+   inventory/score.
+3. **No double-count** — the traversed `bg_A` contributes only its explicit child edges,
+   not its full static inventory (assert the inventory matches the explicit-edge sum,
+   not double).
+4. **Per-variant TD** — a TD defined differently in `V_2020` vs `V_2030` produces
+   different spreads depending on which variant the branch is in.
+5. **Both modes** — parametrize tests across `graph_traversal in {"priority", "bfs"}`.
+
+Match existing fixture conventions in `tests/fixtures` + `tests/conftest.py`
+(see `tests/test_process_at_base_database_time.py` as a template).
+
+## Out of scope (v1)
+
+- Exact priority-mode subgraph scoring for hopped variants (approximation accepted).
+- Co-production / multi-output background processes along descended paths beyond what
+  existing code already supports.

--- a/docs/superpowers/specs/2026-06-19-background-temporal-distributions-design.md
+++ b/docs/superpowers/specs/2026-06-19-background-temporal-distributions-design.md
@@ -98,17 +98,25 @@ accumulated during descent, not by a per-leaf interpolation.
 
 ### Priority-mode caveat (accepted)
 
+> **Implementation note (as-built, 2026-06-19):** The approach described in the
+> original design — approximating heap scores from `base_lca` for hopped-variant nodes
+> — was **abandoned** during implementation. The shipped code does **not** place
+> non-referenced variant subtrees on the priority heap at all. Instead, when the heap
+> loop first reaches an edge whose producer is a static background process with further
+> technosphere inputs, `_emit_variant_split` is called immediately, and each variant's
+> full subtree is walked via `_descend_variant_subtree` (proxy reads, not heap). The
+> referenced-system heap exploration order is therefore unchanged, and the explored
+> amounts are **exact** (identical to `graph_traversal='bfs'` for those subtrees). A
+> one-time warning is still emitted when `traverse_background=True` with
+> `graph_traversal="priority"` to inform users of this behaviour.
+
 `EdgeExtractor` inherits from `TemporalisLCA`, whose heap ordering uses per-subgraph
 **LCA scores computed from `base_lca`**. The other variants' subgraphs are not in
-`base_lca` (the foreground links only one variant), so when descent hops into another
-variant there is no exact subgraph score available. For hopped-variant nodes the heap
-score is **approximated from the nominal node's `base_lca` score**.
-
-This can slightly misorder the priority heap, which only affects *which* edges are
-explored first under `max_calc`/`cutoff` — not the correctness of explored amounts.
-This is an accepted limitation. It is documented and a **one-time warning** is emitted
-when `traverse_background=True` with `graph_traversal="priority"`. BFS has no score
-dependency and is unaffected.
+`base_lca` (the foreground links only one referenced variant), so non-referenced
+variant subtrees are walked in full via proxy reads when their parent edge is first
+reached on the heap — they are never enqueued on the priority heap. This is an
+accepted trade-off: the heap exploration order of the *referenced* system is unchanged,
+and variant subtree amounts are exact.
 
 ## Downstream changes
 

--- a/notebooks/background_temporalization.ipynb
+++ b/notebooks/background_temporalization.ipynb
@@ -1,0 +1,1381 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d901510b",
+   "metadata": {},
+   "source": [
+    "# Temporal distributions in the background system\n",
+    "\n",
+    "This notebook shows a feature that complements the [Getting Started](getting_started.ipynb) example: temporal distributions defined **inside background databases**.\n",
+    "\n",
+    "Normally, `bw_timex` stops the temporal graph traversal at the *first* background process and treats everything behind it as a static snapshot. With the optional flag `traverse_background=True`, the traversal descends **into** the background, so that a `TemporalDistribution` on a background exchange also spreads its downstream flows over time — and each time-shifted flow is sourced from the temporally-appropriate background database variant.\n",
+    "\n",
+    "We'll build a tiny decarbonization story to see why this matters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90786464",
+   "metadata": {},
+   "source": [
+    "## The system\n",
+    "\n",
+    "Our foreground process `A` buys a background component `B`. Producing `B` consumes electricity `C`, and electricity causes CO₂. Both `B` and `C` live in the background.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "subgraph background[<i>background</i>]\n",
+    "    B(\"Component B\"):::bg\n",
+    "    C(\"Electricity C\"):::bg\n",
+    "end\n",
+    "\n",
+    "subgraph foreground[<i>foreground</i>]\n",
+    "    A(\"Process A\"):::fg\n",
+    "end\n",
+    "\n",
+    "subgraph biosphere[<i>biosphere</i>]\n",
+    "    CO2(\"CO2\"):::bio\n",
+    "end\n",
+    "\n",
+    "B-->|\"3 kg\"|A\n",
+    "C-->|\"2 kWh\"|B\n",
+    "C-.->|\"11 kg\"|CO2\n",
+    "\n",
+    "classDef fg color:#222832, fill:#3fb1c5, stroke:none;\n",
+    "classDef bg color:#222832, fill:#f4a259, stroke:none;\n",
+    "classDef bio color:#222832, fill:#9c5ffd, stroke:none;\n",
+    "style background fill:none, stroke:none;\n",
+    "style foreground fill:none, stroke:none;\n",
+    "style biosphere fill:none, stroke:none;\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "942222ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T08:08:47.650263Z",
+     "iopub.status.busy": "2026-06-22T08:08:47.650130Z",
+     "iopub.status.idle": "2026-06-22T08:08:48.990960Z",
+     "shell.execute_reply": "2026-06-22T08:08:48.990545Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 10754.63it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m10:08:48+0200\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mVacuuming database            \u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m10:08:48+0200\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mNot able to determine geocollections for all datasets. This database is not ready for regionalization.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/2 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 2/2 [00:00<00:00, 40920.04it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m10:08:48+0200\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mVacuuming database            \u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m10:08:48+0200\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mNot able to determine geocollections for all datasets. This database is not ready for regionalization.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/1 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 1/1 [00:00<00:00, 10866.07it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m10:08:48+0200\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mVacuuming database            \u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import bw2data as bd\n",
+    "\n",
+    "bd.projects.set_current(\"background_temporalization\")\n",
+    "\n",
+    "bd.Database(\"biosphere\").write(\n",
+    "    {\n",
+    "        (\"biosphere\", \"CO2\"): {\"type\": \"emission\", \"name\": \"CO2\"},\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "bd.Database(\"background_2020\").write(\n",
+    "    {\n",
+    "        (\"background_2020\", \"B\"): {\n",
+    "            \"name\": \"B\",\n",
+    "            \"location\": \"somewhere\",\n",
+    "            \"reference product\": \"B\",\n",
+    "            \"exchanges\": [\n",
+    "                {\"amount\": 1, \"type\": \"production\", \"input\": (\"background_2020\", \"B\")},\n",
+    "                {\"amount\": 2, \"type\": \"technosphere\", \"input\": (\"background_2020\", \"C\")},\n",
+    "            ],\n",
+    "        },\n",
+    "        (\"background_2020\", \"C\"): {\n",
+    "            \"name\": \"C\",\n",
+    "            \"location\": \"somewhere\",\n",
+    "            \"reference product\": \"C\",\n",
+    "            \"exchanges\": [\n",
+    "                {\"amount\": 1, \"type\": \"production\", \"input\": (\"background_2020\", \"C\")},\n",
+    "                {\"amount\": 11, \"type\": \"biosphere\", \"input\": (\"biosphere\", \"CO2\")},\n",
+    "            ],\n",
+    "        },\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "bd.Database(\"foreground\").write(\n",
+    "    {\n",
+    "        (\"foreground\", \"A\"): {\n",
+    "            \"name\": \"A\",\n",
+    "            \"location\": \"somewhere\",\n",
+    "            \"reference product\": \"A\",\n",
+    "            \"exchanges\": [\n",
+    "                {\"amount\": 1, \"type\": \"production\", \"input\": (\"foreground\", \"A\")},\n",
+    "                {\"amount\": 3, \"type\": \"technosphere\", \"input\": (\"background_2020\", \"B\")},\n",
+    "            ],\n",
+    "        },\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "bd.Method((\"our\", \"method\")).write([((\"biosphere\", \"CO2\"), 1)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9be47efd",
+   "metadata": {},
+   "source": [
+    "### A decarbonizing grid\n",
+    "\n",
+    "Our background represents the year 2020, where electricity `C` emits 11 kg CO₂. By 2040 the grid is cleaner, so the same electricity only emits 7 kg CO₂. We write this as a separate, prospective background database.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "subgraph background[<i>background</i>]\n",
+    "    C2020(\"Electricity C \\n 2020\"):::bg\n",
+    "    C2040(\"Electricity C \\n 2040\"):::bg\n",
+    "end\n",
+    "\n",
+    "subgraph biosphere[<i>biosphere</i>]\n",
+    "    CO2(\"CO2\"):::bio\n",
+    "end\n",
+    "\n",
+    "C2020-.->|\"<span style='color:#9c5ffd'><b>11 kg</b></span>\"|CO2\n",
+    "C2040-.->|\"<span style='color:#9c5ffd'><b>7 kg</b></span>\"|CO2\n",
+    "\n",
+    "classDef bg color:#222832, fill:#f4a259, stroke:none;\n",
+    "classDef bio color:#222832, fill:#9c5ffd, stroke:none;\n",
+    "style background fill:none, stroke:none;\n",
+    "style biosphere fill:none, stroke:none;\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d2660de7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T08:08:48.992384Z",
+     "iopub.status.busy": "2026-06-22T08:08:48.992289Z",
+     "iopub.status.idle": "2026-06-22T08:08:49.032820Z",
+     "shell.execute_reply": "2026-06-22T08:08:49.032374Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m10:08:48+0200\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mNot able to determine geocollections for all datasets. This database is not ready for regionalization.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "  0%|          | 0/2 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "100%|██████████| 2/2 [00:00<00:00, 48489.06it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m10:08:48+0200\u001b[0m [\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mVacuuming database            \u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "bd.Database(\"background_2040\").write(\n",
+    "    {\n",
+    "        (\"background_2040\", \"B\"): {\n",
+    "            \"name\": \"B\",\n",
+    "            \"location\": \"somewhere\",\n",
+    "            \"reference product\": \"B\",\n",
+    "            \"exchanges\": [\n",
+    "                {\"amount\": 1, \"type\": \"production\", \"input\": (\"background_2040\", \"B\")},\n",
+    "                {\"amount\": 2, \"type\": \"technosphere\", \"input\": (\"background_2040\", \"C\")},\n",
+    "            ],\n",
+    "        },\n",
+    "        (\"background_2040\", \"C\"): {\n",
+    "            \"name\": \"C\",\n",
+    "            \"location\": \"somewhere\",\n",
+    "            \"reference product\": \"C\",\n",
+    "            \"exchanges\": [\n",
+    "                {\"amount\": 1, \"type\": \"production\", \"input\": (\"background_2040\", \"C\")},\n",
+    "                {\"amount\": 7, \"type\": \"biosphere\", \"input\": (\"biosphere\", \"CO2\")},\n",
+    "            ],\n",
+    "        },\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "for db in bd.databases:\n",
+    "    bd.Database(db).process()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4d74bee",
+   "metadata": {},
+   "source": [
+    "As in Getting Started, we record which background database represents which point in time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e21503fa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T08:08:49.034110Z",
+     "iopub.status.busy": "2026-06-22T08:08:49.034022Z",
+     "iopub.status.idle": "2026-06-22T08:08:49.036177Z",
+     "shell.execute_reply": "2026-06-22T08:08:49.035812Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "database_dates = {\n",
+    "    \"background_2020\": datetime.strptime(\"2020\", \"%Y\"),\n",
+    "    \"background_2040\": datetime.strptime(\"2040\", \"%Y\"),\n",
+    "    \"foreground\": \"dynamic\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c31d40dc",
+   "metadata": {},
+   "source": [
+    "## A temporal distribution on a *background* exchange\n",
+    "\n",
+    "Here's the new part. Component `B` doesn't use its electricity all at once: 60% is used right away, and 40% ten years later (think of a long-lived component being operated over its lifetime). We attach this `TemporalDistribution` to the **background** exchange `C → B` — exactly the same way we would for a foreground exchange.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "subgraph background[<i>background</i>]\n",
+    "    B(\"Component B\"):::bg\n",
+    "    C(\"Electricity C\"):::bg\n",
+    "end\n",
+    "\n",
+    "subgraph foreground[<i>foreground</i>]\n",
+    "    A(\"Process A\"):::fg\n",
+    "end\n",
+    "\n",
+    "B-->|\"3 kg\"|A\n",
+    "C-->|\"amounts: [60%, 40%] * 2 kWh<br/> dates: [0, +10]\" years|B\n",
+    "\n",
+    "classDef fg color:#222832, fill:#3fb1c5, stroke:none;\n",
+    "classDef bg color:#222832, fill:#f4a259, stroke:none;\n",
+    "style background fill:none, stroke:none;\n",
+    "style foreground fill:none, stroke:none;\n",
+    "```\n",
+    "\n",
+    "We add the same distribution to the `C → B` exchange in **both** background variants, so the temporal behaviour is defined consistently for each point in time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ab591abf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T08:08:49.037461Z",
+     "iopub.status.busy": "2026-06-22T08:08:49.037363Z",
+     "iopub.status.idle": "2026-06-22T08:08:49.313368Z",
+     "shell.execute_reply": "2026-06-22T08:08:49.313021Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.308\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.utils\u001b[0m:\u001b[36madd_temporal_distribution_to_exchange\u001b[0m:\u001b[36m604\u001b[0m - \u001b[1mAdded temporal distribution to exchange Exchange: 2 None 'C' (None, somewhere, None) to 'B' (None, somewhere, None).\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.311\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.utils\u001b[0m:\u001b[36madd_temporal_distribution_to_exchange\u001b[0m:\u001b[36m604\u001b[0m - \u001b[1mAdded temporal distribution to exchange Exchange: 2 None 'C' (None, somewhere, None) to 'B' (None, somewhere, None).\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from bw_temporalis import TemporalDistribution\n",
+    "from bw_timex.utils import add_temporal_distribution_to_exchange\n",
+    "\n",
+    "td_c_to_b = TemporalDistribution(\n",
+    "    date=np.array([0, 10], dtype=\"timedelta64[Y]\"),\n",
+    "    amount=np.array([0.6, 0.4]),\n",
+    ")\n",
+    "\n",
+    "for background in [\"background_2020\", \"background_2040\"]:\n",
+    "    add_temporal_distribution_to_exchange(\n",
+    "        temporal_distribution=td_c_to_b,\n",
+    "        input_code=\"C\",\n",
+    "        input_database=background,\n",
+    "        output_code=\"B\",\n",
+    "        output_database=background,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "98ad1021",
+   "metadata": {},
+   "source": [
+    "## Without background traversal (the default)\n",
+    "\n",
+    "By default, `bw_timex` stops at the first background process (`B`) and treats its supply chain as a static snapshot. The component `B` is sourced from a time-interpolated mix of the 2020 and 2040 databases (because the demand occurs in 2024), but the temporal distribution *inside* `B` (`C → B`) is **not** honoured — the background is static."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d44daabf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T08:08:49.314829Z",
+     "iopub.status.busy": "2026-06-22T08:08:49.314709Z",
+     "iopub.status.idle": "2026-06-22T08:08:49.352568Z",
+     "shell.execute_reply": "2026-06-22T08:08:49.352155Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.315\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m136\u001b[0m - \u001b[1mInitializing TimexLCA object...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.316\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m153\u001b[0m - \u001b[1mCalculating base LCA...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.331\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m170\u001b[0m - \u001b[1mCollecting node infos...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.332\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m336\u001b[0m - \u001b[1mNo edge filter function provided. Skipping all edges in background databases.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.333\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m357\u001b[0m - \u001b[1mCreating activity time mapping...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.333\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m112\u001b[0m - \u001b[1mTraversing supply chain graph...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.336\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m186\u001b[0m - \u001b[1mBuilding timeline...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting graph traversal\n",
+      "Calculation count: 1\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>hash_producer</th>\n",
+       "      <th>time_mapped_producer</th>\n",
+       "      <th>date_producer</th>\n",
+       "      <th>producer</th>\n",
+       "      <th>producer_name</th>\n",
+       "      <th>hash_consumer</th>\n",
+       "      <th>time_mapped_consumer</th>\n",
+       "      <th>date_consumer</th>\n",
+       "      <th>consumer</th>\n",
+       "      <th>consumer_name</th>\n",
+       "      <th>amount</th>\n",
+       "      <th>temporal_market_shares</th>\n",
+       "      <th>temporal_evolution</th>\n",
+       "      <th>temporal_evolution_reference</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>327359257374097410</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>327359257227296768</td>\n",
+       "      <td>B</td>\n",
+       "      <td>2024</td>\n",
+       "      <td>327359257374097411</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>327359257286017024</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>{'background_2020': 0.8, 'background_2040': 0.2}</td>\n",
+       "      <td>None</td>\n",
+       "      <td>producer</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>327359257374097411</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>327359257286017024</td>\n",
+       "      <td>A</td>\n",
+       "      <td>2024</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>producer</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   hash_producer  time_mapped_producer date_producer            producer  \\\n",
+       "0           2024    327359257374097410    2024-01-01  327359257227296768   \n",
+       "1           2024    327359257374097411    2024-01-01  327359257286017024   \n",
+       "\n",
+       "  producer_name  hash_consumer  time_mapped_consumer date_consumer  \\\n",
+       "0             B           2024    327359257374097411    2024-01-01   \n",
+       "1             A           2024                    -1    2024-01-01   \n",
+       "\n",
+       "             consumer consumer_name amount  \\\n",
+       "0  327359257286017024             A    3.0   \n",
+       "1                  -1            -1    1.0   \n",
+       "\n",
+       "                             temporal_market_shares temporal_evolution  \\\n",
+       "0  {'background_2020': 0.8, 'background_2040': 0.2}               None   \n",
+       "1                                              None               None   \n",
+       "\n",
+       "  temporal_evolution_reference  \n",
+       "0                     producer  \n",
+       "1                     producer  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from bw_timex import TimexLCA\n",
+    "\n",
+    "tlca_static_bg = TimexLCA(\n",
+    "    demand={(\"foreground\", \"A\"): 1},\n",
+    "    method=(\"our\", \"method\"),\n",
+    "    database_dates=database_dates,\n",
+    ")\n",
+    "tlca_static_bg.build_timeline(starting_datetime=\"2024-01-01\")\n",
+    "tlca_static_bg.timeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06e1dfe9",
+   "metadata": {},
+   "source": [
+    "The timeline stops at `B`: it is a single \"temporal market\" in 2024, split between the two background variants. We never see electricity `C` in the timeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e4b25e4c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T08:08:49.353869Z",
+     "iopub.status.busy": "2026-06-22T08:08:49.353795Z",
+     "iopub.status.idle": "2026-06-22T08:08:49.370227Z",
+     "shell.execute_reply": "2026-06-22T08:08:49.369872Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.359\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m507\u001b[0m - \u001b[1mExpanding matrices...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.361\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m526\u001b[0m - \u001b[1mCalculating dynamic inventory...\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "61.20000000000002"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tlca_static_bg.lci()\n",
+    "tlca_static_bg.static_lcia()\n",
+    "tlca_static_bg.static_score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae70ee1d",
+   "metadata": {},
+   "source": [
+    "## With `traverse_background=True`\n",
+    "\n",
+    "Now we switch on background traversal. The only change is one keyword argument to `build_timeline`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "936fb39b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T08:08:49.371504Z",
+     "iopub.status.busy": "2026-06-22T08:08:49.371429Z",
+     "iopub.status.idle": "2026-06-22T08:08:49.395760Z",
+     "shell.execute_reply": "2026-06-22T08:08:49.395276Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.371\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m136\u001b[0m - \u001b[1mInitializing TimexLCA object...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.372\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m153\u001b[0m - \u001b[1mCalculating base LCA...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.378\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m170\u001b[0m - \u001b[1mCollecting node infos...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.379\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m303\u001b[0m - \u001b[33m\u001b[1mtraverse_background=True with graph_traversal='priority': non-referenced background variants are not placed on the priority heap; each variant subtree is walked in full via proxy reads when its parent edge is reached. The referenced-system heap exploration order is unchanged and explored amounts are exact (identical to graph_traversal='bfs' for these subtrees).\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.380\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m357\u001b[0m - \u001b[1mCreating activity time mapping...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.380\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m112\u001b[0m - \u001b[1mTraversing supply chain graph...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.384\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m186\u001b[0m - \u001b[1mBuilding timeline...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting graph traversal\n",
+      "Calculation count: 2\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date_producer</th>\n",
+       "      <th>producer_name</th>\n",
+       "      <th>date_consumer</th>\n",
+       "      <th>consumer_name</th>\n",
+       "      <th>amount</th>\n",
+       "      <th>temporal_market_shares</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>B</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>A</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>C</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>B</td>\n",
+       "      <td>1.2</td>\n",
+       "      <td>{'background_2020': 0.8, 'background_2040': 0.2}</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>A</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2034-01-01</td>\n",
+       "      <td>C</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>B</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>{'background_2020': 0.3, 'background_2040': 0.7}</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  date_producer producer_name date_consumer consumer_name amount  \\\n",
+       "0    2024-01-01             B    2024-01-01             A    3.0   \n",
+       "1    2024-01-01             C    2024-01-01             B    1.2   \n",
+       "2    2024-01-01             A    2024-01-01            -1    1.0   \n",
+       "3    2034-01-01             C    2024-01-01             B    0.8   \n",
+       "\n",
+       "                             temporal_market_shares  \n",
+       "0                                              None  \n",
+       "1  {'background_2020': 0.8, 'background_2040': 0.2}  \n",
+       "2                                              None  \n",
+       "3  {'background_2020': 0.3, 'background_2040': 0.7}  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tlca_dynamic_bg = TimexLCA(\n",
+    "    demand={(\"foreground\", \"A\"): 1},\n",
+    "    method=(\"our\", \"method\"),\n",
+    "    database_dates=database_dates,\n",
+    ")\n",
+    "tlca_dynamic_bg.build_timeline(\n",
+    "    starting_datetime=\"2024-01-01\",\n",
+    "    traverse_background=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "297d140c",
+   "metadata": {},
+   "source": [
+    "Now the traversal descends into `B` and the `C → B` temporal distribution takes effect. Electricity `C` shows up **twice**, and each cohort is sourced from a time-interpolated grid mix:\n",
+    "\n",
+    "- 60% of it in **2024** — mostly the 2020 grid (`{'background_2020': 0.8, 'background_2040': 0.2}`), and\n",
+    "- 40% of it in **2034** — mostly the cleaner 2040 grid (`{'background_2020': 0.3, 'background_2040': 0.7}`).\n",
+    "\n",
+    "Because the later electricity leans on the future, cleaner grid, the total impact is lower:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bcd18cf7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T08:08:49.396974Z",
+     "iopub.status.busy": "2026-06-22T08:08:49.396899Z",
+     "iopub.status.idle": "2026-06-22T08:08:49.414524Z",
+     "shell.execute_reply": "2026-06-22T08:08:49.414221Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.401\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m507\u001b[0m - \u001b[1mExpanding matrices...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.405\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m526\u001b[0m - \u001b[1mCalculating dynamic inventory...\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "56.39999999999999"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tlca_dynamic_bg.lci()\n",
+    "tlca_dynamic_bg.static_lcia()\n",
+    "tlca_dynamic_bg.static_score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51735379",
+   "metadata": {},
+   "source": [
+    "## Comparison\n",
+    "\n",
+    "| | CO₂ score |\n",
+    "|---|---|\n",
+    "| Plain static LCA (2020 grid only) | 66.0 |\n",
+    "| `TimexLCA`, static background | 61.2 |\n",
+    "| `TimexLCA`, `traverse_background=True` | 56.4 |\n",
+    "\n",
+    "We can check the `traverse_background=True` number by hand. The demand pulls `3 × 2 = 6` kWh of electricity, split 60/40 by the temporal distribution, with each cohort interpolated linearly between the 2020 and 2040 grids:\n",
+    "\n",
+    "- **3.6 kWh in 2024** → `0.8 × 11 + 0.2 × 7 = 10.2` kg/kWh → `36.72` kg\n",
+    "- **2.4 kWh in 2034** → `0.3 × 11 + 0.7 × 7 = 8.2` kg/kWh → `19.68` kg\n",
+    "\n",
+    "Total: `56.4` kg CO₂. ✅\n",
+    "\n",
+    "> **Note:** This works identically with `graph_traversal=\"bfs\"`. In the default `\"priority\"` mode a one-time informational warning is emitted, because non-referenced background variants are explored via direct database reads rather than through the priority heap — the explored amounts are exact either way."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6bc846b",
+   "metadata": {},
+   "source": [
+    "## Composing foreground and background temporal distributions\n",
+    "\n",
+    "Background distributions compose with foreground ones. Suppose `A` also doesn't buy component `B` all at once — 70% now and 30% in six years. We add a `TemporalDistribution` to the foreground edge `B → A` (just like in [Getting Started](getting_started.ipynb)) and rebuild with `traverse_background=True`. Now **both** edges carry temporal information:\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "subgraph background[<i>background</i>]\n",
+    "    B(\"Component B\"):::bg\n",
+    "    C(\"Electricity C\"):::bg\n",
+    "end\n",
+    "\n",
+    "subgraph foreground[<i>foreground</i>]\n",
+    "    A(\"Process A\"):::fg\n",
+    "end\n",
+    "\n",
+    "B-->|\"amounts: [70%, 30%] * 3 kg<br/> dates: [0, +6]\" years|A\n",
+    "C-->|\"amounts: [60%, 40%] * 2 kWh<br/> dates: [0, +10]\" years|B\n",
+    "\n",
+    "classDef fg color:#222832, fill:#3fb1c5, stroke:none;\n",
+    "classDef bg color:#222832, fill:#f4a259, stroke:none;\n",
+    "style background fill:none, stroke:none;\n",
+    "style foreground fill:none, stroke:none;\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b2d881bb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T08:08:49.415999Z",
+     "iopub.status.busy": "2026-06-22T08:08:49.415925Z",
+     "iopub.status.idle": "2026-06-22T08:08:49.445670Z",
+     "shell.execute_reply": "2026-06-22T08:08:49.445208Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.420\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.utils\u001b[0m:\u001b[36madd_temporal_distribution_to_exchange\u001b[0m:\u001b[36m604\u001b[0m - \u001b[1mAdded temporal distribution to exchange Exchange: 3 None 'B' (None, somewhere, None) to 'A' (None, somewhere, None).\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.420\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m136\u001b[0m - \u001b[1mInitializing TimexLCA object...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.420\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m153\u001b[0m - \u001b[1mCalculating base LCA...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.429\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m170\u001b[0m - \u001b[1mCollecting node infos...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.430\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m303\u001b[0m - \u001b[33m\u001b[1mtraverse_background=True with graph_traversal='priority': non-referenced background variants are not placed on the priority heap; each variant subtree is walked in full via proxy reads when its parent edge is reached. The referenced-system heap exploration order is unchanged and explored amounts are exact (identical to graph_traversal='bfs' for these subtrees).\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.431\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m357\u001b[0m - \u001b[1mCreating activity time mapping...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.431\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m112\u001b[0m - \u001b[1mTraversing supply chain graph...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.435\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m186\u001b[0m - \u001b[1mBuilding timeline...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting graph traversal\n",
+      "Calculation count: 2\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>hash_producer</th>\n",
+       "      <th>time_mapped_producer</th>\n",
+       "      <th>date_producer</th>\n",
+       "      <th>producer</th>\n",
+       "      <th>producer_name</th>\n",
+       "      <th>hash_consumer</th>\n",
+       "      <th>time_mapped_consumer</th>\n",
+       "      <th>date_consumer</th>\n",
+       "      <th>consumer</th>\n",
+       "      <th>consumer_name</th>\n",
+       "      <th>amount</th>\n",
+       "      <th>temporal_market_shares</th>\n",
+       "      <th>temporal_evolution</th>\n",
+       "      <th>temporal_evolution_reference</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>327359257374097410</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>327359257227296768</td>\n",
+       "      <td>B</td>\n",
+       "      <td>2024</td>\n",
+       "      <td>327359257374097412</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>327359257286017024</td>\n",
+       "      <td>A</td>\n",
+       "      <td>2.1</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>producer</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>327359257374097411</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>327359257227296769</td>\n",
+       "      <td>C</td>\n",
+       "      <td>2024</td>\n",
+       "      <td>327359257374097410</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>327359257227296768</td>\n",
+       "      <td>B</td>\n",
+       "      <td>1.2</td>\n",
+       "      <td>{'background_2020': 0.8, 'background_2040': 0.2}</td>\n",
+       "      <td>None</td>\n",
+       "      <td>producer</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2024</td>\n",
+       "      <td>327359257374097412</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>327359257286017024</td>\n",
+       "      <td>A</td>\n",
+       "      <td>2024</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>producer</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2030</td>\n",
+       "      <td>327359257374097413</td>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>327359257227296768</td>\n",
+       "      <td>B</td>\n",
+       "      <td>2024</td>\n",
+       "      <td>327359257374097412</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>327359257286017024</td>\n",
+       "      <td>A</td>\n",
+       "      <td>0.9</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>producer</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2030</td>\n",
+       "      <td>327359257374097414</td>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>327359257227296769</td>\n",
+       "      <td>C</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>327359257374097413</td>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>327359257227296768</td>\n",
+       "      <td>B</td>\n",
+       "      <td>1.2</td>\n",
+       "      <td>{'background_2020': 0.5, 'background_2040': 0.5}</td>\n",
+       "      <td>None</td>\n",
+       "      <td>producer</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2034</td>\n",
+       "      <td>327359257374097415</td>\n",
+       "      <td>2034-01-01</td>\n",
+       "      <td>327359257227296769</td>\n",
+       "      <td>C</td>\n",
+       "      <td>2024</td>\n",
+       "      <td>327359257374097410</td>\n",
+       "      <td>2024-01-01</td>\n",
+       "      <td>327359257227296768</td>\n",
+       "      <td>B</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>{'background_2020': 0.3, 'background_2040': 0.7}</td>\n",
+       "      <td>None</td>\n",
+       "      <td>producer</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2040</td>\n",
+       "      <td>327359257374097416</td>\n",
+       "      <td>2040-01-01</td>\n",
+       "      <td>327359257227296769</td>\n",
+       "      <td>C</td>\n",
+       "      <td>2030</td>\n",
+       "      <td>327359257374097413</td>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>327359257227296768</td>\n",
+       "      <td>B</td>\n",
+       "      <td>0.8</td>\n",
+       "      <td>{'background_2040': 1}</td>\n",
+       "      <td>None</td>\n",
+       "      <td>producer</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   hash_producer  time_mapped_producer date_producer            producer  \\\n",
+       "0           2024    327359257374097410    2024-01-01  327359257227296768   \n",
+       "1           2024    327359257374097411    2024-01-01  327359257227296769   \n",
+       "2           2024    327359257374097412    2024-01-01  327359257286017024   \n",
+       "3           2030    327359257374097413    2030-01-01  327359257227296768   \n",
+       "4           2030    327359257374097414    2030-01-01  327359257227296769   \n",
+       "5           2034    327359257374097415    2034-01-01  327359257227296769   \n",
+       "6           2040    327359257374097416    2040-01-01  327359257227296769   \n",
+       "\n",
+       "  producer_name  hash_consumer  time_mapped_consumer date_consumer  \\\n",
+       "0             B           2024    327359257374097412    2024-01-01   \n",
+       "1             C           2024    327359257374097410    2024-01-01   \n",
+       "2             A           2024                    -1    2024-01-01   \n",
+       "3             B           2024    327359257374097412    2024-01-01   \n",
+       "4             C           2030    327359257374097413    2030-01-01   \n",
+       "5             C           2024    327359257374097410    2024-01-01   \n",
+       "6             C           2030    327359257374097413    2030-01-01   \n",
+       "\n",
+       "             consumer consumer_name amount  \\\n",
+       "0  327359257286017024             A    2.1   \n",
+       "1  327359257227296768             B    1.2   \n",
+       "2                  -1            -1    1.0   \n",
+       "3  327359257286017024             A    0.9   \n",
+       "4  327359257227296768             B    1.2   \n",
+       "5  327359257227296768             B    0.8   \n",
+       "6  327359257227296768             B    0.8   \n",
+       "\n",
+       "                             temporal_market_shares temporal_evolution  \\\n",
+       "0                                              None               None   \n",
+       "1  {'background_2020': 0.8, 'background_2040': 0.2}               None   \n",
+       "2                                              None               None   \n",
+       "3                                              None               None   \n",
+       "4  {'background_2020': 0.5, 'background_2040': 0.5}               None   \n",
+       "5  {'background_2020': 0.3, 'background_2040': 0.7}               None   \n",
+       "6                            {'background_2040': 1}               None   \n",
+       "\n",
+       "  temporal_evolution_reference  \n",
+       "0                     producer  \n",
+       "1                     producer  \n",
+       "2                     producer  \n",
+       "3                     producer  \n",
+       "4                     producer  \n",
+       "5                     producer  \n",
+       "6                     producer  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "add_temporal_distribution_to_exchange(\n",
+    "    temporal_distribution=TemporalDistribution(\n",
+    "        date=np.array([0, 6], dtype=\"timedelta64[Y]\"),\n",
+    "        amount=np.array([0.7, 0.3]),\n",
+    "    ),\n",
+    "    input_code=\"B\",\n",
+    "    input_database=\"background_2020\",\n",
+    "    output_code=\"A\",\n",
+    "    output_database=\"foreground\",\n",
+    ")\n",
+    "\n",
+    "tlca_both = TimexLCA(\n",
+    "    demand={(\"foreground\", \"A\"): 1},\n",
+    "    method=(\"our\", \"method\"),\n",
+    "    database_dates=database_dates,\n",
+    ")\n",
+    "tlca_both.build_timeline(starting_datetime=\"2024-01-01\", traverse_background=True)\n",
+    "tlca_both.timeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "442daa1a",
+   "metadata": {},
+   "source": [
+    "The foreground distribution (*when* `B` is bought) convolves with the background distribution (*when* `B` uses electricity). Component `B` now appears in **2024** and **2030**, and electricity `C` fans out into **four** cohorts — 2024, 2030, 2034 and 2040 — each routed to the appropriate grid. The score drops further:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f62d8e8f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T08:08:49.446963Z",
+     "iopub.status.busy": "2026-06-22T08:08:49.446878Z",
+     "iopub.status.idle": "2026-06-22T08:08:49.466326Z",
+     "shell.execute_reply": "2026-06-22T08:08:49.465882Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.452\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m507\u001b[0m - \u001b[1mExpanding matrices...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 10:08:49.456\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m526\u001b[0m - \u001b[1mCalculating dynamic inventory...\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "54.239999999999995"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tlca_both.lci()\n",
+    "tlca_both.static_lcia()\n",
+    "tlca_both.static_score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "924c2fbb",
+   "metadata": {},
+   "source": [
+    "## Recap\n",
+    "\n",
+    "Temporalizing the background is just two things:\n",
+    "\n",
+    "1. Put a `TemporalDistribution` on a background exchange (in each time-specific background database).\n",
+    "2. Pass `traverse_background=True` to `build_timeline`.\n",
+    "\n",
+    "Foreground and background temporal distributions compose automatically through the supply-chain convolution, and everything else — `lci()`, `static_lcia()`, dynamic characterization — works exactly as in [Getting Started](getting_started.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "bw-timex (3.13.9.final.0)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/example_electric_vehicle_premise.ipynb
+++ b/notebooks/example_electric_vehicle_premise.ipynb
@@ -1137,7 +1137,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "timex",
+   "display_name": "bw-timex (3.13.9.final.0)",
    "language": "python",
    "name": "python3"
   },
@@ -1151,7 +1151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.2"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/teaching/teaching_example_ev_premise.ipynb
+++ b/notebooks/teaching/teaching_example_ev_premise.ipynb
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 1,
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 4,
    "metadata": {
     "jupyter": {
      "source_hidden": true
@@ -153,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -222,7 +222,7 @@
        "21882.062546933954"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -276,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,15 +340,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-06-11 19:27:36.389\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.utils\u001b[0m:\u001b[36madd_temporal_distribution_to_exchange\u001b[0m:\u001b[36m500\u001b[0m - \u001b[1mAdded temporal distribution to exchange Exchange: 20000.0 kilowatt hour 'market group for electricity, low voltage' (kilowatt hour, GLO, None) to 'driving an electric vehicle' (pkm over ev lifetime, GLO, None).\u001b[0m\n",
-      "\u001b[32m2026-06-11 19:27:36.396\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.utils\u001b[0m:\u001b[36madd_temporal_distribution_to_exchange\u001b[0m:\u001b[36m500\u001b[0m - \u001b[1mAdded temporal distribution to exchange Exchange: -280 kilogram 'market for used Li-ion battery' (kilogram, GLO, None) to 'driving an electric vehicle' (pkm over ev lifetime, GLO, None).\u001b[0m\n"
+      "\u001b[32m2026-06-18 14:53:57.995\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.utils\u001b[0m:\u001b[36madd_temporal_distribution_to_exchange\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1mAdded temporal distribution to exchange Exchange: 20000.0 kilowatt hour 'market group for electricity, low voltage' (kilowatt hour, GLO, None) to 'driving an electric vehicle' (pkm over ev lifetime, GLO, None).\u001b[0m\n",
+      "\u001b[32m2026-06-18 14:53:57.999\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.utils\u001b[0m:\u001b[36madd_temporal_distribution_to_exchange\u001b[0m:\u001b[36m544\u001b[0m - \u001b[1mAdded temporal distribution to exchange Exchange: -280 kilogram 'market for used Li-ion battery' (kilogram, GLO, None) to 'driving an electric vehicle' (pkm over ev lifetime, GLO, None).\u001b[0m\n"
      ]
     }
    ],
@@ -389,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,18 +412,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-06-11 19:29:54.567\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m136\u001b[0m - \u001b[1mInitializing TimexLCA object...\u001b[0m\n",
-      "\u001b[32m2026-06-11 19:29:54.570\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m153\u001b[0m - \u001b[1mCalculating base LCA...\u001b[0m\n",
+      "\u001b[32m2026-06-18 14:54:00.085\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m136\u001b[0m - \u001b[1mInitializing TimexLCA object...\u001b[0m\n",
+      "\u001b[32m2026-06-18 14:54:00.087\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m153\u001b[0m - \u001b[1mCalculating base LCA...\u001b[0m\n",
       "/Users/timodiepers/Documents/Coding/bw_timex/.venv/lib/python3.13/site-packages/scikits/umfpack/umfpack.py:737: UmfpackWarning: (almost) singular matrix! (estimated cond. number: 1.65e+13)\n",
       "  warnings.warn(msg, UmfpackWarning)\n",
-      "\u001b[32m2026-06-11 19:29:57.185\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m170\u001b[0m - \u001b[1mCollecting node infos...\u001b[0m\n"
+      "\u001b[32m2026-06-18 14:54:02.409\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m170\u001b[0m - \u001b[1mCollecting node infos...\u001b[0m\n"
      ]
     }
    ],
@@ -435,18 +435,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-06-11 19:30:38.973\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m301\u001b[0m - \u001b[1mNo edge filter function provided. Skipping all edges in background databases.\u001b[0m\n",
-      "\u001b[32m2026-06-11 19:30:44.465\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m319\u001b[0m - \u001b[1mCreating activity time mapping...\u001b[0m\n",
-      "\u001b[32m2026-06-11 19:30:44.618\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m103\u001b[0m - \u001b[1mTraversing supply chain graph...\u001b[0m\n",
-      "\u001b[32m2026-06-11 19:30:44.698\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m159\u001b[0m - \u001b[1mBuilding timeline...\u001b[0m\n",
-      "\u001b[32m2026-06-11 19:30:44.735\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36mget_weights_for_interpolation_between_nearest_years\u001b[0m:\u001b[36m583\u001b[0m - \u001b[1mReference date 2040-04-01 00:00:00 is higher than all provided dates. Data will be taken from the closest lower year.\u001b[0m\n"
+      "\u001b[32m2026-06-18 14:54:09.942\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m301\u001b[0m - \u001b[1mNo edge filter function provided. Skipping all edges in background databases.\u001b[0m\n",
+      "\u001b[32m2026-06-18 14:54:14.480\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m319\u001b[0m - \u001b[1mCreating activity time mapping...\u001b[0m\n",
+      "\u001b[32m2026-06-18 14:54:14.611\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m103\u001b[0m - \u001b[1mTraversing supply chain graph...\u001b[0m\n",
+      "\u001b[32m2026-06-18 14:54:14.659\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m160\u001b[0m - \u001b[1mBuilding timeline...\u001b[0m\n",
+      "\u001b[32m2026-06-18 14:54:14.681\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36mget_weights_for_interpolation_between_nearest_years\u001b[0m:\u001b[36m587\u001b[0m - \u001b[1mReference date 2040-04-01 00:00:00 is higher than all provided dates. Data will be taken from the closest lower year.\u001b[0m\n"
      ]
     },
     {
@@ -959,7 +959,7 @@
        "38               {'ei312_REMIND-EU_SSP2_NDC_2040': 1}  "
       ]
      },
-     "execution_count": 27,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1004,15 +1004,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-06-11 19:35:05.707\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m453\u001b[0m - \u001b[1mExpanding matrices...\u001b[0m\n",
-      "\u001b[32m2026-06-11 19:35:05.733\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m472\u001b[0m - \u001b[1mCalculating dynamic inventory...\u001b[0m\n",
+      "\u001b[32m2026-06-18 14:54:15.141\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m453\u001b[0m - \u001b[1mExpanding matrices...\u001b[0m\n",
+      "\u001b[32m2026-06-18 14:54:15.223\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m472\u001b[0m - \u001b[1mCalculating dynamic inventory...\u001b[0m\n",
       "/Users/timodiepers/Documents/Coding/bw_timex/.venv/lib/python3.13/site-packages/scikits/umfpack/umfpack.py:737: UmfpackWarning: (almost) singular matrix! (estimated cond. number: 4.97e+12)\n",
       "  warnings.warn(msg, UmfpackWarning)\n",
       "/Users/timodiepers/Documents/Coding/bw_timex/.venv/lib/python3.13/site-packages/scikits/umfpack/umfpack.py:737: UmfpackWarning: (almost) singular matrix! (estimated cond. number: 4.97e+12)\n",
@@ -1047,7 +1047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1056,7 +1056,7 @@
        "13372.0761526528"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1585,7 +1585,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "bw-timex (3.13.9.final.0)",
    "language": "python",
    "name": "python3"
   },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from .fixtures.background_td_db_fixture import background_td_db
+from .fixtures.background_td_deep_db_fixture import background_td_deep_db
 from .fixtures.dynamic_biomatrix_db_fixture import dynamic_biosphere_matrix_db
 from .fixtures.explicit_process_product_db_fixture import explicit_process_product_db
 from .fixtures.nonunitary_db_fixture import nonunitary_db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from .fixtures.background_td_db_fixture import background_td_db
 from .fixtures.dynamic_biomatrix_db_fixture import dynamic_biosphere_matrix_db
 from .fixtures.explicit_process_product_db_fixture import explicit_process_product_db
 from .fixtures.nonunitary_db_fixture import nonunitary_db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from .fixtures.dynamic_biomatrix_db_fixture import dynamic_biosphere_matrix_db
+from .fixtures.explicit_process_product_db_fixture import explicit_process_product_db
 from .fixtures.nonunitary_db_fixture import nonunitary_db
 from .fixtures.process_at_base_database_time_db_fixture import (
     process_at_base_database_time_db,
@@ -14,3 +15,4 @@ from .fixtures.temporal_evolution_db_fixture import (
     temporal_evolution_db,
 )
 from .fixtures.vehicle_db_fixture import vehicle_db
+from .fixtures.vehicle_explicit_db_fixture import vehicle_explicit_db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ from .fixtures.background_td_db_fixture import background_td_db
 from .fixtures.background_td_deep_db_fixture import background_td_deep_db
 from .fixtures.background_td_deep_tdvar_db_fixture import background_td_deep_tdvar_db
 from .fixtures.background_td_fg_and_bg_db_fixture import background_td_fg_and_bg_db
+from .fixtures.background_td_single_db_fixture import background_td_single_db
+from .fixtures.explicit_background_td_db_fixture import explicit_background_td_db
 from .fixtures.background_td_multdate_consumer_fixture import (
     background_td_multidate_consumer_db,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 from .fixtures.background_td_db_fixture import background_td_db
 from .fixtures.background_td_deep_db_fixture import background_td_deep_db
 from .fixtures.background_td_deep_tdvar_db_fixture import background_td_deep_tdvar_db
+from .fixtures.background_td_multdate_consumer_fixture import (
+    background_td_multidate_consumer_db,
+)
 from .fixtures.dynamic_biomatrix_db_fixture import dynamic_biosphere_matrix_db
 from .fixtures.explicit_process_product_db_fixture import explicit_process_product_db
 from .fixtures.nonunitary_db_fixture import nonunitary_db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from .fixtures.background_td_db_fixture import background_td_db
 from .fixtures.background_td_deep_db_fixture import background_td_deep_db
+from .fixtures.background_td_deep_tdvar_db_fixture import background_td_deep_tdvar_db
 from .fixtures.dynamic_biomatrix_db_fixture import dynamic_biosphere_matrix_db
 from .fixtures.explicit_process_product_db_fixture import explicit_process_product_db
 from .fixtures.nonunitary_db_fixture import nonunitary_db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from .fixtures.background_td_db_fixture import background_td_db
 from .fixtures.background_td_deep_db_fixture import background_td_deep_db
 from .fixtures.background_td_deep_tdvar_db_fixture import background_td_deep_tdvar_db
+from .fixtures.background_td_fg_and_bg_db_fixture import background_td_fg_and_bg_db
 from .fixtures.background_td_multdate_consumer_fixture import (
     background_td_multidate_consumer_db,
 )

--- a/tests/fixtures/background_td_db_fixture.py
+++ b/tests/fixtures/background_td_db_fixture.py
@@ -1,0 +1,74 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def background_td_db():
+    """foreground.fu -> background.bg_A -> background.bg_B -> CO2.
+
+    Two dated background variants (2020, 2030). The bg_A -> bg_B exchange
+    carries a temporal_distribution so that, when traversed, bg_B is spread
+    over time and sourced from the temporally-appropriate variant.
+    """
+    biosphere = bd.Database("biosphere")
+    biosphere.write(
+        {
+            ("biosphere", "CO2"): {"type": "emission", "name": "carbon dioxide"},
+        }
+    )
+    node_co2 = biosphere.get("CO2")
+
+    foreground = bd.Database("foreground")
+    foreground.register()
+
+    background_2020 = bd.Database("background_2020")
+    background_2020.register()
+    background_2030 = bd.Database("background_2030")
+    background_2030.register()
+
+    # --- foreground ---
+    fu = foreground.new_node("fu", name="fu", unit="unit")
+    fu["reference product"] = "fu"
+    fu.save()
+    fu.new_edge(input=fu, amount=1, type="production").save()
+
+    # --- build both background variants identically (structure) ---
+    # bg_A -> bg_B TD: spread 60% at +0y, 40% at +10y from bg_A's time.
+    td_a_to_b = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+
+    variant_nodes = {}
+    for db, dbname in [(background_2020, "background_2020"), (background_2030, "background_2030")]:
+        bg_a = db.new_node("bg_A", name="bg_A", unit="kWh")
+        bg_a["reference product"] = "bg_A"
+        bg_a.save()
+        bg_b = db.new_node("bg_B", name="bg_B", unit="kg")
+        bg_b["reference product"] = "bg_B"
+        bg_b.save()
+
+        bg_a.new_edge(input=bg_a, amount=1, type="production").save()
+        bg_b.new_edge(input=bg_b, amount=1, type="production").save()
+
+        a_to_b = bg_a.new_edge(input=bg_b, amount=5, type="technosphere")
+        a_to_b["temporal_distribution"] = td_a_to_b
+        a_to_b.save()
+
+        bg_b.new_edge(input=node_co2, amount=1, type="biosphere").save()
+        variant_nodes[dbname] = (bg_a, bg_b)
+
+    # --- foreground -> background_2020.bg_A ---
+    bg_a_2020 = variant_nodes["background_2020"][0]
+    fu.new_edge(input=bg_a_2020, amount=2, type="technosphere").save()
+
+    bd.Method(("GWP", "example")).write([(("biosphere", "CO2"), 1)])
+
+    for dbn in bd.databases:
+        bd.Database(dbn).process()
+
+    return variant_nodes

--- a/tests/fixtures/background_td_deep_db_fixture.py
+++ b/tests/fixtures/background_td_deep_db_fixture.py
@@ -1,0 +1,76 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def background_td_deep_db():
+    """fu -> bg_A -> bg_B -> bg_C -> CO2, two dated background variants.
+
+    bg_A -> bg_B carries a TD (60% +0y, 40% +10y), identical in both variants.
+    bg_B -> bg_C amount DIFFERS per variant (2020: 1, 2030: 7), so descending
+    into the 2034 cohort (which routes to background_2030) MUST read the 2030
+    variant's bg_B->bg_C exchange to get the correct result.
+    """
+    biosphere = bd.Database("biosphere")
+    biosphere.write(
+        {("biosphere", "CO2"): {"type": "emission", "name": "carbon dioxide"}}
+    )
+    node_co2 = biosphere.get("CO2")
+
+    foreground = bd.Database("foreground")
+    foreground.register()
+    background_2020 = bd.Database("background_2020")
+    background_2020.register()
+    background_2030 = bd.Database("background_2030")
+    background_2030.register()
+
+    fu = foreground.new_node("fu", name="fu", unit="unit")
+    fu["reference product"] = "fu"
+    fu.save()
+    fu.new_edge(input=fu, amount=1, type="production").save()
+
+    td_a_to_b = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+    b_to_c_amount = {"background_2020": 1.0, "background_2030": 7.0}
+
+    variant_nodes = {}
+    for db, dbname in [
+        (background_2020, "background_2020"),
+        (background_2030, "background_2030"),
+    ]:
+        bg_a = db.new_node("bg_A", name="bg_A", unit="kWh")
+        bg_a["reference product"] = "bg_A"
+        bg_a.save()
+        bg_b = db.new_node("bg_B", name="bg_B", unit="kg")
+        bg_b["reference product"] = "bg_B"
+        bg_b.save()
+        bg_c = db.new_node("bg_C", name="bg_C", unit="kg")
+        bg_c["reference product"] = "bg_C"
+        bg_c.save()
+
+        bg_a.new_edge(input=bg_a, amount=1, type="production").save()
+        bg_b.new_edge(input=bg_b, amount=1, type="production").save()
+        bg_c.new_edge(input=bg_c, amount=1, type="production").save()
+
+        a_to_b = bg_a.new_edge(input=bg_b, amount=5, type="technosphere")
+        a_to_b["temporal_distribution"] = td_a_to_b
+        a_to_b.save()
+
+        bg_b.new_edge(input=bg_c, amount=b_to_c_amount[dbname], type="technosphere").save()
+        bg_c.new_edge(input=node_co2, amount=1, type="biosphere").save()
+        variant_nodes[dbname] = {"bg_A": bg_a, "bg_B": bg_b, "bg_C": bg_c}
+
+    fu.new_edge(
+        input=variant_nodes["background_2020"]["bg_A"], amount=2, type="technosphere"
+    ).save()
+
+    bd.Method(("GWP", "example")).write([(("biosphere", "CO2"), 1)])
+    for dbn in bd.databases:
+        bd.Database(dbn).process()
+    return variant_nodes

--- a/tests/fixtures/background_td_deep_tdvar_db_fixture.py
+++ b/tests/fixtures/background_td_deep_tdvar_db_fixture.py
@@ -1,0 +1,88 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def background_td_deep_tdvar_db():
+    """fu -> bg_A -> bg_B -> bg_C -> CO2, two dated variants.
+
+    bg_A -> bg_B: TD 60% +0y / 40% +10y (identical both variants).
+    bg_B -> bg_C: amount 1 in BOTH variants, but the TD DIFFERS:
+        background_2020: 100% +0y (no spread)
+        background_2030:  50% +0y / 50% +20y
+    So the +20y bg_C cohorts appear ONLY if the 2030 variant's TD is read
+    (respective-variant TD reads). Amounts are equal across variants, so total
+    CO2 stays 10 kg; only the temporal distribution of bg_C differs.
+    """
+    biosphere = bd.Database("biosphere")
+    biosphere.write(
+        {("biosphere", "CO2"): {"type": "emission", "name": "carbon dioxide"}}
+    )
+    node_co2 = biosphere.get("CO2")
+
+    foreground = bd.Database("foreground")
+    foreground.register()
+    background_2020 = bd.Database("background_2020")
+    background_2020.register()
+    background_2030 = bd.Database("background_2030")
+    background_2030.register()
+
+    fu = foreground.new_node("fu", name="fu", unit="unit")
+    fu["reference product"] = "fu"
+    fu.save()
+    fu.new_edge(input=fu, amount=1, type="production").save()
+
+    td_a_to_b = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"), amount=np.array([0.6, 0.4])
+    )
+    td_b_to_c = {
+        "background_2020": TemporalDistribution(
+            date=np.array([0], dtype="timedelta64[Y]"), amount=np.array([1.0])
+        ),
+        "background_2030": TemporalDistribution(
+            date=np.array([0, 20], dtype="timedelta64[Y]"), amount=np.array([0.5, 0.5])
+        ),
+    }
+
+    variant_nodes = {}
+    for db, dbname in [
+        (background_2020, "background_2020"),
+        (background_2030, "background_2030"),
+    ]:
+        bg_a = db.new_node("bg_A", name="bg_A", unit="kWh")
+        bg_a["reference product"] = "bg_A"
+        bg_a.save()
+        bg_b = db.new_node("bg_B", name="bg_B", unit="kg")
+        bg_b["reference product"] = "bg_B"
+        bg_b.save()
+        bg_c = db.new_node("bg_C", name="bg_C", unit="kg")
+        bg_c["reference product"] = "bg_C"
+        bg_c.save()
+
+        bg_a.new_edge(input=bg_a, amount=1, type="production").save()
+        bg_b.new_edge(input=bg_b, amount=1, type="production").save()
+        bg_c.new_edge(input=bg_c, amount=1, type="production").save()
+
+        a_to_b = bg_a.new_edge(input=bg_b, amount=5, type="technosphere")
+        a_to_b["temporal_distribution"] = td_a_to_b
+        a_to_b.save()
+
+        b_to_c = bg_b.new_edge(input=bg_c, amount=1, type="technosphere")
+        b_to_c["temporal_distribution"] = td_b_to_c[dbname]
+        b_to_c.save()
+
+        bg_c.new_edge(input=node_co2, amount=1, type="biosphere").save()
+        variant_nodes[dbname] = {"bg_A": bg_a, "bg_B": bg_b, "bg_C": bg_c}
+
+    fu.new_edge(
+        input=variant_nodes["background_2020"]["bg_A"], amount=2, type="technosphere"
+    ).save()
+
+    bd.Method(("GWP", "example")).write([(("biosphere", "CO2"), 1)])
+    for dbn in bd.databases:
+        bd.Database(dbn).process()
+    return variant_nodes

--- a/tests/fixtures/background_td_fg_and_bg_db_fixture.py
+++ b/tests/fixtures/background_td_fg_and_bg_db_fixture.py
@@ -1,0 +1,83 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def background_td_fg_and_bg_db():
+    """fu -> A(fg) -> B(bg) -> C(bg) -> CO2, two dated background variants.
+
+    Exercises convolution of a FOREGROUND temporal distribution (on the
+    background->foreground edge B->A) with a BACKGROUND temporal distribution
+    (on the internal background edge C->B), while the traversal descends into
+    the background.
+
+    - A -> B (amount 3) carries a TD: 70% at +0y, 30% at +6y.
+    - B -> C (amount 2) carries a TD: 60% at +0y, 40% at +10y (same both variants).
+    - C -> CO2 decarbonizes: 11 kg in 2020, 7 kg in 2030.
+
+    C is an emission-only leaf, so it is routed to the temporally-appropriate
+    grid variant by date (the existing temporal-market mechanism); B is
+    descended into. The combination produces four electricity cohorts at
+    2024 / 2030 / 2034 / 2040.
+    """
+    biosphere = bd.Database("biosphere")
+    biosphere.write(
+        {("biosphere", "CO2"): {"type": "emission", "name": "CO2"}}
+    )
+    node_co2 = biosphere.get("CO2")
+
+    foreground = bd.Database("foreground")
+    foreground.register()
+    background_2020 = bd.Database("background_2020")
+    background_2020.register()
+    background_2030 = bd.Database("background_2030")
+    background_2030.register()
+
+    td_c_to_b = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"), amount=np.array([0.6, 0.4])
+    )
+    co2_per_variant = {"background_2020": 11, "background_2030": 7}
+
+    variant_nodes = {}
+    for db, dbname in [
+        (background_2020, "background_2020"),
+        (background_2030, "background_2030"),
+    ]:
+        b = db.new_node("B", name="B", unit="kg")
+        b["reference product"] = "B"
+        b.save()
+        c = db.new_node("C", name="C", unit="kWh")
+        c["reference product"] = "C"
+        c.save()
+
+        b.new_edge(input=b, amount=1, type="production").save()
+        c.new_edge(input=c, amount=1, type="production").save()
+
+        c_to_b = b.new_edge(input=c, amount=2, type="technosphere")
+        c_to_b["temporal_distribution"] = td_c_to_b
+        c_to_b.save()
+
+        c.new_edge(input=node_co2, amount=co2_per_variant[dbname], type="biosphere").save()
+        variant_nodes[dbname] = {"B": b, "C": c}
+
+    a = foreground.new_node("A", name="A", unit="unit")
+    a["reference product"] = "A"
+    a.save()
+    a.new_edge(input=a, amount=1, type="production").save()
+
+    b_to_a = a.new_edge(
+        input=variant_nodes["background_2020"]["B"], amount=3, type="technosphere"
+    )
+    b_to_a["temporal_distribution"] = TemporalDistribution(
+        date=np.array([0, 6], dtype="timedelta64[Y]"), amount=np.array([0.7, 0.3])
+    )
+    b_to_a.save()
+
+    bd.Method(("GWP", "example")).write([(("biosphere", "CO2"), 1)])
+    for dbn in bd.databases:
+        bd.Database(dbn).process()
+    return variant_nodes

--- a/tests/fixtures/background_td_multdate_consumer_fixture.py
+++ b/tests/fixtures/background_td_multdate_consumer_fixture.py
@@ -1,0 +1,85 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def background_td_multidate_consumer_db():
+    """fu -> bg_A -> bg_B -> bg_C -> CO2, with a TD on the FOREGROUND fu->bg_A exchange.
+
+    The TD on fu->bg_A (foreground exchange) spreads bg_A across two absolute
+    dates (2024 and 2034).  bg_A is a non-leaf background activity: it has
+    bg_A->bg_B, and bg_B itself has a technosphere input bg_B->bg_C, so bg_B
+    also qualifies for a variant split.
+
+    When the BFS queue processes bg_A (reached at 2 dates), it tries to trigger
+    a variant split on bg_A->bg_B.  At that point the consumer (bg_A) has a
+    multi-date abs_td (from the foreground TD), which fires the documented
+    NotImplementedError inside _emit_variant_split.
+    """
+    biosphere = bd.Database("biosphere")
+    biosphere.write(
+        {("biosphere", "CO2"): {"type": "emission", "name": "carbon dioxide"}}
+    )
+    node_co2 = biosphere.get("CO2")
+
+    foreground = bd.Database("foreground")
+    foreground.register()
+    background_2020 = bd.Database("background_2020")
+    background_2020.register()
+    background_2030 = bd.Database("background_2030")
+    background_2030.register()
+
+    fu = foreground.new_node("fu", name="fu", unit="unit")
+    fu["reference product"] = "fu"
+    fu.save()
+    fu.new_edge(input=fu, amount=1, type="production").save()
+
+    variant_nodes = {}
+    for db, dbname in [
+        (background_2020, "background_2020"),
+        (background_2030, "background_2030"),
+    ]:
+        bg_a = db.new_node("bg_A", name="bg_A", unit="kWh")
+        bg_a["reference product"] = "bg_A"
+        bg_a.save()
+        bg_b = db.new_node("bg_B", name="bg_B", unit="kg")
+        bg_b["reference product"] = "bg_B"
+        bg_b.save()
+        bg_c = db.new_node("bg_C", name="bg_C", unit="kg")
+        bg_c["reference product"] = "bg_C"
+        bg_c.save()
+
+        bg_a.new_edge(input=bg_a, amount=1, type="production").save()
+        bg_b.new_edge(input=bg_b, amount=1, type="production").save()
+        bg_c.new_edge(input=bg_c, amount=1, type="production").save()
+
+        # bg_A -> bg_B: plain amount.  bg_B has a further technosphere input
+        # (bg_B -> bg_C), so bg_B is a non-leaf and qualifies for variant split.
+        bg_a.new_edge(input=bg_b, amount=1, type="technosphere").save()
+        bg_b.new_edge(input=bg_c, amount=1, type="technosphere").save()
+        bg_c.new_edge(input=node_co2, amount=1, type="biosphere").save()
+
+        variant_nodes[dbname] = {"bg_A": bg_a, "bg_B": bg_b, "bg_C": bg_c}
+
+    # Foreground exchange WITH a TD: spreads bg_A consumption over +0y and +10y.
+    # This makes bg_A's abs_td have 2 dates when it enters the BFS queue.
+    # When the queue later processes bg_A's inputs (bg_A->bg_B) and tries the
+    # variant split, the consumer (bg_A) has a multi-date abs_td -> NotImplementedError.
+    td_fu_to_bg_a = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+    fg_exc = fu.new_edge(
+        input=variant_nodes["background_2020"]["bg_A"], amount=1, type="technosphere"
+    )
+    fg_exc["temporal_distribution"] = td_fu_to_bg_a
+    fg_exc.save()
+
+    bd.Method(("GWP", "example")).write([(("biosphere", "CO2"), 1)])
+    for dbn in bd.databases:
+        bd.Database(dbn).process()
+    return variant_nodes

--- a/tests/fixtures/background_td_multdate_consumer_fixture.py
+++ b/tests/fixtures/background_td_multdate_consumer_fixture.py
@@ -13,12 +13,14 @@ def background_td_multidate_consumer_db():
     The TD on fu->bg_A (foreground exchange) spreads bg_A across two absolute
     dates (2024 and 2034).  bg_A is a non-leaf background activity: it has
     bg_A->bg_B, and bg_B itself has a technosphere input bg_B->bg_C, so bg_B
-    also qualifies for a variant split.
+    qualifies for a variant split.
 
-    When the BFS queue processes bg_A (reached at 2 dates), it tries to trigger
-    a variant split on bg_A->bg_B.  At that point the consumer (bg_A) has a
-    multi-date abs_td (from the foreground TD), which fires the documented
-    NotImplementedError inside _emit_variant_split.
+    When the queue processes bg_A (reached at 2 dates) and triggers the variant
+    split on bg_A->bg_B, the consumer (bg_A) has a multi-date abs_td. The split
+    handles this by routing each consumer cohort independently.
+
+    bg_C -> CO2 decarbonizes (11 kg in 2020, 7 kg in 2030), so the result depends
+    on the per-cohort variant routing (it is not symmetric).
     """
     biosphere = bd.Database("biosphere")
     biosphere.write(
@@ -37,6 +39,8 @@ def background_td_multidate_consumer_db():
     fu["reference product"] = "fu"
     fu.save()
     fu.new_edge(input=fu, amount=1, type="production").save()
+
+    co2_per_variant = {"background_2020": 11, "background_2030": 7}
 
     variant_nodes = {}
     for db, dbname in [
@@ -61,14 +65,15 @@ def background_td_multidate_consumer_db():
         # (bg_B -> bg_C), so bg_B is a non-leaf and qualifies for variant split.
         bg_a.new_edge(input=bg_b, amount=1, type="technosphere").save()
         bg_b.new_edge(input=bg_c, amount=1, type="technosphere").save()
-        bg_c.new_edge(input=node_co2, amount=1, type="biosphere").save()
+        bg_c.new_edge(
+            input=node_co2, amount=co2_per_variant[dbname], type="biosphere"
+        ).save()
 
         variant_nodes[dbname] = {"bg_A": bg_a, "bg_B": bg_b, "bg_C": bg_c}
 
     # Foreground exchange WITH a TD: spreads bg_A consumption over +0y and +10y.
-    # This makes bg_A's abs_td have 2 dates when it enters the BFS queue.
-    # When the queue later processes bg_A's inputs (bg_A->bg_B) and tries the
-    # variant split, the consumer (bg_A) has a multi-date abs_td -> NotImplementedError.
+    # This makes bg_A's abs_td have 2 dates when it enters the queue, so the
+    # bg_A->bg_B variant split has a multi-date consumer.
     td_fu_to_bg_a = TemporalDistribution(
         date=np.array([0, 10], dtype="timedelta64[Y]"),
         amount=np.array([0.6, 0.4]),

--- a/tests/fixtures/background_td_single_db_fixture.py
+++ b/tests/fixtures/background_td_single_db_fixture.py
@@ -1,0 +1,82 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def background_td_single_db():
+    """fu -> electricity -> fuel -> CO2 with only ONE background database.
+
+    The background carries an internal temporal distribution (electricity ->
+    fuel), but there is a single time-representative background database, so
+    every flow - whenever it occurs - is sourced from that same database. The
+    background TD therefore only redistributes emissions in time; the
+    time-aggregated (static) score must be unchanged. Used to assert
+    ``traverse_background=True`` equals the plain static LCA score.
+    """
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_electricity_fuel = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+
+    bd.Database("background").write(
+        {
+            ("background", "electricity"): {
+                "name": "electricity",
+                "unit": "kWh",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("background", "electricity"),
+                        "amount": 1,
+                        "type": "production",
+                    },
+                    {
+                        "input": ("background", "fuel"),
+                        "amount": 2,
+                        "type": "technosphere",
+                        "temporal_distribution": td_electricity_fuel,
+                    },
+                ],
+            },
+            ("background", "fuel"): {
+                "name": "fuel",
+                "unit": "kg",
+                "location": "GLO",
+                "exchanges": [
+                    {"input": ("background", "fuel"), "amount": 1, "type": "production"},
+                    {"input": ("bio", "co2"), "amount": 11, "type": "biosphere"},
+                ],
+            },
+        }
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "fu"): {
+                "name": "fu",
+                "unit": "unit",
+                "location": "GLO",
+                "reference product": "fu",
+                "exchanges": [
+                    {"input": ("foreground", "fu"), "amount": 1, "type": "production"},
+                    {
+                        "input": ("background", "electricity"),
+                        "amount": 3,
+                        "type": "technosphere",
+                    },
+                ],
+            }
+        }
+    )
+
+    for db in bd.databases:
+        bd.Database(db).process()

--- a/tests/fixtures/explicit_background_td_db_fixture.py
+++ b/tests/fixtures/explicit_background_td_db_fixture.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def explicit_background_td_db():
+    """Explicit process/product foreground pulling a background chain that
+    carries an internal temporal distribution, across two dated variants.
+
+    Foreground (explicit paradigm): a bare ``service_product`` plus a
+    ``service_process`` that owns the production edge to it and a technosphere
+    edge to background ``electricity``. The demand is the *product*.
+
+    Background (two variants, 2020 / 2040): ``electricity -> fuel`` (amount 2)
+    carries a TD (60% +0y, 40% +10y); ``fuel -> CO2`` decarbonizes (11 kg in
+    2020, 7 kg in 2040). With ``traverse_background=True`` the traversal descends
+    into ``electricity`` (temporalized), the ``electricity -> fuel`` TD spreads
+    fuel over time, and each fuel cohort is routed to the temporally appropriate
+    grid variant.
+    """
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_electricity_fuel = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+    co2_per_variant = {"bg_2020": 11, "bg_2040": 7}
+
+    for dbname, co2 in co2_per_variant.items():
+        bd.Database(dbname).write(
+            {
+                (dbname, "electricity"): {
+                    "name": "electricity",
+                    "unit": "kWh",
+                    "location": "GLO",
+                    "exchanges": [
+                        {
+                            "input": (dbname, "electricity"),
+                            "amount": 1,
+                            "type": "production",
+                        },
+                        {
+                            "input": (dbname, "fuel"),
+                            "amount": 2,
+                            "type": "technosphere",
+                            "temporal_distribution": td_electricity_fuel,
+                        },
+                    ],
+                },
+                (dbname, "fuel"): {
+                    "name": "fuel",
+                    "unit": "kg",
+                    "location": "GLO",
+                    "exchanges": [
+                        {"input": (dbname, "fuel"), "amount": 1, "type": "production"},
+                        {"input": ("bio", "co2"), "amount": co2, "type": "biosphere"},
+                    ],
+                },
+            }
+        )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "service_product"): {
+                "name": "service product",
+                "type": "product",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [],
+            },
+            ("foreground", "service_process"): {
+                "name": "service process",
+                "type": "process",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "service_product"),
+                        "amount": 1,
+                        "type": "production",
+                    },
+                    {
+                        "input": ("bg_2020", "electricity"),
+                        "amount": 3,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+        }
+    )
+
+    for db in bd.databases:
+        bd.Database(db).process()
+
+    return {
+        "bg_2020": datetime(2020, 1, 1),
+        "bg_2040": datetime(2040, 1, 1),
+        "foreground": "dynamic",
+    }

--- a/tests/fixtures/explicit_process_product_db_fixture.py
+++ b/tests/fixtures/explicit_process_product_db_fixture.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+
+import bw2data as bd
+import numpy as np
+import pytest
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+def explicit_process_product_db():
+    bd.projects.set_current("__test_explicit_process_product__")
+    bd.databases.clear()
+    bd.methods.clear()
+
+    bio = bd.Database("bio")
+    bio.write(
+        {
+            ("bio", "co2"): {
+                "name": "Carbon dioxide",
+                "unit": "kg",
+                "type": "emission",
+            }
+        }
+    )
+
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    bd.Database("bg_2030").write(
+        {
+            ("bg_2030", "electricity"): {
+                "name": "electricity",
+                "unit": "kWh",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("bg_2030", "electricity"),
+                        "amount": 1,
+                        "type": "production",
+                    },
+                    {"input": ("bio", "co2"), "amount": 0.5, "type": "biosphere"},
+                ],
+            }
+        }
+    )
+
+    td = TemporalDistribution(
+        date=np.array([0, 1], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "fleet_driving_process"): {
+                "name": "fleet driving process",
+                "unit": "unit",
+                "location": "GLO",
+                "type": "process",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "fleet_driving_product"),
+                        "amount": 1,
+                        "type": "production",
+                        "temporal_distribution": td,
+                    },
+                    {
+                        "input": ("bg_2030", "electricity"),
+                        "amount": 10,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+            ("foreground", "fleet_driving_product"): {
+                "name": "fleet driving product",
+                "unit": "unit",
+                "location": "GLO",
+                "type": "product",
+                "exchanges": [],
+            },
+        }
+    )
+
+    return {
+        "database_dates": {
+            "bg_2030": datetime.strptime("2030", "%Y"),
+            "foreground": "dynamic",
+        }
+    }

--- a/tests/fixtures/vehicle_explicit_db_fixture.py
+++ b/tests/fixtures/vehicle_explicit_db_fixture.py
@@ -1,0 +1,292 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def vehicle_explicit_db():
+    """
+    Same EV system as ``vehicle_db`` but with the foreground modeled in the
+    explicit process/product paradigm (separate product node + process node)
+    instead of a chimaera node.
+    """
+    bd.Database("bio").write(
+        {
+            ("bio", "CO2"): {
+                "type": "emission",
+                "name": "carbon dioxide",
+            },
+        },
+    )
+
+    bd.Database("db_2020").write(
+        {
+            ("db_2020", "glider"): {
+                "name": "market for glider, passenger car",
+                "location": "somewhere",
+                "reference product": "market for glider, passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "glider")},
+                    {"amount": 6.29, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2020", "powertrain"): {
+                "name": "market for powertrain, for electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for powertrain, for electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "powertrain")},
+                    {"amount": 17.89, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2020", "battery"): {
+                "name": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "location": "somewhere",
+                "reference product": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "battery")},
+                    {"amount": 8.23, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2020", "electricity"): {
+                "name": "market group for electricity, low voltage",
+                "location": "somewhere",
+                "reference product": "market group for electricity, low voltage",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "electricity")},
+                    {"amount": 0.73, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2020", "dismantling"): {
+                "name": "market for manual dismantling of used electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for manual dismantling of used electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "dismantling")},
+                    {"amount": 0.0091, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2020", "battery_recycling"): {
+                "name": "market for used Li-ion battery",
+                "location": "somewhere",
+                "reference product": "market for used Li-ion battery",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2020", "battery_recycling")},
+                    {"amount": -1.18, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+        }
+    )
+
+    bd.Database("db_2030").write(
+        {
+            ("db_2030", "glider"): {
+                "name": "market for glider, passenger car",
+                "location": "somewhere",
+                "reference product": "market for glider, passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "glider")},
+                    {"amount": 4.37, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2030", "powertrain"): {
+                "name": "market for powertrain, for electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for powertrain, for electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "powertrain")},
+                    {"amount": 11.90, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2030", "battery"): {
+                "name": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "location": "somewhere",
+                "reference product": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "battery")},
+                    {"amount": 5.26, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2030", "electricity"): {
+                "name": "market group for electricity, low voltage",
+                "location": "somewhere",
+                "reference product": "market group for electricity, low voltage",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "electricity")},
+                    {"amount": 0.23, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2030", "dismantling"): {
+                "name": "market for manual dismantling of used electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for manual dismantling of used electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "dismantling")},
+                    {"amount": 0.008, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2030", "battery_recycling"): {
+                "name": "market for used Li-ion battery",
+                "location": "somewhere",
+                "reference product": "market for used Li-ion battery",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2030", "battery_recycling")},
+                    {"amount": -0.60, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+        }
+    )
+
+    bd.Database("db_2040").write(
+        {
+            ("db_2040", "glider"): {
+                "name": "market for glider, passenger car",
+                "location": "somewhere",
+                "reference product": "market for glider, passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "glider")},
+                    {"amount": 3.71, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2040", "powertrain"): {
+                "name": "market for powertrain, for electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for powertrain, for electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "powertrain")},
+                    {"amount": 9.79, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2040", "battery"): {
+                "name": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "location": "somewhere",
+                "reference product": "battery production, Li-ion, LiMn2O4, rechargeable, prismatic",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "battery")},
+                    {"amount": 4.25, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2040", "electricity"): {
+                "name": "market group for electricity, low voltage",
+                "location": "somewhere",
+                "reference product": "market group for electricity, low voltage",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "electricity")},
+                    {"amount": 0.067, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2040", "dismantling"): {
+                "name": "market for manual dismantling of used electric passenger car",
+                "location": "somewhere",
+                "reference product": "market for manual dismantling of used electric passenger car",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "dismantling")},
+                    {"amount": 0.0077, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+            ("db_2040", "battery_recycling"): {
+                "name": "market for used Li-ion battery",
+                "location": "somewhere",
+                "reference product": "market for used Li-ion battery",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("db_2040", "battery_recycling")},
+                    {"amount": -0.40, "type": "biosphere", "input": ("bio", "CO2")},
+                ],
+            },
+        }
+    )
+
+    ELECTRICITY_CONSUMPTION = 0.2
+    MILEAGE = 150_000
+    LIFETIME = 16
+    MASS_GLIDER = 840
+    MASS_POWERTRAIN = 80
+    MASS_BATTERY = 280
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "EV_product"): {
+                "name": "electric vehicle life cycle product",
+                "location": "somewhere",
+                "unit": "unit",
+                "type": "product",
+                "exchanges": [],
+            },
+            ("foreground", "EV_process"): {
+                "name": "electric vehicle life cycle process",
+                "location": "somewhere",
+                "unit": "unit",
+                "type": "process",
+                "exchanges": [
+                    {
+                        "amount": 1,
+                        "type": "production",
+                        "input": ("foreground", "EV_product"),
+                    },
+                    {
+                        "amount": MASS_GLIDER,
+                        "type": "technosphere",
+                        "input": ("db_2020", "glider"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([-2, -1], dtype="timedelta64[Y]"),
+                            amount=np.array([0.6, 0.4]),
+                        ),
+                    },
+                    {
+                        "amount": MASS_POWERTRAIN,
+                        "type": "technosphere",
+                        "input": ("db_2020", "powertrain"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([-2, -1], dtype="timedelta64[Y]"),
+                            amount=np.array([0.6, 0.4]),
+                        ),
+                    },
+                    {
+                        "amount": MASS_BATTERY,
+                        "type": "technosphere",
+                        "input": ("db_2020", "battery"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([-2, -1], dtype="timedelta64[Y]"),
+                            amount=np.array([0.6, 0.4]),
+                        ),
+                    },
+                    {
+                        "amount": ELECTRICITY_CONSUMPTION * MILEAGE,
+                        "type": "technosphere",
+                        "input": ("db_2020", "electricity"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([int(LIFETIME / 2)], dtype="timedelta64[Y]"),
+                            amount=np.array([1]),
+                        ),
+                    },
+                    {
+                        "amount": MASS_GLIDER,
+                        "type": "technosphere",
+                        "input": ("db_2020", "dismantling"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([LIFETIME + 1], dtype="timedelta64[Y]"),
+                            amount=np.array([1]),
+                        ),
+                    },
+                    {
+                        "amount": -MASS_BATTERY,
+                        "type": "technosphere",
+                        "input": ("db_2020", "battery_recycling"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([LIFETIME + 1], dtype="timedelta64[Y]"),
+                            amount=np.array([1]),
+                        ),
+                    },
+                ],
+            },
+        }
+    )
+
+    bd.Method(("GWP", "example")).write([(("bio", "CO2"), 1)])
+
+    for db in bd.databases:
+        bd.Database(db).register()
+        bd.Database(db).process()

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -100,3 +100,38 @@ def test_bfs_respective_variant_deep_chain(background_td_deep_db):
     # bg_C must appear at both 2024 and 2034.
     bg_c = tlca.timeline[tlca.timeline["producer_name"] == "bg_C"]
     assert sorted({d.year for d in bg_c["date_producer"]}) == [2024, 2034]
+
+
+def test_bfs_per_variant_td_reads_respective_variant(background_td_deep_tdvar_db):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal="bfs",
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    bg_c = tlca.timeline[tlca.timeline["producer_name"] == "bg_C"]
+    years = sorted({d.year for d in bg_c["date_producer"]})
+    # +20y spread (2044, 2054) appears ONLY if the 2030-variant TD was read.
+    assert 2044 in years, f"expected 2044 cohort from background_2030 TD, got {years}"
+    assert 2054 in years, f"expected 2054 cohort from background_2030 TD, got {years}"
+    # amounts equal across variants -> total CO2 unchanged at 10 kg
+    assert tlca.static_score == pytest.approx(10.0, rel=1e-9)
+
+
+def test_bfs_traversed_background_not_double_counted(background_td_deep_db):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal="bfs",
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    tl = tlca.timeline
+    # bg_B is descended into -> temporalized, NOT a temporal market (no shares).
+    bg_b = tl[tl["producer_name"] == "bg_B"]
+    assert bg_b["temporal_market_shares"].isnull().all()
+    # Score is the hand-computed 48.4 (no inventory doubling).
+    assert tlca.static_score == pytest.approx(48.4, rel=1e-9)

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -160,6 +160,22 @@ def test_bfs_per_variant_td_reads_respective_variant(background_td_deep_tdvar_db
     assert tlca.static_score == pytest.approx(10.0, rel=1e-9)
 
 
+@pytest.mark.parametrize("graph_traversal", ["bfs", "priority"])
+def test_multi_date_consumer_raises(
+    background_td_multidate_consumer_db, graph_traversal
+):
+    """A foreground TD feeding into a non-leaf background activity causes bg_A
+    to be reached at >1 cohort date. The variant split cannot handle a multi-date
+    consumer and must raise NotImplementedError loudly."""
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    with pytest.raises(NotImplementedError):
+        tlca.build_timeline(
+            starting_datetime="2024-01-01",
+            graph_traversal=graph_traversal,
+            traverse_background=True,
+        )
+
+
 def test_bfs_traversed_background_not_double_counted(background_td_deep_db):
     tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
     tlca.build_timeline(

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -191,3 +191,56 @@ def test_bfs_traversed_background_not_double_counted(background_td_deep_db):
     assert bg_b["temporal_market_shares"].isnull().all()
     # Score is the hand-computed 48.4 (no inventory doubling).
     assert tlca.static_score == pytest.approx(48.4, rel=1e-9)
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_foreground_td_into_traversed_background_convolves(
+    background_td_fg_and_bg_db, graph_traversal
+):
+    """A foreground TD on the background->foreground edge (B->A) must convolve
+    correctly with a background TD (C->B) when the traversal descends into the
+    background. This stresses the convolution + graph-traversal path.
+
+    Non-uniform weights are used on purpose so a symmetric bug cannot hide.
+
+    Hand-computation (starting 2024):
+    - A->B (amount 3), TD 70% @2024 / 30% @2030  -> B: 2.1 @2024, 0.9 @2030.
+    - B->C (amount 2), TD 60% @+0y / 40% @+10y    -> electricity C cohorts (kWh):
+        from B@2024: 2.1*2*0.6 = 2.52 @2024,  2.1*2*0.4 = 1.68 @2034
+        from B@2030: 0.9*2*0.6 = 1.08 @2030,  0.9*2*0.4 = 0.72 @2040
+    - C->CO2 by date-routed grid variant: @2024 -> 0.6*11+0.4*7 = 9.4;
+      @2030/@2034/@2040 -> 7 (clean 2030 grid).
+    - CO2 = 2.52*9.4 + 1.08*7 + 1.68*7 + 0.72*7
+          = 23.688 + 7.56 + 11.76 + 5.04 = 48.048 kg.
+    """
+    tlca = TimexLCA({("foreground", "A"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal=graph_traversal,
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    assert tlca.static_score == pytest.approx(48.048, rel=1e-9)
+
+    tl = tlca.timeline
+    # The foreground TD spreads B (the descended background process) over 2024 & 2030.
+    b_years = sorted({d.year for d in tl[tl["producer_name"] == "B"]["date_producer"]})
+    assert b_years == [2024, 2030]
+    # Convolving both TDs yields four electricity cohorts.
+    c_years = sorted({d.year for d in tl[tl["producer_name"] == "C"]["date_producer"]})
+    assert c_years == [2024, 2030, 2034, 2040]
+    # B is descended into -> temporalized (no shares); C is the routed leaf.
+    assert tl[tl["producer_name"] == "B"]["temporal_market_shares"].isnull().all()
+    assert tl[tl["producer_name"] == "C"]["temporal_market_shares"].notnull().all()
+
+    # Per-row amounts are per-unit-of-parent-cohort (codebase convention):
+    #   B->A: 3 * [0.7, 0.3] = [2.1, 0.9]
+    #   C->B: 2 * [0.6, 0.4] = [1.2, 0.8] for each B cohort -> C rows [1.2, 1.2, 0.8, 0.8]
+    #   FU A: 1.0
+    amount_by = lambda name: sorted(
+        round(a, 6) for a in tl[tl["producer_name"] == name]["amount"]
+    )
+    assert amount_by("A") == [1.0]
+    assert amount_by("B") == [0.9, 2.1]
+    assert amount_by("C") == [0.8, 0.8, 1.2, 1.2]

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import bw2data as bd
+import pytest
 
 from bw_timex import TimexLCA
 
@@ -30,3 +31,38 @@ def test_classification_keys_on_shares_not_db(background_td_db):
     tlca.static_lcia()
     # bg_A is the only first-level background producer -> exactly one temporal market.
     assert len(tlca.node_collections["temporal_markets"]) == 1
+
+
+def _strip_background_tds():
+    """Remove the temporal_distribution on every background bg_A->bg_B exchange."""
+    for dbname in ("background_2020", "background_2030"):
+        for act in bd.Database(dbname):
+            for exc in act.technosphere():
+                if "temporal_distribution" in exc:
+                    del exc["temporal_distribution"]
+                    exc.save()
+        bd.Database(dbname).process()
+
+
+def _score(traverse_background):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal="bfs",
+        traverse_background=traverse_background,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    return tlca.static_score, tlca.timeline
+
+
+def test_bfs_equivalence_without_background_tds(background_td_db):
+    _strip_background_tds()
+    score_static, tl_static = _score(False)
+    score_traverse, tl_traverse = _score(True)
+    # With traverse_background=True the BFS descends into bg_B, so the
+    # traverse timeline must contain bg_B edges (more rows than the static one).
+    assert len(tl_traverse) > len(tl_static), (
+        "traverse_background=True must produce a deeper timeline than False"
+    )
+    assert score_traverse == pytest.approx(score_static, rel=1e-9)

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -66,3 +66,37 @@ def test_bfs_equivalence_without_background_tds(background_td_db):
         "traverse_background=True must produce a deeper timeline than False"
     )
     assert score_traverse == pytest.approx(score_static, rel=1e-9)
+
+
+def test_bfs_leaf_background_td_routes_by_variant(background_td_db):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal="bfs",
+        traverse_background=True,
+    )
+    tl = tlca.timeline
+    bg_b = tl[tl["producer_name"] == "bg_B"]
+    assert sorted({d.year for d in bg_b["date_producer"]}) == [2024, 2034]
+    row_2034 = bg_b[[d.year == 2034 for d in bg_b["date_producer"]]].iloc[0]
+    assert set(row_2034["temporal_market_shares"].keys()) == {"background_2030"}
+    tlca.lci()
+    tlca.static_lcia()
+    assert tlca.static_score == pytest.approx(10.0, rel=1e-9)  # 2 * 5 * 1
+
+
+def test_bfs_respective_variant_deep_chain(background_td_deep_db):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal="bfs",
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    # Respective-variant reads: 2034 cohort sources bg_B->bg_C from background_2030 (=7),
+    # not the referenced background_2020 (=1). Correct total CO2 = 48.4 kg.
+    assert tlca.static_score == pytest.approx(48.4, rel=1e-9)
+    # bg_C must appear at both 2024 and 2034.
+    bg_c = tlca.timeline[tlca.timeline["producer_name"] == "bg_C"]
+    assert sorted({d.year for d in bg_c["date_producer"]}) == [2024, 2034]

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -20,3 +20,13 @@ def test_fixture_loads(background_td_db):
     tlca.lci()
     tlca.static_lcia()
     assert tlca.static_score > 0
+
+
+def test_classification_keys_on_shares_not_db(background_td_db):
+    """With traverse_background=False, results are unchanged by the refactor."""
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2024-01-01", traverse_background=False)
+    tlca.lci()
+    tlca.static_lcia()
+    # bg_A is the only first-level background producer -> exactly one temporal market.
+    assert len(tlca.node_collections["temporal_markets"]) == 1

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -255,3 +255,89 @@ def test_foreground_td_into_traversed_background_convolves(
     assert amount_by("A") == [1.0]
     assert amount_by("B") == [0.9, 2.1]
     assert amount_by("C") == [0.8, 0.8, 1.2, 1.2]
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_background_td_with_explicit_product_paradigm(
+    explicit_background_td_db, graph_traversal
+):
+    """Background temporal distributions work when the foreground uses the
+    explicit process/product paradigm: a bare ``service_product`` plus a
+    ``service_process`` that owns the production edge to it, and the demand is
+    the *product*.
+
+    Hand-computation (demand service_product = 1, starting 2024):
+    - service_process -> 3 kWh electricity (descended -> temporalized).
+    - electricity -> fuel (amount 2), TD 60% +0y / 40% +10y -> fuel cohorts:
+        3.6 kg @2024,  2.4 kg @2034.
+    - fuel -> CO2 routed linearly between the 2020 and 2040 grids:
+        @2024 -> 0.8*11 + 0.2*7 = 10.2 -> 36.72
+        @2034 -> 0.3*11 + 0.7*7 = 8.2  -> 19.68
+    - total = 56.4 kg CO2 (the all-2020-grid static base would be 66.0).
+    """
+    import bw2calc as bc
+
+    database_dates = explicit_background_td_db
+    product = bd.get_node(database="foreground", code="service_product")
+    demand = {product.key: 1}
+
+    slca = bc.LCA(demand, method=METHOD)
+    slca.lci()
+    slca.lcia()
+    assert slca.score == pytest.approx(66.0, rel=1e-9)
+
+    tlca = TimexLCA(demand=demand, method=METHOD, database_dates=database_dates)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal=graph_traversal,
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+
+    assert tlca.base_lca.score == pytest.approx(slca.score)
+    assert tlca.static_score == pytest.approx(56.4, rel=1e-9)
+
+    tl = tlca.timeline
+    # The demanded explicit product's process is descended -> temporalized (no shares).
+    elec = tl[tl["producer_name"] == "electricity"]
+    assert elec["temporal_market_shares"].isnull().all()
+    # The background TD spreads fuel across two cohorts, each routed across variants.
+    fuel = tl[tl["producer_name"] == "fuel"]
+    assert sorted({d.year for d in fuel["date_producer"]}) == [2024, 2034]
+    assert fuel["temporal_market_shares"].notnull().all()
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_single_background_db_with_td_matches_static(
+    background_td_single_db, graph_traversal
+):
+    """With a single background database, an internal background TD only
+    redistributes emissions in time. Since every flow is sourced from that one
+    database regardless of when it occurs, the time-aggregated (static) score is
+    unchanged: traverse_background must match the plain static LCA score."""
+    import bw2calc as bc
+
+    from datetime import datetime
+
+    demand = {("foreground", "fu"): 1}
+    database_dates = {"background": datetime(2020, 1, 1), "foreground": "dynamic"}
+
+    slca = bc.LCA(demand, method=METHOD)
+    slca.lci()
+    slca.lcia()
+
+    tlca = TimexLCA(demand=demand, method=METHOD, database_dates=database_dates)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal=graph_traversal,
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+
+    # The background TD still spreads fuel over time...
+    fuel = tlca.timeline[tlca.timeline["producer_name"] == "fuel"]
+    assert sorted({d.year for d in fuel["date_producer"]}) == [2024, 2034]
+    # ...but with one background db the score equals the static LCA exactly.
+    assert tlca.static_score == pytest.approx(slca.score, rel=1e-9)

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -161,19 +161,30 @@ def test_bfs_per_variant_td_reads_respective_variant(background_td_deep_tdvar_db
 
 
 @pytest.mark.parametrize("graph_traversal", ["bfs", "priority"])
-def test_multi_date_consumer_raises(
+def test_multi_date_consumer_split(
     background_td_multidate_consumer_db, graph_traversal
 ):
-    """A foreground TD feeding into a non-leaf background activity causes bg_A
-    to be reached at >1 cohort date. The variant split cannot handle a multi-date
-    consumer and must raise NotImplementedError loudly."""
+    """A foreground TD feeding a non-leaf background activity makes bg_A reached
+    at >1 cohort date, so the bg_A->bg_B variant split has a multi-date consumer.
+    The split routes each consumer cohort independently.
+
+    Hand-computation (starting 2024, fu->bg_A TD 60% @2024 / 40% @2034; all
+    intermediate amounts 1; bg_C->CO2 = 11 in 2020, 7 in 2030):
+    - bg_A: 0.6 @2024, 0.4 @2034  -> bg_B / bg_C carry the same dates.
+    - bg_B@2024 (0.6) routes {2020:0.6, 2030:0.4} -> 0.36 via 2020, 0.24 via 2030.
+    - bg_B@2034 (0.4) routes {2030:1.0}           -> 0.40 via 2030.
+    - locked-variant bg_C emissions: 0.36*11 + 0.24*7 + 0.40*7
+      = 3.96 + 1.68 + 2.80 = 8.44 kg CO2.
+    """
     tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
-    with pytest.raises(NotImplementedError):
-        tlca.build_timeline(
-            starting_datetime="2024-01-01",
-            graph_traversal=graph_traversal,
-            traverse_background=True,
-        )
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal=graph_traversal,
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    assert tlca.static_score == pytest.approx(8.44, rel=1e-9)
 
 
 def test_bfs_traversed_background_not_double_counted(background_td_deep_db):

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -44,6 +44,18 @@ def _strip_background_tds():
         bd.Database(dbname).process()
 
 
+def _strip_background_tds_deep():
+    """Remove temporal_distribution on every background technosphere exchange
+    (bg_A->bg_B and bg_B->bg_C) in both variants of the deep fixture."""
+    for dbname in ("background_2020", "background_2030"):
+        for act in bd.Database(dbname):
+            for exc in act.technosphere():
+                if "temporal_distribution" in exc:
+                    del exc["temporal_distribution"]
+                    exc.save()
+        bd.Database(dbname).process()
+
+
 def _score(traverse_background):
     tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
     tlca.build_timeline(
@@ -100,6 +112,40 @@ def test_bfs_respective_variant_deep_chain(background_td_deep_db):
     # bg_C must appear at both 2024 and 2034.
     bg_c = tlca.timeline[tlca.timeline["producer_name"] == "bg_C"]
     assert sorted({d.year for d in bg_c["date_producer"]}) == [2024, 2034]
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_respective_variant_deep_chain_both_engines(
+    background_td_deep_db, graph_traversal
+):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal=graph_traversal,
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    assert tlca.static_score == pytest.approx(48.4, rel=1e-9)
+    bg_c = tlca.timeline[tlca.timeline["producer_name"] == "bg_C"]
+    assert sorted({d.year for d in bg_c["date_producer"]}) == [2024, 2034]
+
+
+def test_priority_equivalence_without_background_tds(background_td_deep_db):
+    _strip_background_tds_deep()
+
+    def score(tb):
+        t = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+        t.build_timeline(
+            starting_datetime="2024-01-01",
+            graph_traversal="priority",
+            traverse_background=tb,
+        )
+        t.lci()
+        t.static_lcia()
+        return t.static_score
+
+    assert score(True) == pytest.approx(score(False), rel=1e-9)
 
 
 def test_bfs_per_variant_td_reads_respective_variant(background_td_deep_tdvar_db):

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+import bw2data as bd
+
+from bw_timex import TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+
+
+def test_fixture_loads(background_td_db):
+    assert "background_2020" in bd.databases
+    assert "background_2030" in bd.databases
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2024-01-01", traverse_background=False)
+    tlca.lci()
+    tlca.static_lcia()
+    assert tlca.static_score > 0

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -47,13 +47,7 @@ def _strip_background_tds():
 def _strip_background_tds_deep():
     """Remove temporal_distribution on every background technosphere exchange
     (bg_A->bg_B and bg_B->bg_C) in both variants of the deep fixture."""
-    for dbname in ("background_2020", "background_2030"):
-        for act in bd.Database(dbname):
-            for exc in act.technosphere():
-                if "temporal_distribution" in exc:
-                    del exc["temporal_distribution"]
-                    exc.save()
-        bd.Database(dbname).process()
+    _strip_background_tds()
 
 
 def _score(traverse_background):

--- a/tests/test_electric_vehicle_explicit.py
+++ b/tests/test_electric_vehicle_explicit.py
@@ -1,0 +1,130 @@
+"""
+Mirror of ``test_electric_vehicle.py`` using the explicit process/product
+paradigm instead of the chimaera node convention. Verifies that demanding a
+bare product node and routing all edges through a separate process node
+yields the same TimexLCA static score as the chimaera-modeled equivalent.
+"""
+
+from datetime import datetime
+
+import bw2calc as bc
+import bw2data as bd
+import pytest
+
+from bw_timex import TimexLCA
+
+
+def test_vehicle_explicit_db_fixture(vehicle_explicit_db):
+    assert len(bd.databases) == 5
+
+
+@pytest.mark.usefixtures("vehicle_explicit_db")
+class TestClass_EV_Explicit:
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self, vehicle_explicit_db):
+        self.ev_product = bd.get_node(database="foreground", code="EV_product")
+
+        database_dates = {
+            "db_2020": datetime.strptime("2020", "%Y"),
+            "db_2030": datetime.strptime("2030", "%Y"),
+            "db_2040": datetime.strptime("2040", "%Y"),
+            "foreground": "dynamic",
+        }
+
+        self.tlca = TimexLCA(
+            demand={self.ev_product.key: 1},
+            method=("GWP", "example"),
+            database_dates=database_dates,
+        )
+
+        self.tlca.build_timeline(
+            starting_datetime=datetime.strptime("2024-01-02", "%Y-%m-%d")
+        )
+        self.tlca.lci()
+        self.tlca.static_lcia()
+
+    def test_base_lca_score(self):
+        slca = bc.LCA({self.ev_product.key: 1}, method=("GWP", "example"))
+        slca.lci()
+        slca.lcia()
+        assert self.tlca.base_lca.score == slca.score
+
+    def test_bw_timex_score_matches_chimaera_manual(self):
+        # Identical hand-computation to test_electric_vehicle.py — the
+        # explicit product/process model must produce the same temporal
+        # interpolation result as the chimaera node.
+        ELECTRICITY_CONSUMPTION = 0.2
+        MILEAGE = 150_000
+        MASS_GLIDER = 840
+        MASS_POWERTRAIN = 80
+        MASS_BATTERY = 280
+
+        glider_2020 = [
+            exc["amount"] for exc in bd.get_activity(("db_2020", "glider")).biosphere()
+        ][0]
+        glider_2030 = [
+            exc["amount"] for exc in bd.get_activity(("db_2030", "glider")).biosphere()
+        ][0]
+        powertrain_2020 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2020", "powertrain")).biosphere()
+        ][0]
+        powertrain_2030 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2030", "powertrain")).biosphere()
+        ][0]
+        battery_2020 = [
+            exc["amount"] for exc in bd.get_activity(("db_2020", "battery")).biosphere()
+        ][0]
+        battery_2030 = [
+            exc["amount"] for exc in bd.get_activity(("db_2030", "battery")).biosphere()
+        ][0]
+        elec_2030 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2030", "electricity")).biosphere()
+        ][0]
+        elec_2040 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2040", "electricity")).biosphere()
+        ][0]
+        dismantling_2040 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2040", "dismantling")).biosphere()
+        ][0]
+        battery_recycling_2040 = [
+            exc["amount"]
+            for exc in bd.get_activity(("db_2040", "battery_recycling")).biosphere()
+        ][0]
+
+        # 2022 -> 80% 2020, 20% 2030; 2023 -> 70% 2020, 30% 2030
+        expected_glider_score = (
+            0.6 * MASS_GLIDER * (0.8 * glider_2020 + 0.2 * glider_2030)
+            + 0.4 * MASS_GLIDER * (0.7 * glider_2020 + 0.3 * glider_2030)
+        )
+        expected_powertrain_score = (
+            0.6 * MASS_POWERTRAIN * (0.8 * powertrain_2020 + 0.2 * powertrain_2030)
+            + 0.4 * MASS_POWERTRAIN * (0.7 * powertrain_2020 + 0.3 * powertrain_2030)
+        )
+        expected_battery_score = (
+            0.6 * MASS_BATTERY * (0.8 * battery_2020 + 0.2 * battery_2030)
+            + 0.4 * MASS_BATTERY * (0.7 * battery_2020 + 0.3 * battery_2030)
+        )
+        # electricity in 2032 -> 80% 2030, 20% 2040
+        expected_electricity_score = (
+            MILEAGE * ELECTRICITY_CONSUMPTION * (0.8 * elec_2030 + 0.2 * elec_2040)
+        )
+        # dismantling 2041 -> 100% 2040
+        expected_glider_recycling_score = MASS_GLIDER * dismantling_2040
+        expected_battery_recycling_score = -(MASS_BATTERY * battery_recycling_2040)
+
+        expected_timex_score = (
+            expected_glider_score
+            + expected_powertrain_score
+            + expected_battery_score
+            + expected_electricity_score
+            + expected_glider_recycling_score
+            + expected_battery_recycling_score
+        )
+
+        assert self.tlca.static_score == pytest.approx(expected_timex_score, abs=0.5)

--- a/tests/test_explicit_process_product_end_to_end.py
+++ b/tests/test_explicit_process_product_end_to_end.py
@@ -498,3 +498,107 @@ def test_multi_vintage_demand_splits_across_cohorts():
     ]
 
     assert tlca.static_score == pytest.approx(0.5 * 0.40 + 0.5 * 0.10)
+
+
+def test_explicit_output_coefficient_alpha_scales_inputs():
+    """Production output coefficient alpha != 1 must scale the supply chain by 1/alpha.
+
+    A process produces *2* units of its product per invocation and consumes 4
+    units of background input. Demanding 1 unit of the product therefore runs
+    the process at scale 1/2, so the input is consumed at 0.5 * 4 = 2.0 and the
+    score is 2.0 (background = 1 kg CO2 per input unit, GWP = 1).
+
+    Every existing explicit fixture uses production amount = 1, so the 1/alpha
+    division is otherwise never exercised: a bug there would be invisible.
+    """
+    bd.projects.set_current("__test_explicit_alpha_scaling__")
+    bd.databases.clear()
+    bd.methods.clear()
+
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Database("background").write(
+        {
+            ("background", "input"): {
+                "name": "input production",
+                "reference product": "input",
+                "unit": "kg",
+                "location": "GLO",
+                "exchanges": [
+                    {"input": ("background", "input"), "amount": 1, "type": "production"},
+                    {"input": ("bio", "co2"), "amount": 1, "type": "biosphere"},
+                ],
+            }
+        }
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_output = TemporalDistribution(
+        date=np.array([0, 1], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "product"): {
+                "name": "product",
+                "type": "product",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [],
+            },
+            ("foreground", "process"): {
+                "name": "process",
+                "type": "process",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "product"),
+                        "amount": 2,  # alpha != 1
+                        "type": "production",
+                        "temporal_distribution": td_output,
+                    },
+                    {
+                        "input": ("background", "input"),
+                        "amount": 4,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+        }
+    )
+    for db in bd.databases:
+        bd.Database(db).process()
+
+    product = bd.get_node(database="foreground", code="product")
+    method = ("GWP", "example")
+    demand = {product.key: 1}
+    database_dates = {"background": datetime(2030, 1, 1), "foreground": "dynamic"}
+
+    slca = bc.LCA(demand, method=method)
+    slca.lci()
+    slca.lcia()
+    # Sanity: bw2calc itself applies 1/alpha -> 0.5 * 4 * 1 = 2.0
+    assert slca.score == pytest.approx(2.0)
+
+    tlca = TimexLCA(demand=demand, method=method, database_dates=database_dates)
+    tlca.build_timeline(starting_datetime=datetime(2030, 1, 1))
+    tlca.lci()
+    tlca.static_lcia()
+
+    assert tlca.base_lca.score == pytest.approx(2.0)
+    assert tlca.static_score == pytest.approx(2.0)
+
+    # The per-cohort-instance input intensity carries the 1/alpha scaling:
+    # edge amount 4 / alpha 2 = 2.0 per cohort row (the cohort TD weights 0.6/0.4
+    # are applied to the process column in the matrix, summing to 1, so the total
+    # input is 0.6*2 + 0.4*2 = 2.0 and the score is 2.0). If 1/alpha were dropped
+    # the row amount would be 4.0; if mis-applied, 8.0.
+    input_rows = tlca.timeline[tlca.timeline["producer_name"] == "input production"]
+    observed = sorted(
+        (row.date_consumer.year, row.date_producer.year, float(row.amount))
+        for row in input_rows.itertuples()
+    )
+    assert observed == pytest.approx([(2030, 2030, 2.0), (2031, 2031, 2.0)])

--- a/tests/test_explicit_process_product_end_to_end.py
+++ b/tests/test_explicit_process_product_end_to_end.py
@@ -1,0 +1,500 @@
+from datetime import datetime
+
+import bw2calc as bc
+import bw2data as bd
+import numpy as np
+import pytest
+from bw_temporalis import TemporalDistribution
+
+from bw_timex import TimexLCA
+
+
+def _write_multilayer_explicit_process_product_db():
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Database("background").write(
+        {
+            ("background", "input"): {
+                "name": "input production",
+                "reference product": "input",
+                "unit": "kg",
+                "location": "GLO",
+                "exchanges": [
+                    {"input": ("background", "input"), "amount": 1, "type": "production"},
+                    {"input": ("bio", "co2"), "amount": 1, "type": "biosphere"},
+                ],
+            }
+        }
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_final_output = TemporalDistribution(
+        date=np.array([0, 2], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+    td_component_output = TemporalDistribution(
+        date=np.array([0, 1], dtype="timedelta64[Y]"),
+        amount=np.array([0.25, 0.75]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "component_product"): {
+                "name": "component product",
+                "type": "product",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [],
+            },
+            ("foreground", "component_process"): {
+                "name": "component process",
+                "type": "process",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "component_product"),
+                        "amount": 1,
+                        "type": "production",
+                        "temporal_distribution": td_component_output,
+                    },
+                    {
+                        "input": ("background", "input"),
+                        "amount": 4,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+            ("foreground", "final_product"): {
+                "name": "final product",
+                "type": "product",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [],
+            },
+            ("foreground", "final_process"): {
+                "name": "final process",
+                "type": "process",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "final_product"),
+                        "amount": 1,
+                        "type": "production",
+                        "temporal_distribution": td_final_output,
+                    },
+                    {
+                        "input": ("foreground", "component_product"),
+                        "amount": 2,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+        }
+    )
+    for db in bd.databases:
+        bd.Database(db).process()
+
+
+def _run_multilayer_explicit_process_product_lca():
+    final_product = bd.get_node(database="foreground", code="final_product")
+    tlca = TimexLCA(
+        demand={final_product.key: 1},
+        method=("GWP", "example"),
+        database_dates={
+            "background": datetime(2030, 1, 1),
+            "foreground": "dynamic",
+        },
+    )
+    tlca.build_timeline(starting_datetime=datetime(2030, 1, 1))
+    tlca.lci()
+    tlca.static_lcia()
+    return tlca
+
+
+@pytest.mark.usefixtures("explicit_process_product_db")
+class TestExplicitProcessProductEndToEnd:
+    def test_static_and_timex_scores_match(self, explicit_process_product_db):
+        fu_product = bd.get_node(database="foreground", code="fleet_driving_product")
+        demand = {fu_product.key: 1}
+        method = ("GWP", "example")
+
+        slca = bc.LCA(demand, method=method)
+        slca.lci()
+        slca.lcia()
+
+        tlca = TimexLCA(
+            demand=demand,
+            method=method,
+            database_dates=explicit_process_product_db["database_dates"],
+        )
+        tlca.build_timeline(starting_datetime=datetime(2030, 1, 1))
+        tlca.lci()
+        tlca.static_lcia()
+
+        assert tlca.base_lca.score == pytest.approx(slca.score)
+        assert len(tlca.timeline) > 1
+
+        production_rows = tlca.timeline[
+            tlca.timeline["producer_name"] == "fleet driving process"
+        ]
+        assert set(production_rows["date_producer"].dt.year) == {2030, 2031}
+        assert sorted(production_rows["amount"].tolist()) == pytest.approx([0.4, 0.6])
+
+        electricity_rows = tlca.timeline[tlca.timeline["producer_name"] == "electricity"]
+        assert set(electricity_rows["date_consumer"].dt.year) == {2030, 2031}
+        assert tlca.static_score == pytest.approx(slca.score)
+
+
+def test_explicit_product_output_td_convolves_with_input_td():
+    bd.projects.set_current("__test_explicit_product_output_input_td__")
+    bd.databases.clear()
+    bd.methods.clear()
+
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Database("background").write(
+        {
+            ("background", "input"): {
+                "name": "input production",
+                "reference product": "input",
+                "unit": "kg",
+                "location": "GLO",
+                "exchanges": [
+                    {"input": ("background", "input"), "amount": 1, "type": "production"},
+                    {"input": ("bio", "co2"), "amount": 0.5, "type": "biosphere"},
+                ],
+            }
+        }
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_output = TemporalDistribution(
+        date=np.array([0, 2], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+    td_input = TemporalDistribution(
+        date=np.array([0, 1], dtype="timedelta64[Y]"),
+        amount=np.array([0.25, 0.75]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "service_process"): {
+                "name": "service process",
+                "type": "process",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [
+                    {
+                        "input": ("foreground", "service_product"),
+                        "amount": 1,
+                        "type": "production",
+                        "temporal_distribution": td_output,
+                    },
+                    {
+                        "input": ("background", "input"),
+                        "amount": 8,
+                        "type": "technosphere",
+                        "temporal_distribution": td_input,
+                    },
+                ],
+            },
+            ("foreground", "service_product"): {
+                "name": "service product",
+                "type": "product",
+                "unit": "unit",
+                "location": "GLO",
+                "exchanges": [],
+            },
+        }
+    )
+    for db in bd.databases:
+        bd.Database(db).process()
+
+    product = bd.get_node(database="foreground", code="service_product")
+    method = ("GWP", "example")
+    demand = {product.key: 1}
+    database_dates = {
+        "background": datetime(2030, 1, 1),
+        "foreground": "dynamic",
+    }
+
+    slca = bc.LCA(demand, method=method)
+    slca.lci()
+    slca.lcia()
+
+    tlca = TimexLCA(demand=demand, method=method, database_dates=database_dates)
+    tlca.build_timeline(starting_datetime=datetime(2030, 1, 1))
+    tlca.lci()
+    tlca.static_lcia()
+
+    production_rows = tlca.timeline[
+        tlca.timeline["producer_name"] == "service process"
+    ].sort_values("date_producer")
+    assert production_rows["date_producer"].dt.year.tolist() == [2030, 2032]
+    assert production_rows["date_consumer"].dt.year.tolist() == [2030, 2032]
+    assert production_rows["amount"].tolist() == pytest.approx([0.6, 0.4])
+
+    input_rows = tlca.timeline[tlca.timeline["producer_name"] == "input production"]
+    observed = sorted(
+        (
+            row.date_consumer.year,
+            row.date_producer.year,
+            float(row.amount),
+        )
+        for row in input_rows.itertuples()
+    )
+    assert observed == pytest.approx(
+        [
+            (2030, 2030, 2.0),
+            (2030, 2031, 6.0),
+            (2032, 2032, 2.0),
+            (2032, 2033, 6.0),
+        ]
+    )
+
+    assert tlca.base_lca.score == pytest.approx(slca.score)
+    assert tlca.static_score == pytest.approx(4.0)
+    assert tlca.static_score == pytest.approx(slca.score)
+
+    service_process = bd.get_node(database="foreground", code="service_process")
+    input_edge = next(edge for edge in service_process.technosphere())
+    input_edge["temporal_evolution_factors"] = {
+        datetime(2030, 1, 1): 1.0,
+        datetime(2032, 1, 1): 0.5,
+    }
+    input_edge["temporal_evolution_reference"] = "consumer"
+    input_edge.save()
+    bd.Database("foreground").process()
+
+    tlca_with_process_version_evolution = TimexLCA(
+        demand=demand,
+        method=method,
+        database_dates=database_dates,
+    )
+    tlca_with_process_version_evolution.build_timeline(
+        starting_datetime=datetime(2030, 1, 1)
+    )
+    tlca_with_process_version_evolution.lci()
+    tlca_with_process_version_evolution.static_lcia()
+
+    evolved_rows = tlca_with_process_version_evolution.timeline[
+        tlca_with_process_version_evolution.timeline["producer_name"] == "input production"
+    ]
+    assert set(evolved_rows["date_consumer"].dt.year) == {2030, 2032}
+    assert set(evolved_rows["temporal_evolution_reference"]) == {"consumer"}
+    # Cohort 2030 (weight 0.6, cop 1.0) → 0.6 * 8 * 1.0 * 0.5 = 2.4
+    # Cohort 2032 (weight 0.4, cop 0.5) → 0.4 * 8 * 0.5 * 0.5 = 0.8
+    assert tlca_with_process_version_evolution.static_score == pytest.approx(3.2)
+
+
+def test_multilayer_explicit_process_product_chain_with_evolution():
+    bd.projects.set_current("__test_multilayer_explicit_process_product_chain__")
+    bd.databases.clear()
+    bd.methods.clear()
+    _write_multilayer_explicit_process_product_db()
+
+    tlca = _run_multilayer_explicit_process_product_lca()
+
+    final_rows = tlca.timeline[
+        tlca.timeline["producer_name"] == "final process"
+    ].sort_values("date_producer")
+    assert final_rows["date_producer"].dt.year.tolist() == [2030, 2032]
+    assert final_rows["date_consumer"].dt.year.tolist() == [2030, 2032]
+    assert final_rows["amount"].tolist() == pytest.approx([0.6, 0.4])
+
+    component_rows = tlca.timeline[
+        tlca.timeline["producer_name"] == "component process"
+    ]
+    observed_component_timeline = sorted(
+        (
+            row.date_consumer.year,
+            row.date_producer.year,
+            float(row.amount),
+        )
+        for row in component_rows.itertuples()
+    )
+    assert observed_component_timeline == pytest.approx(
+        [
+            (2030, 2030, 0.5),
+            (2030, 2031, 1.5),
+            (2032, 2032, 0.5),
+            (2032, 2033, 1.5),
+        ]
+    )
+
+    background_rows = tlca.timeline[
+        tlca.timeline["producer_name"] == "input production"
+    ]
+    observed_background_timeline = sorted(
+        (
+            row.date_consumer.year,
+            row.date_producer.year,
+            float(row.amount),
+        )
+        for row in background_rows.itertuples()
+    )
+    assert observed_background_timeline == pytest.approx(
+        [
+            (2030, 2030, 4.0),
+            (2031, 2031, 4.0),
+            (2032, 2032, 4.0),
+            (2033, 2033, 4.0),
+        ]
+    )
+    assert tlca.static_score == pytest.approx(8.0)
+
+    final_process = bd.get_node(database="foreground", code="final_process")
+    component_edge = next(
+        edge
+        for edge in final_process.technosphere()
+        if edge.input["code"] == "component_product"
+    )
+    component_edge["temporal_evolution_factors"] = {datetime(2030, 1, 1): 0.5}
+    component_edge["temporal_evolution_reference"] = "consumer"
+    component_edge.save()
+    bd.Database("foreground").process()
+
+    evolved_tlca = _run_multilayer_explicit_process_product_lca()
+    evolved_component_rows = evolved_tlca.timeline[
+        evolved_tlca.timeline["producer_name"] == "component process"
+    ]
+    assert sorted(
+        (
+            row.date_consumer.year,
+            row.date_producer.year,
+            float(row.amount),
+        )
+        for row in evolved_component_rows.itertuples()
+    ) == pytest.approx(observed_component_timeline)
+    assert set(evolved_component_rows["temporal_evolution_reference"]) == {"consumer"}
+    assert evolved_tlca.static_score == pytest.approx(4.0)
+
+
+def test_multi_vintage_demand_splits_across_cohorts():
+    """Two install-year cohorts each draw from a different background database.
+
+    With install-year RTD = [2025: 0.5, 2035: 0.5] and the use-phase happening
+    at the install year, cohort 2025 should source electricity from
+    `electricity_market_2025` and cohort 2035 from `electricity_market_2035`.
+    The fleet score must therefore be the demand-weighted mix of both
+    backgrounds, not just one of them.
+    """
+    bd.projects.set_current("__test_multi_vintage_demand_split__")
+    bd.databases.clear()
+    bd.methods.clear()
+
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    for db_name, co2_per_kwh in [
+        ("electricity_market_2025", 0.40),
+        ("electricity_market_2035", 0.10),
+    ]:
+        bd.Database(db_name).write(
+            {
+                (db_name, "elec"): {
+                    "name": "electricity market",
+                    "reference product": "electricity",
+                    "location": "DE",
+                    "unit": "kWh",
+                    "exchanges": [
+                        {
+                            "amount": 1,
+                            "type": "production",
+                            "input": (db_name, "elec"),
+                        },
+                        {
+                            "amount": co2_per_kwh,
+                            "type": "biosphere",
+                            "input": ("bio", "co2"),
+                        },
+                    ],
+                },
+            }
+        )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_install = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.5, 0.5]),
+    )
+    td_use_at_install = TemporalDistribution(
+        date=np.array([0], dtype="timedelta64[Y]"),
+        amount=np.array([1.0]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "unit_product"): {
+                "name": "unit product",
+                "type": "product",
+                "unit": "unit",
+                "location": "DE",
+                "exchanges": [],
+            },
+            ("foreground", "unit_lifecycle"): {
+                "name": "unit lifecycle",
+                "type": "process",
+                "unit": "unit",
+                "location": "DE",
+                "exchanges": [
+                    {
+                        "amount": 1,
+                        "type": "production",
+                        "input": ("foreground", "unit_product"),
+                        "temporal_distribution": td_install,
+                    },
+                    {
+                        "amount": 1.0,
+                        "type": "technosphere",
+                        "input": ("electricity_market_2025", "elec"),
+                        "temporal_distribution": td_use_at_install,
+                    },
+                ],
+            },
+        }
+    )
+    for db in bd.databases:
+        bd.Database(db).process()
+
+    product = bd.get_node(database="foreground", code="unit_product")
+    database_dates = {
+        "electricity_market_2025": datetime(2025, 1, 1),
+        "electricity_market_2035": datetime(2035, 1, 1),
+        "foreground": "dynamic",
+    }
+    tlca = TimexLCA(
+        demand={product.key: 1},
+        method=("GWP", "example"),
+        database_dates=database_dates,
+    )
+    tlca.build_timeline(
+        starting_datetime=datetime(2025, 1, 1),
+        temporal_grouping="year",
+    )
+    tlca.lci()
+    tlca.static_lcia()
+
+    fu_rows = tlca.timeline[tlca.timeline["consumer"] == -1].sort_values(
+        "date_producer"
+    )
+    assert fu_rows["date_producer"].dt.year.tolist() == [2025, 2035]
+    assert fu_rows["amount"].tolist() == pytest.approx([0.5, 0.5])
+
+    elec_rows = tlca.timeline[
+        tlca.timeline["producer_name"] == "electricity market"
+    ].sort_values("date_consumer")
+    assert elec_rows["date_consumer"].dt.year.tolist() == [2025, 2035]
+    assert [
+        row.temporal_market_shares for row in elec_rows.itertuples()
+    ] == [
+        {"electricity_market_2025": 1.0},
+        {"electricity_market_2035": 1.0},
+    ]
+
+    assert tlca.static_score == pytest.approx(0.5 * 0.40 + 0.5 * 0.10)

--- a/tests/test_explicit_process_product_end_to_end.py
+++ b/tests/test_explicit_process_product_end_to_end.py
@@ -602,3 +602,115 @@ def test_explicit_output_coefficient_alpha_scales_inputs():
         for row in input_rows.itertuples()
     )
     assert observed == pytest.approx([(2030, 2030, 2.0), (2031, 2031, 2.0)])
+
+
+def _write_explicit_two_background_cohort_db():
+    """Explicit process/product with a cohort production TD whose two cohorts
+    resolve to two different background databases. If the production-edge TD is
+    dropped, both cohorts collapse onto one background and the score changes -
+    so this fixture is sensitive to correct production-edge handling.
+    """
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    for db_name, co2_per_kwh in [
+        ("electricity_market_2025", 0.40),
+        ("electricity_market_2035", 0.10),
+    ]:
+        bd.Database(db_name).write(
+            {
+                (db_name, "elec"): {
+                    "name": "electricity market",
+                    "reference product": "electricity",
+                    "location": "DE",
+                    "unit": "kWh",
+                    "exchanges": [
+                        {"amount": 1, "type": "production", "input": (db_name, "elec")},
+                        {"amount": co2_per_kwh, "type": "biosphere", "input": ("bio", "co2")},
+                    ],
+                },
+            }
+        )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    td_install = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.5, 0.5]),
+    )
+    td_use_at_install = TemporalDistribution(
+        date=np.array([0], dtype="timedelta64[Y]"),
+        amount=np.array([1.0]),
+    )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "unit_product"): {
+                "name": "unit product",
+                "type": "product",
+                "unit": "unit",
+                "location": "DE",
+                "exchanges": [],
+            },
+            ("foreground", "unit_lifecycle"): {
+                "name": "unit lifecycle",
+                "type": "process",
+                "unit": "unit",
+                "location": "DE",
+                "exchanges": [
+                    {
+                        "amount": 1,
+                        "type": "production",
+                        "input": ("foreground", "unit_product"),
+                        "temporal_distribution": td_install,
+                    },
+                    {
+                        "amount": 1.0,
+                        "type": "technosphere",
+                        "input": ("electricity_market_2025", "elec"),
+                        "temporal_distribution": td_use_at_install,
+                    },
+                ],
+            },
+        }
+    )
+    for db in bd.databases:
+        bd.Database(db).process()
+
+
+def test_explicit_bfs_traversal_matches_priority():
+    """Explicit graphs must traverse correctly under graph_traversal='bfs' too.
+
+    Both EdgeExtractor variants (priority + BFS) need explicit-node support, and
+    BFS has regressed on temporal data before (see fix-bfs-with-evo-factors).
+    Two background databases make the score sensitive to the cohort split: if
+    the production-edge TD is dropped, both cohorts collapse onto the 2025
+    background (score 0.40) instead of the 0.5/0.5 mix (score 0.25).
+    """
+    bd.projects.set_current("__test_explicit_bfs_traversal__")
+    bd.databases.clear()
+    bd.methods.clear()
+    _write_explicit_two_background_cohort_db()
+
+    product = bd.get_node(database="foreground", code="unit_product")
+    method = ("GWP", "example")
+    demand = {product.key: 1}
+    database_dates = {
+        "electricity_market_2025": datetime(2025, 1, 1),
+        "electricity_market_2035": datetime(2035, 1, 1),
+        "foreground": "dynamic",
+    }
+
+    def score(graph_traversal):
+        tlca = TimexLCA(demand=demand, method=method, database_dates=database_dates)
+        tlca.build_timeline(
+            starting_datetime=datetime(2025, 1, 1),
+            temporal_grouping="year",
+            graph_traversal=graph_traversal,
+        )
+        tlca.lci()
+        tlca.static_lcia()
+        return tlca.static_score
+
+    priority_score = score("priority")
+    assert priority_score == pytest.approx(0.5 * 0.40 + 0.5 * 0.10)
+    assert score("bfs") == pytest.approx(priority_score)

--- a/tests/test_temporal_evolution.py
+++ b/tests/test_temporal_evolution.py
@@ -343,6 +343,80 @@ def test_temporal_evolution_score_matches_hardcoded():
 
 
 @bw2test
+def test_temporal_evolution_reference_consumer_vs_producer():
+    """Temporal evolution can be evaluated at consumer (vintage) time or producer time."""
+    bd.Database("bio").write(
+        {("bio", "CO2"): {"type": "emission", "name": "carbon dioxide"}}
+    )
+
+    for db_name in ("db_2020", "db_2030"):
+        bd.Database(db_name).write(
+            {
+                (db_name, "electricity"): {
+                    "name": "electricity production",
+                    "reference product": "electricity",
+                    "location": "GLO",
+                    "exchanges": [
+                        {"amount": 1, "type": "production", "input": (db_name, "electricity")},
+                        {"amount": 1, "type": "biosphere", "input": ("bio", "CO2")},
+                    ],
+                }
+            }
+        )
+
+    bd.Method(("GWP", "example")).write([(("bio", "CO2"), 1.0)])
+
+    td_use = TemporalDistribution(
+        date=np.array([5], dtype="timedelta64[Y]"), amount=np.array([1.0])
+    )
+
+    def run_model(reference: str) -> float:
+        bd.Database("foreground").write(
+            {
+                ("foreground", "consumer"): {
+                    "name": "consumer",
+                    "reference product": "unit",
+                    "location": "GLO",
+                    "exchanges": [
+                        {"amount": 1, "type": "production", "input": ("foreground", "consumer")},
+                        {
+                            "amount": 10,
+                            "type": "technosphere",
+                            "input": ("db_2020", "electricity"),
+                            "temporal_distribution": td_use,
+                            "temporal_evolution_factors": {
+                                datetime(2025, 1, 1): 1.0,
+                                datetime(2030, 1, 1): 2.0,
+                            },
+                            "temporal_evolution_reference": reference,
+                        },
+                    ],
+                }
+            }
+        )
+
+        database_dates = {
+            "db_2020": datetime(2020, 1, 1),
+            "db_2030": datetime(2030, 1, 1),
+            "foreground": "dynamic",
+        }
+        tlca = TimexLCA(
+            demand={("foreground", "consumer"): 1},
+            method=("GWP", "example"),
+            database_dates=database_dates,
+        )
+        tlca.build_timeline(starting_datetime=datetime(2025, 1, 1))
+        tlca.lci()
+        tlca.static_lcia()
+        return tlca.static_score
+
+    score_consumer_ref = run_model("consumer")
+    score_producer_ref = run_model("producer")
+
+    assert score_producer_ref == pytest.approx(2 * score_consumer_ref, rel=1e-6)
+
+
+@bw2test
 def test_temporal_evolution_applied_with_bfs_traversal():
     """temporal_evolution_factors must be applied with graph_traversal='bfs' too,
     not only with the default priority traversal.

--- a/tests/test_timeline_builder.py
+++ b/tests/test_timeline_builder.py
@@ -110,3 +110,20 @@ class TestAdjustSignOfAmount:
     def test_unrecognized_type(self):
         with pytest.raises(TypeError, match="Unrecognized type"):
             self.adjust("unknown_type")
+
+
+# --- traverse_background flag ---
+
+
+def test_traverse_background_flag_accepted_and_stored(process_at_base_database_time_db):
+    from bw_timex import TimexLCA
+
+    method = ("GWP", "example")
+    database_dates = {
+        "background_2020": datetime.strptime("2020", "%Y"),
+        "background_2030": datetime.strptime("2030", "%Y"),
+        "foreground": "dynamic",
+    }
+    tlca = TimexLCA({("foreground", "fu"): 1}, method, database_dates)
+    tlca.build_timeline(starting_datetime="2024-01-01", traverse_background=False)
+    assert tlca.timeline_builder.traverse_background is False


### PR DESCRIPTION
## Summary

Adds an opt-in `traverse_background` flag to `TimexLCA.build_timeline(...)` (default `False`). When enabled, the supply-chain traversal descends **into** background databases instead of stopping at the first-level frontier, so temporal distributions defined on exchanges *inside* background databases take effect: time-spread flows are sourced from the temporally-appropriate background-db variant, reading each non-referenced variant's exchanges/amounts/TDs.

Implemented in **both** traversal engines (`graph_traversal="priority"` and `"bfs"`) via a shared `VariantBackgroundMixin`. Default behaviour is unchanged.

## How it works

- The static-background exclusion is dropped when `traverse_background=True`; traversal is bounded by `cutoff`/`max_calc`.
- Temporal-market-vs-temporalized classification keys on the presence of `temporal_market_shares` (a descended-into background process is temporalized, not double-counted).
- At the first background crossing, a producer is split into its date-interpolated variants; each branch reads the respective variant via `interdatabase_activity_mapping` + bw2data proxies. Leaf (emission-only) background producers keep the existing temporal-market routing, preserving exact equivalence when no background TDs are present.
- Priority mode walks non-referenced variant subtrees in full via proxy reads (no heap-node fabrication); referenced-system heap order is unchanged and amounts are exact. A one-time informational warning is emitted.

## Known limitation

The variant split raises `NotImplementedError` for the multi-date-consumer case (a background process with further background technosphere inputs reached at more than one cohort date). It fails loudly and only under `traverse_background=True`. Documented in the docstring and theory docs.

## Tests

- No-TD equivalence (`True` == `False`), respective-variant amount reads, per-variant TD reads, no-double-count, parity across both engines, the `NotImplementedError` guard, and convolution of a foreground TD with a background TD through the traversal (with per-row amount checks). Full suite green.

## Docs / example

- `build_timeline` docstring + `docs/content/theory.md` updated.
- New `notebooks/background_temporalization.ipynb`: a Getting-Started-style walkthrough with a decarbonizing-grid story across 2020/2040 background variants.

---

> **Note:** Stacked on #193 (`explicit-product-bfs-support`). Until #193 merges, the diff here also shows that branch's commits; it will narrow automatically once #193 lands.
