### PR TITLE
v1.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## [1.1.1] - 2026-06-23
-* Added module-level caching of database node proxies so repeated `TimexLCA` objects in a session reuse them instead of re-querying
-* Fixed `traverse_background` crashing on zero-amount background exchanges
-* Fixed `max_calc` not bounding the background traversal
+* Added module-level caching of database node proxies so repeated `TimexLCA` objects in a session reuse them instead of re-querying ([#196](https://github.com/brightway-lca/bw_timex/pull/196))
+* Fixed `traverse_background` crashing on zero-amount background exchanges ([#196](https://github.com/brightway-lca/bw_timex/pull/196))
+* Fixed `max_calc` not bounding the background traversal ([#196](https://github.com/brightway-lca/bw_timex/pull/196))
 
 ## [1.1.0] - 2026-06-22
 * Added support for explicit `product` and `process` nodes instead of only `processwithreferenceproduct` ([#192](https://github.com/brightway-lca/bw_timex/pull/192))([#193](https://github.com/brightway-lca/bw_timex/pull/193))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.1.1] - 2026-06-23
+* Added module-level caching of database node proxies so repeated `TimexLCA` objects in a session reuse them instead of re-querying
+* Fixed `traverse_background` crashing on zero-amount background exchanges
+* Fixed `max_calc` not bounding the background traversal
+
 ## [1.1.0] - 2026-06-22
 * Added support for explicit `product` and `process` nodes instead of only `processwithreferenceproduct` ([#192](https://github.com/brightway-lca/bw_timex/pull/192))([#193](https://github.com/brightway-lca/bw_timex/pull/193))
 * Added `traverse_background` option to include temporal distributions in the background system ([#195](https://github.com/brightway-lca/bw_timex/pull/195))

--- a/bw_timex/__init__.py
+++ b/bw_timex/__init__.py
@@ -11,4 +11,4 @@ from .utils import (
     get_temporal_evolution_factor,
 )
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/bw_timex/_lci_cache.py
+++ b/bw_timex/_lci_cache.py
@@ -26,9 +26,16 @@ BIOSPHERE_EXCHANGES_CACHE = {}
 # session can skip the ~1.4 s `spsolve` for the functional unit.
 LCI_SOLVE_CACHE = {}
 
+# Cached node proxies per database. Keyed by ``("nodes", project, db,
+# modified)`` so each ``TimexLCA`` reuses the ``Activity`` proxies built from
+# the database rows instead of re-querying. Editing a database bumps its
+# ``modified`` token, invalidating stale entries automatically.
+NODES_CACHE = {}
+
 
 def clear_background_lci_cache() -> None:
-    """Clear all module-level bw_timex caches (unit LCI, biosphere exchanges, solve)."""
+    """Clear all module-level bw_timex caches (unit LCI, biosphere exchanges, solve, nodes)."""
     BACKGROUND_UNIT_LCI_CACHE.clear()
     BIOSPHERE_EXCHANGES_CACHE.clear()
     LCI_SOLVE_CACHE.clear()
+    NODES_CACHE.clear()

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -444,12 +444,19 @@ class VariantBackgroundMixin:
 
         Engine-agnostic: it does not touch the priority heap or the BFS matrix,
         so both extractors call it identically after their first-crossing split.
+
+        Bounded by ``cutoff`` (per-edge supply threshold) and ``max_calc`` (total
+        descended-node budget, shared via ``self._calc_count``); the latter
+        caps how deep the background descent runs.
         """
         edges = []
         queue = deque()
         queue.append((node_id, td, td_parent, abs_td, supply))
 
         while queue:
+            self._calc_count += 1
+            if self._calc_count > self.max_calc:
+                break
             cur_id, cur_td, cur_parent, cur_abs_td, cur_supply = queue.popleft()
 
             production_amount = self._proxy_production_amount(cur_id)
@@ -467,6 +474,14 @@ class VariantBackgroundMixin:
                         date=np.array([0], dtype="timedelta64[Y]"),
                         amount=np.array([td_producer]),
                     )
+
+                # Zero-amount technosphere exchanges (ubiquitous in real
+                # ecoinvent) carry no inventory. Convolving them away would yield
+                # an empty TemporalDistribution (temporal_convolution drops zero
+                # entries), so skip them entirely, mirroring the matrix path
+                # where structural zeros are not edges.
+                if not np.any(td_producer.amount):
+                    continue
 
                 distribution = (cur_td * td_producer).simplify()
                 abs_td_producer = _join_datetime_and_timedelta_distributions(
@@ -561,6 +576,11 @@ class EdgeExtractor(VariantBackgroundMixin, TemporalisLCA):
         # not stored on it; the shared variant-descent mixin needs both, so keep
         # local copies before delegating.
         self.cutoff = kwargs.get("cutoff", 5e-4)
+        # max_calc bounds the background proxy descent too (the shared mixin's
+        # _descend_variant_subtree). TemporalisLCA consumes max_calc for its own
+        # heap traversal but does not store it, so keep a local copy + counter.
+        self.max_calc = kwargs.get("max_calc", 2000)
+        self._calc_count = 0
         self.static_activity_indices = kwargs.get("static_activity_indices") or set()
         # INVARIANT: static_activity_indices holds TemporalisLCA MATRIX INDICES,
         # not activity ids. _proxy_technosphere_inputs filters by activity id, so

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -28,7 +28,7 @@ from loguru import logger
 from peewee import fn
 from scipy import sparse
 
-from ._lci_cache import BACKGROUND_UNIT_LCI_CACHE, LCI_SOLVE_CACHE
+from ._lci_cache import BACKGROUND_UNIT_LCI_CACHE, LCI_SOLVE_CACHE, NODES_CACHE
 FACTORIZE_SOLVES_THRESHOLD = 8
 
 from .dynamic_biosphere_builder import DynamicBiosphereBuilder
@@ -174,17 +174,31 @@ class TimexLCA:
 
         self.interdatabase_activity_mapping = InterDatabaseMapping()
 
-        # Getting all nodes from the databases for faster lookup later
-        all_nodes = bd.backends.ActivityDataset.select().where(
-            bd.backends.ActivityDataset.database << list(self.database_dates.keys())
-        )
-        self.nodes = {node.id: bd.backends.Activity(node) for node in all_nodes}
+        # Getting all nodes from the databases for faster lookup later. Node
+        # proxies are cached per database at module level (keyed by the
+        # database's `modified` token) so repeated TimexLCA objects in the same
+        # session reuse them instead of re-querying. Opt out via
+        # `use_global_lci_cache=False`.
+        self._nodes_cache = NODES_CACHE if use_global_lci_cache else {}
+        project = bd.projects.current
+        self.nodes = {}
+        # Build a cache mapping activity code to name for efficient lookups.
+        # This avoids repeated database queries in plotting and labeling functions.
+        self._activity_code_to_name_cache = {}
+        for db in self.database_dates.keys():
+            modified = bd.databases[db].get("modified") if db in bd.databases else None
+            key = ("nodes", project, db, modified)
+            db_nodes = self._nodes_cache.get(key)
+            if db_nodes is None:
+                rows = bd.backends.ActivityDataset.select().where(
+                    bd.backends.ActivityDataset.database == db
+                )
+                db_nodes = {row.id: bd.backends.Activity(row) for row in rows}
+                self._nodes_cache[key] = db_nodes
+            self.nodes.update(db_nodes)
+            for node in db_nodes.values():
+                self._activity_code_to_name_cache[node["code"]] = node["name"]
 
-        # Build a cache mapping activity code to name for efficient lookups
-        # This avoids repeated database queries in plotting and labeling functions
-        self._activity_code_to_name_cache = {
-            node["code"]: node["name"] for node in self.nodes.values()
-        }
         self._last_timeline_build_key = None
         self._cached_timeline = None
         self._default_edge_filter_function = None

--- a/notebooks/background_temporalization_premise.ipynb
+++ b/notebooks/background_temporalization_premise.ipynb
@@ -1,0 +1,953 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2e192eb7",
+   "metadata": {},
+   "source": [
+    "# `bw_timex` — Temporal distributions on **background** exchanges (real premise data)\n",
+    "\n",
+    "This notebook is a sibling of [`teaching_example_ev_premise.ipynb`](teaching/teaching_example_ev_premise.ipynb).\n",
+    "It uses the **same project and prospective premise databases**, but instead of putting temporal\n",
+    "distributions (TDs) on the *foreground* edges, we put them on edges **inside the background system**\n",
+    "and let the traversal descend into them with the `traverse_background=True` option.\n",
+    "\n",
+    "**The experiment**\n",
+    "\n",
+    "1. Take a background process `P1` and add a TD to one of its technosphere exchanges.\n",
+    "2. Go one step further down the supply chain: the *input* of that exchange is `P2`. Add a TD to one\n",
+    "   of `P2`'s exchanges too.\n",
+    "3. Build a tiny foreground process `A` that consumes `P1`.\n",
+    "4. Run a `TimexLCA` with `traverse_background=True` and confirm from the timeline that the descent\n",
+    "   actually reaches `P2` (and `P3`) at the time-shifted, variant-resolved dates.\n",
+    "\n",
+    "```mermaid\n",
+    "flowchart LR\n",
+    "subgraph fg[<i>foreground</i>]\n",
+    "  A(\"Process A\"):::fg\n",
+    "end\n",
+    "subgraph bg[<i>background (premise variants)</i>]\n",
+    "  P1(\"P1: passenger car production,<br/>electric, w/o battery\"):::bg\n",
+    "  P2(\"P2: market for glider,<br/>passenger car\"):::bg\n",
+    "  P3(\"P3: glider production,<br/>passenger car\"):::bg\n",
+    "end\n",
+    "A -->|\"1 unit\"| P1\n",
+    "P1 -->|\"0.91 kg <b>+ TD₁</b>\"| P2\n",
+    "P2 -->|\"1 kg <b>+ TD₂</b>\"| P3\n",
+    "classDef fg color:#222832, fill:#9c5ffd, stroke:none;\n",
+    "classDef bg color:#222832, fill:#3fb1c5, stroke:none;\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da80326a",
+   "metadata": {},
+   "source": [
+    "## Step 0 — Setup (same project as the EV teaching example)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4838b6e0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:28:25.283832Z",
+     "iopub.status.busy": "2026-06-22T13:28:25.283748Z",
+     "iopub.status.idle": "2026-06-22T13:28:26.690317Z",
+     "shell.execute_reply": "2026-06-22T13:28:26.689424Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import bw2data as bd\n",
+    "\n",
+    "bd.projects.set_current(\"ei312_REMIND_EU\")\n",
+    "\n",
+    "BG_DATABASE = \"ei312_REMIND-EU_SSP2_NDC_2020\"  # the variant the foreground references\n",
+    "\n",
+    "if \"foreground\" in bd.databases:\n",
+    "    del bd.databases[\"foreground\"]  # rebuild the foreground from scratch\n",
+    "foreground = bd.Database(\"foreground\")\n",
+    "foreground.register()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38bd8159",
+   "metadata": {},
+   "source": [
+    "## Step 1 — Pick a background process `P1` and inspect its exchanges\n",
+    "\n",
+    "We grab a *random-ish* but meaningful background process: the production of an electric passenger car\n",
+    "glider-less body. We list its technosphere exchanges and pick one to temporalize."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c7cddaf8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:28:26.692197Z",
+     "iopub.status.busy": "2026-06-22T13:28:26.692070Z",
+     "iopub.status.idle": "2026-06-22T13:28:26.872477Z",
+     "shell.execute_reply": "2026-06-22T13:28:26.871788Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P1: passenger car production, electric, without battery | GLO | 24511137e9da4c9ebb5f39d4caea0705\n",
+      "\n",
+      "Technosphere exchanges of P1:\n",
+      "  [0] +0.9126   kilogram | market for glider, passenger car (GLO)\n",
+      "  [1] +1       unit | market for manual dismantling of used electric passenger car (GLO)\n",
+      "  [2] +0.08736   kilogram | market for powertrain, for electric passenger car (GLO)\n",
+      "  [3] -4.626e-07   kilogram | market for waste glass (ZA)\n",
+      "  [4] -1.57e-07   kilogram | market for waste glass (PE)\n",
+      "  [5] -9.193e-05   kilogram | market group for waste glass (RER)\n",
+      "  [6] -1.108e-06   kilogram | market for waste glass (CO)\n",
+      "  [7] -1.034e-07   kilogram | market for waste glass (IN)\n",
+      "  [8] -0.03639   kilogram | market for waste glass (RoW)\n",
+      "  [9] -1.202e-05   kilogram | market for waste glass (BR)\n",
+      "  [10] -2.514e-08   kilogram | market for waste glass (CY)\n",
+      "  [11] -0.002316   kilogram | market for waste mineral oil (RoW)\n",
+      "  [12] -0.001114   kilogram | market for waste mineral oil (Europe without Switzerland)\n",
+      "  [13] -3.031e-05   kilogram | market for waste mineral oil (CH)\n",
+      "  [14] -0.03251   kilogram | market for waste rubber, unspecified (RoW)\n",
+      "  [15] -0.01828   kilogram | market for waste rubber, unspecified (Europe without Switzerland)\n",
+      "  [16] -0.0007674   kilogram | market for waste rubber, unspecified (CH)\n"
+     ]
+    }
+   ],
+   "source": [
+    "P1 = bd.get_node(\n",
+    "    database=BG_DATABASE,\n",
+    "    name=\"passenger car production, electric, without battery\",\n",
+    ")\n",
+    "print(\"P1:\", P1[\"name\"], \"|\", P1.get(\"location\"), \"|\", P1[\"code\"])\n",
+    "print(\"\\nTechnosphere exchanges of P1:\")\n",
+    "for i, exc in enumerate(P1.technosphere()):\n",
+    "    inp = exc.input\n",
+    "    print(f\"  [{i}] {exc['amount']:+.4g} {inp['unit']:>10} | {inp['name']} ({inp.get('location')})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a2c772c",
+   "metadata": {},
+   "source": [
+    "We select exchange `[0]` — the **glider** input (`market for glider, passenger car`, ~0.91 kg).\n",
+    "This is `P1 → P2`. We attach a temporal distribution `TD₁` saying the glider is sourced **1–2 years\n",
+    "before** the car is produced."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "80ff9151",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:28:26.874039Z",
+     "iopub.status.busy": "2026-06-22T13:28:26.873930Z",
+     "iopub.status.idle": "2026-06-22T13:28:26.894293Z",
+     "shell.execute_reply": "2026-06-22T13:28:26.893788Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "e1: 0.9126 market for glider, passenger car -> passenger car production, electric, without battery\n",
+      "Added TD1 to e1.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bw_temporalis import TemporalDistribution\n",
+    "import numpy as np\n",
+    "\n",
+    "# the exchange P1 -> P2 (glider)\n",
+    "e1 = next(\n",
+    "    exc for exc in P1.technosphere()\n",
+    "    if exc.input[\"name\"] == \"market for glider, passenger car\"\n",
+    ")\n",
+    "P2 = e1.input\n",
+    "print(\"e1:\", round(e1[\"amount\"], 4), e1.input[\"name\"], \"->\", e1.output[\"name\"])\n",
+    "\n",
+    "td1 = TemporalDistribution(\n",
+    "    date=np.array([-2, -1], dtype=\"timedelta64[Y]\"),\n",
+    "    amount=np.array([0.4, 0.6]),\n",
+    ")\n",
+    "e1[\"temporal_distribution\"] = td1\n",
+    "e1.save()\n",
+    "print(\"Added TD1 to e1.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a1d2ca5",
+   "metadata": {},
+   "source": [
+    "## Step 2 — Go one step deeper: add a TD to an exchange of `P2`\n",
+    "\n",
+    "`P2` is `market for glider, passenger car`. We inspect *its* exchanges and temporalize the link to\n",
+    "`P3` (`glider production, passenger car`) with `TD₂`: production happens **6–12 months before** the\n",
+    "market delivers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "022ffb0f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:28:26.895968Z",
+     "iopub.status.busy": "2026-06-22T13:28:26.895851Z",
+     "iopub.status.idle": "2026-06-22T13:28:26.899208Z",
+     "shell.execute_reply": "2026-06-22T13:28:26.898671Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P2: market for glider, passenger car | GLO | 487a4e1fe9564da4b86aec0b20def778\n",
+      "\n",
+      "Technosphere exchanges of P2:\n",
+      "  [0] +1   kilogram | glider production, passenger car (GLO)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"P2:\", P2[\"name\"], \"|\", P2.get(\"location\"), \"|\", P2[\"code\"])\n",
+    "print(\"\\nTechnosphere exchanges of P2:\")\n",
+    "for i, exc in enumerate(P2.technosphere()):\n",
+    "    inp = exc.input\n",
+    "    print(f\"  [{i}] {exc['amount']:+.4g} {inp['unit']:>10} | {inp['name']} ({inp.get('location')})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8c52f817",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:28:26.900498Z",
+     "iopub.status.busy": "2026-06-22T13:28:26.900421Z",
+     "iopub.status.idle": "2026-06-22T13:28:26.907242Z",
+     "shell.execute_reply": "2026-06-22T13:28:26.906749Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "e2: 1.0 glider production, passenger car -> market for glider, passenger car\n",
+      "Added TD2 to e2.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# the exchange P2 -> P3 (glider production)\n",
+    "e2 = next(\n",
+    "    exc for exc in P2.technosphere()\n",
+    "    if exc.input[\"name\"] == \"glider production, passenger car\"\n",
+    ")\n",
+    "P3 = e2.input\n",
+    "print(\"e2:\", round(e2[\"amount\"], 4), e2.input[\"name\"], \"->\", e2.output[\"name\"])\n",
+    "\n",
+    "td2 = TemporalDistribution(\n",
+    "    date=np.array([-12, -9, -6], dtype=\"timedelta64[M]\"),\n",
+    "    amount=np.array([0.3, 0.4, 0.3]),\n",
+    ")\n",
+    "e2[\"temporal_distribution\"] = td2\n",
+    "e2.save()\n",
+    "print(\"Added TD2 to e2.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35c668c9",
+   "metadata": {},
+   "source": [
+    "> **Note:** these `temporal_distribution` keys are now persisted on exchanges *inside* the\n",
+    "> premise background database. They are ignored by any normal run (and by `traverse_background=False`),\n",
+    "> so they don't affect the other notebooks. The last cell shows how to remove them again."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3648d4f",
+   "metadata": {},
+   "source": [
+    "## Step 3 — Build a tiny foreground process `A` that consumes `P1`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ad429186",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:28:26.908575Z",
+     "iopub.status.busy": "2026-06-22T13:28:26.908490Z",
+     "iopub.status.idle": "2026-06-22T13:28:26.927710Z",
+     "shell.execute_reply": "2026-06-22T13:28:26.927100Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Foreground A -> P1 created.\n"
+     ]
+    }
+   ],
+   "source": [
+    "A = foreground.new_node(\"A\", name=\"process A\", unit=\"unit\")\n",
+    "A[\"reference product\"] = \"A\"\n",
+    "A.save()\n",
+    "\n",
+    "A.new_edge(input=A, amount=1, type=\"production\").save()\n",
+    "A.new_edge(input=P1, amount=1, type=\"technosphere\").save()\n",
+    "print(\"Foreground A -> P1 created.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a299ed1",
+   "metadata": {},
+   "source": [
+    "## Step 4 — `TimexLCA` with `traverse_background=True`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c9d57751",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:28:26.929033Z",
+     "iopub.status.busy": "2026-06-22T13:28:26.928927Z",
+     "iopub.status.idle": "2026-06-22T13:28:26.931129Z",
+     "shell.execute_reply": "2026-06-22T13:28:26.930740Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "method = (\n",
+    "    \"ecoinvent-3.12\",\n",
+    "    \"EF v3.1\",\n",
+    "    \"climate change\",\n",
+    "    \"global warming potential (GWP100)\",\n",
+    ")\n",
+    "\n",
+    "database_dates = {\n",
+    "    \"ei312_REMIND-EU_SSP2_NDC_2020\": datetime.strptime(\"2020\", \"%Y\"),\n",
+    "    \"ei312_REMIND-EU_SSP2_NDC_2030\": datetime.strptime(\"2030\", \"%Y\"),\n",
+    "    \"ei312_REMIND-EU_SSP2_NDC_2040\": datetime.strptime(\"2040\", \"%Y\"),\n",
+    "    \"foreground\": \"dynamic\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8a6e7075",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:28:26.932467Z",
+     "iopub.status.busy": "2026-06-22T13:28:26.932383Z",
+     "iopub.status.idle": "2026-06-22T13:29:03.913327Z",
+     "shell.execute_reply": "2026-06-22T13:29:03.912830Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:28:27.216\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m136\u001b[0m - \u001b[1mInitializing TimexLCA object...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:28:27.217\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m153\u001b[0m - \u001b[1mCalculating base LCA...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/timodiepers/Documents/Coding/bw_timex/.venv/lib/python3.13/site-packages/scikits/umfpack/umfpack.py:737: UmfpackWarning: (almost) singular matrix! (estimated cond. number: 1.65e+13)\n",
+      "  warnings.warn(msg, UmfpackWarning)\n",
+      "\u001b[32m2026-06-22 15:28:57.297\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m170\u001b[0m - \u001b[1mCollecting node infos...\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "from bw_timex import TimexLCA\n",
+    "\n",
+    "# This single line runs a full static ecoinvent LCA of the demand under the hood\n",
+    "# (the \"base LCA\"), which is the slowest step of the whole notebook (~30 s on a\n",
+    "# cold cache). We build exactly ONE TimexLCA and reuse it below.\n",
+    "tlca = TimexLCA({A: 1}, method, database_dates)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f7af944",
+   "metadata": {},
+   "source": [
+    "Build the timeline **descending into the background**. We use `graph_traversal=\"bfs\"` (recommended\n",
+    "with `traverse_background=True`), a monthly grouping, and start in 2030 so the time-shifts land between\n",
+    "the 2020 and 2030 variants.\n",
+    "\n",
+    "> With `traverse_background=True` the traversal descends into the *entire* background supply chain, so\n",
+    "> we cap it with a small `max_calc` to keep this demo fast — the glider chain we care about\n",
+    "> (`P1 → P2 → P3`) is reached in the first few graph-traversal steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "61a9bc07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:29:03.920563Z",
+     "iopub.status.busy": "2026-06-22T13:29:03.920431Z",
+     "iopub.status.idle": "2026-06-22T13:29:04.786341Z",
+     "shell.execute_reply": "2026-06-22T13:29:04.785817Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:29:03.924\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m349\u001b[0m - \u001b[1mCreating activity time mapping...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:29:04.294\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m112\u001b[0m - \u001b[1mTraversing supply chain graph...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:29:04.729\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m186\u001b[0m - \u001b[1mBuilding timeline...\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date_producer</th>\n",
+       "      <th>producer_name</th>\n",
+       "      <th>date_consumer</th>\n",
+       "      <th>consumer_name</th>\n",
+       "      <th>amount</th>\n",
+       "      <th>temporal_market_shares</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2027-01-01</td>\n",
+       "      <td>market for polyethylene, low density, granulate</td>\n",
+       "      <td>2027-01-01</td>\n",
+       "      <td>glider production, passenger car</td>\n",
+       "      <td>0.003172</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2027-01-01</td>\n",
+       "      <td>market for road vehicle factory</td>\n",
+       "      <td>2027-01-01</td>\n",
+       "      <td>glider production, passenger car</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2027-01-01</td>\n",
+       "      <td>treatment of aluminium scrap, post-consumer, prepared fo...</td>\n",
+       "      <td>2027-01-01</td>\n",
+       "      <td>market for aluminium, wrought alloy</td>\n",
+       "      <td>0.001931</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2027-01-01</td>\n",
+       "      <td>epoxy resin production, liquid</td>\n",
+       "      <td>2027-01-01</td>\n",
+       "      <td>market for epoxy resin, liquid</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2027-01-01</td>\n",
+       "      <td>market for polyethylene, low density, granulate</td>\n",
+       "      <td>2027-01-01</td>\n",
+       "      <td>glider production, passenger car</td>\n",
+       "      <td>0.006416</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>779</th>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>market for waste glass</td>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>passenger car production, electric, without battery</td>\n",
+       "      <td>-0.036394</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>780</th>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>market for waste glass</td>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>passenger car production, electric, without battery</td>\n",
+       "      <td>-0.0</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>781</th>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>market for waste rubber, unspecified</td>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>passenger car production, electric, without battery</td>\n",
+       "      <td>-0.018279</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>782</th>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>market for powertrain, for electric passenger car</td>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>passenger car production, electric, without battery</td>\n",
+       "      <td>0.087365</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>783</th>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>process A</td>\n",
+       "      <td>2030-01-01</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>784 rows × 6 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    date_producer  \\\n",
+       "0      2027-01-01   \n",
+       "1      2027-01-01   \n",
+       "2      2027-01-01   \n",
+       "3      2027-01-01   \n",
+       "4      2027-01-01   \n",
+       "..            ...   \n",
+       "779    2030-01-01   \n",
+       "780    2030-01-01   \n",
+       "781    2030-01-01   \n",
+       "782    2030-01-01   \n",
+       "783    2030-01-01   \n",
+       "\n",
+       "                                                   producer_name  \\\n",
+       "0                market for polyethylene, low density, granulate   \n",
+       "1                                market for road vehicle factory   \n",
+       "2    treatment of aluminium scrap, post-consumer, prepared fo...   \n",
+       "3                                 epoxy resin production, liquid   \n",
+       "4                market for polyethylene, low density, granulate   \n",
+       "..                                                           ...   \n",
+       "779                                       market for waste glass   \n",
+       "780                                       market for waste glass   \n",
+       "781                         market for waste rubber, unspecified   \n",
+       "782            market for powertrain, for electric passenger car   \n",
+       "783                                                    process A   \n",
+       "\n",
+       "    date_consumer                                        consumer_name  \\\n",
+       "0      2027-01-01                     glider production, passenger car   \n",
+       "1      2027-01-01                     glider production, passenger car   \n",
+       "2      2027-01-01                  market for aluminium, wrought alloy   \n",
+       "3      2027-01-01                       market for epoxy resin, liquid   \n",
+       "4      2027-01-01                     glider production, passenger car   \n",
+       "..            ...                                                  ...   \n",
+       "779    2030-01-01  passenger car production, electric, without battery   \n",
+       "780    2030-01-01  passenger car production, electric, without battery   \n",
+       "781    2030-01-01  passenger car production, electric, without battery   \n",
+       "782    2030-01-01  passenger car production, electric, without battery   \n",
+       "783    2030-01-01                                                   -1   \n",
+       "\n",
+       "       amount temporal_market_shares  \n",
+       "0    0.003172                   None  \n",
+       "1         0.0                   None  \n",
+       "2    0.001931                   None  \n",
+       "3         1.0                   None  \n",
+       "4    0.006416                   None  \n",
+       "..        ...                    ...  \n",
+       "779 -0.036394                   None  \n",
+       "780      -0.0                   None  \n",
+       "781 -0.018279                   None  \n",
+       "782  0.087365                   None  \n",
+       "783       1.0                   None  \n",
+       "\n",
+       "[784 rows x 6 columns]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "timeline = tlca.build_timeline(\n",
+    "    starting_datetime=\"2030-01-01\",\n",
+    "    temporal_grouping=\"month\",\n",
+    "    graph_traversal=\"bfs\",\n",
+    "    traverse_background=True,\n",
+    "    max_calc=20,\n",
+    ")\n",
+    "import pandas as pd\n",
+    "pd.set_option(\"display.max_rows\", 200)\n",
+    "pd.set_option(\"display.max_colwidth\", 60)\n",
+    "timeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ea4032c",
+   "metadata": {},
+   "source": [
+    "### Double-check: did the background traversal actually reach `P2` and `P3`?\n",
+    "\n",
+    "If `traverse_background` works, the timeline must contain rows whose **producer** is the glider market\n",
+    "(`P2`) and the glider production (`P3`) — these live *inside the background* and would never appear with\n",
+    "the default static-background behavior.\n",
+    "\n",
+    "The proof is in the **`date_producer`** column: `P2` is pulled back by `TD₁` (−2/−1 years from the 2030\n",
+    "car) and `P3` is pulled back further by `TD₁ ⊗ TD₂` (the −12/−9/−6 month convolution on top). Each\n",
+    "time-shifted cohort is resolved to its temporally-appropriate background variant *directly* — these are\n",
+    "\"variant-resolved producers\", temporalized in place rather than re-interpolated as temporal markets,\n",
+    "so their `temporal_market_shares` is `None` (that is expected here, not a bug)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "58f3794e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:29:04.787715Z",
+     "iopub.status.busy": "2026-06-22T13:29:04.787633Z",
+     "iopub.status.idle": "2026-06-22T13:29:04.791595Z",
+     "shell.execute_reply": "2026-06-22T13:29:04.791210Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ">>> market for glider, passenger car: 4 timeline row(s)\n",
+      "date_producer date_consumer                                       consumer_name    amount\n",
+      "   2028-01-01    2030-01-01 passenger car production, electric, without battery  0.073011\n",
+      "   2028-01-01    2030-01-01 passenger car production, electric, without battery  0.292043\n",
+      "   2029-01-01    2030-01-01 passenger car production, electric, without battery  0.054758\n",
+      "   2029-01-01    2030-01-01 passenger car production, electric, without battery  0.492823\n",
+      "\n",
+      ">>> glider production, passenger car: 6 timeline row(s)\n",
+      "date_producer date_consumer                    consumer_name amount\n",
+      "   2027-01-01    2028-01-01 market for glider, passenger car    0.3\n",
+      "   2027-04-01    2028-01-01 market for glider, passenger car    0.4\n",
+      "   2027-07-01    2028-01-01 market for glider, passenger car    0.3\n",
+      "   2028-01-01    2029-01-01 market for glider, passenger car    0.3\n",
+      "   2028-04-01    2029-01-01 market for glider, passenger car    0.4\n",
+      "   2028-07-01    2029-01-01 market for glider, passenger car    0.3\n",
+      "\n",
+      "OK: background traversal reached both P2 and P3.\n"
+     ]
+    }
+   ],
+   "source": [
+    "producers_traversed = set(timeline[\"producer_name\"])\n",
+    "\n",
+    "for name in [\"market for glider, passenger car\", \"glider production, passenger car\"]:\n",
+    "    sub = timeline[timeline[\"producer_name\"] == name]\n",
+    "    assert len(sub) > 0, f\"MISSING from timeline: {name} (background descent failed!)\"\n",
+    "    print(f\">>> {name}: {len(sub)} timeline row(s)\")\n",
+    "    print(sub[[\"date_producer\", \"date_consumer\", \"consumer_name\", \"amount\"]].to_string(index=False))\n",
+    "    print()\n",
+    "\n",
+    "print(\"OK: background traversal reached both P2 and P3.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9576827",
+   "metadata": {},
+   "source": [
+    "### Step 5 — Compute the inventory and score (time-explicit, background-traversed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8b5b9151",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:29:04.792921Z",
+     "iopub.status.busy": "2026-06-22T13:29:04.792855Z",
+     "iopub.status.idle": "2026-06-22T13:29:11.175531Z",
+     "shell.execute_reply": "2026-06-22T13:29:11.174999Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:29:05.170\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m499\u001b[0m - \u001b[1mExpanding matrices...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:29:06.304\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mlci\u001b[0m:\u001b[36m518\u001b[0m - \u001b[1mCalculating dynamic inventory...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/timodiepers/Documents/Coding/bw_timex/.venv/lib/python3.13/site-packages/scikits/umfpack/umfpack.py:737: UmfpackWarning: (almost) singular matrix! (estimated cond. number: 1.65e+13)\n",
+      "  warnings.warn(msg, UmfpackWarning)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "traverse_background=True  static score: 1.0200287688160934\n"
+     ]
+    }
+   ],
+   "source": [
+    "tlca.lci()\n",
+    "tlca.static_lcia()\n",
+    "score_traversed = tlca.static_score\n",
+    "print(\"traverse_background=True  static score:\", score_traversed)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f42eedf3",
+   "metadata": {},
+   "source": [
+    "### Sanity comparison: same system **without** descending into the background\n",
+    "\n",
+    "With `traverse_background=False` the glider TDs are ignored and the background is a static snapshot, so\n",
+    "`P2`/`P3` never appear in the timeline. This is a **structural** check (glider chain present vs. absent).\n",
+    "\n",
+    "To keep it cheap we **reuse the same `TimexLCA` object** (so we don't pay for a second base LCA) and\n",
+    "only rebuild the *timeline* — no second inventory solve is needed to see that the glider chain is gone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "4db6ea36",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:29:11.176911Z",
+     "iopub.status.busy": "2026-06-22T13:29:11.176830Z",
+     "iopub.status.idle": "2026-06-22T13:29:16.993851Z",
+     "shell.execute_reply": "2026-06-22T13:29:16.993247Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:29:11.177\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m328\u001b[0m - \u001b[1mNo edge filter function provided. Skipping all edges in background databases.\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:29:16.801\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timex_lca\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m349\u001b[0m - \u001b[1mCreating activity time mapping...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:29:16.919\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m112\u001b[0m - \u001b[1mTraversing supply chain graph...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2026-06-22 15:29:16.930\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mbw_timex.timeline_builder\u001b[0m:\u001b[36mbuild_timeline\u001b[0m:\u001b[36m186\u001b[0m - \u001b[1mBuilding timeline...\u001b[0m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'market for glider, passenger car':\n",
+      "    traverse_background=True : True\n",
+      "    traverse_background=False: False\n",
+      "'glider production, passenger car':\n",
+      "    traverse_background=True : True\n",
+      "    traverse_background=False: False\n"
+     ]
+    }
+   ],
+   "source": [
+    "timeline_static_bg = tlca.build_timeline(\n",
+    "    starting_datetime=\"2030-01-01\",\n",
+    "    temporal_grouping=\"month\",\n",
+    "    graph_traversal=\"bfs\",\n",
+    "    traverse_background=False,\n",
+    "    max_calc=20,\n",
+    ")\n",
+    "producers_static = set(timeline_static_bg[\"producer_name\"])\n",
+    "\n",
+    "for name in [\"market for glider, passenger car\", \"glider production, passenger car\"]:\n",
+    "    print(f\"{name!r}:\")\n",
+    "    print(f\"    traverse_background=True : {name in producers_traversed}\")\n",
+    "    print(f\"    traverse_background=False: {name in producers_static}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "306dbbf4",
+   "metadata": {},
+   "source": [
+    "So the glider chain (`P2`, `P3`) is only present when we descend into the background — confirming the\n",
+    "`traverse_background=True` machinery works end-to-end on real premise data.\n",
+    "\n",
+    "> Note we deliberately do **not** compare the two *scores*: with `traverse_background=True` we capped the\n",
+    "> descent at `max_calc=20` for speed, so most of the car's background supply chain is left un-traversed\n",
+    "> and the absolute score is incomplete. For a real analysis you would raise `max_calc` until the score\n",
+    "> stabilizes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da7fae23",
+   "metadata": {},
+   "source": [
+    "## Cleanup (optional)\n",
+    "\n",
+    "Remove the temporal distributions we added to the background exchanges, restoring the premise\n",
+    "databases to their original state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "12cf1504",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T13:29:16.995369Z",
+     "iopub.status.busy": "2026-06-22T13:29:16.995269Z",
+     "iopub.status.idle": "2026-06-22T13:29:17.009856Z",
+     "shell.execute_reply": "2026-06-22T13:29:17.009432Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Removed background TDs.\n"
+     ]
+    }
+   ],
+   "source": [
+    "for e in (e1, e2):\n",
+    "    if \"temporal_distribution\" in e:\n",
+    "        del e[\"temporal_distribution\"]\n",
+    "        e.save()\n",
+    "print(\"Removed background TDs.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.11"
 dependencies = [
     "bw2calc>=2.4",
     "bw2data>=4.6",
-    "bw_graph_tools>=0.4",
+    "bw_graph_tools>=0.9",
     "numpy",
     "pandas",
     "tqdm",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
 from .fixtures.background_td_db_fixture import background_td_db
 from .fixtures.background_td_deep_db_fixture import background_td_deep_db
+from .fixtures.background_td_deep_chain_db_fixture import background_td_deep_chain_db
 from .fixtures.background_td_deep_tdvar_db_fixture import background_td_deep_tdvar_db
 from .fixtures.background_td_fg_and_bg_db_fixture import background_td_fg_and_bg_db
 from .fixtures.background_td_single_db_fixture import background_td_single_db
+from .fixtures.background_td_zero_exchange_db_fixture import (
+    background_td_zero_exchange_db,
+)
 from .fixtures.explicit_background_td_db_fixture import explicit_background_td_db
 from .fixtures.background_td_multdate_consumer_fixture import (
     background_td_multidate_consumer_db,

--- a/tests/fixtures/background_td_deep_chain_db_fixture.py
+++ b/tests/fixtures/background_td_deep_chain_db_fixture.py
@@ -1,0 +1,76 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+# Length of the linear background chain bg_0 -> bg_1 -> ... -> bg_{N-1}.
+CHAIN_LEN = 6
+
+
+@pytest.fixture
+@bw2test
+def background_td_deep_chain_db():
+    """fu -> bg_0 -> bg_1 -> ... -> bg_5 -> CO2, a long linear background chain
+    in two identical dated variants.
+
+    bg_0 -> bg_1 carries a TD so the variant-aware proxy descent is exercised.
+    Every link has amount 1, so with the default ``max_calc`` the descent walks
+    the whole chain. With a small ``max_calc`` the descent must stop early
+    (the documented ``max_calc`` bound applies to the background descent, not
+    only to the referenced-variant traversal), leaving the deepest nodes out of
+    the timeline.
+    """
+    biosphere = bd.Database("biosphere")
+    biosphere.write(
+        {("biosphere", "CO2"): {"type": "emission", "name": "carbon dioxide"}}
+    )
+    node_co2 = biosphere.get("CO2")
+
+    foreground = bd.Database("foreground")
+    foreground.register()
+    background_2020 = bd.Database("background_2020")
+    background_2020.register()
+    background_2030 = bd.Database("background_2030")
+    background_2030.register()
+
+    fu = foreground.new_node("fu", name="fu", unit="unit")
+    fu["reference product"] = "fu"
+    fu.save()
+    fu.new_edge(input=fu, amount=1, type="production").save()
+
+    td_0_to_1 = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+
+    variant_nodes = {}
+    for db, dbname in [
+        (background_2020, "background_2020"),
+        (background_2030, "background_2030"),
+    ]:
+        nodes = []
+        for i in range(CHAIN_LEN):
+            n = db.new_node(f"bg_{i}", name=f"bg_{i}", unit="kg")
+            n["reference product"] = f"bg_{i}"
+            n.save()
+            n.new_edge(input=n, amount=1, type="production").save()
+            nodes.append(n)
+
+        for i in range(CHAIN_LEN - 1):
+            edge = nodes[i].new_edge(input=nodes[i + 1], amount=1, type="technosphere")
+            if i == 0:
+                edge["temporal_distribution"] = td_0_to_1
+            edge.save()
+        # The deepest node emits CO2.
+        nodes[-1].new_edge(input=node_co2, amount=1, type="biosphere").save()
+        variant_nodes[dbname] = {f"bg_{i}": nodes[i] for i in range(CHAIN_LEN)}
+
+    fu.new_edge(
+        input=variant_nodes["background_2020"]["bg_0"], amount=1, type="technosphere"
+    ).save()
+
+    bd.Method(("GWP", "example")).write([(("biosphere", "CO2"), 1)])
+    for dbn in bd.databases:
+        bd.Database(dbn).process()
+    return variant_nodes

--- a/tests/fixtures/background_td_zero_exchange_db_fixture.py
+++ b/tests/fixtures/background_td_zero_exchange_db_fixture.py
@@ -1,0 +1,86 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
+
+
+@pytest.fixture
+@bw2test
+def background_td_zero_exchange_db():
+    """fu -> bg_A -> bg_B, two dated background variants, where bg_B carries a
+    ZERO-amount technosphere exchange to bg_C.
+
+    Real ecoinvent processes routinely contain technosphere exchanges with an
+    amount of exactly 0. When ``traverse_background=True`` descends into bg_B
+    (because bg_A -> bg_B carries a TD), the proxy descent reads bg_B's
+    exchanges directly, including the zero one. Convolving the incoming TD with
+    a zero edge produces an all-zero array, which ``temporal_convolution`` drops
+    entirely, raising ``ValueError("Empty array")``. The descent must skip
+    zero-amount exchanges instead (they contribute nothing to the inventory).
+
+    Both variants are identical, so the time-spreading from the TD must not
+    change the total mass: the static score equals that of a static background.
+    bg_B emits 1 kg CO2; bg_C would emit 1 kg too but is reached through the
+    zero edge, so it contributes nothing.
+    """
+    biosphere = bd.Database("biosphere")
+    biosphere.write(
+        {("biosphere", "CO2"): {"type": "emission", "name": "carbon dioxide"}}
+    )
+    node_co2 = biosphere.get("CO2")
+
+    foreground = bd.Database("foreground")
+    foreground.register()
+    background_2020 = bd.Database("background_2020")
+    background_2020.register()
+    background_2030 = bd.Database("background_2030")
+    background_2030.register()
+
+    fu = foreground.new_node("fu", name="fu", unit="unit")
+    fu["reference product"] = "fu"
+    fu.save()
+    fu.new_edge(input=fu, amount=1, type="production").save()
+
+    td_a_to_b = TemporalDistribution(
+        date=np.array([0, 10], dtype="timedelta64[Y]"),
+        amount=np.array([0.6, 0.4]),
+    )
+
+    variant_nodes = {}
+    for db, dbname in [
+        (background_2020, "background_2020"),
+        (background_2030, "background_2030"),
+    ]:
+        bg_a = db.new_node("bg_A", name="bg_A", unit="kWh")
+        bg_a["reference product"] = "bg_A"
+        bg_a.save()
+        bg_b = db.new_node("bg_B", name="bg_B", unit="kg")
+        bg_b["reference product"] = "bg_B"
+        bg_b.save()
+        bg_c = db.new_node("bg_C", name="bg_C", unit="kg")
+        bg_c["reference product"] = "bg_C"
+        bg_c.save()
+
+        bg_a.new_edge(input=bg_a, amount=1, type="production").save()
+        bg_b.new_edge(input=bg_b, amount=1, type="production").save()
+        bg_c.new_edge(input=bg_c, amount=1, type="production").save()
+
+        a_to_b = bg_a.new_edge(input=bg_b, amount=5, type="technosphere")
+        a_to_b["temporal_distribution"] = td_a_to_b
+        a_to_b.save()
+
+        # The zero-amount technosphere exchange that triggers the crash.
+        bg_b.new_edge(input=bg_c, amount=0, type="technosphere").save()
+        bg_b.new_edge(input=node_co2, amount=1, type="biosphere").save()
+        bg_c.new_edge(input=node_co2, amount=1, type="biosphere").save()
+        variant_nodes[dbname] = {"bg_A": bg_a, "bg_B": bg_b, "bg_C": bg_c}
+
+    fu.new_edge(
+        input=variant_nodes["background_2020"]["bg_A"], amount=2, type="technosphere"
+    ).save()
+
+    bd.Method(("GWP", "example")).write([(("biosphere", "CO2"), 1)])
+    for dbn in bd.databases:
+        bd.Database(dbn).process()
+    return variant_nodes

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -341,3 +341,57 @@ def test_single_background_db_with_td_matches_static(
     assert sorted({d.year for d in fuel["date_producer"]}) == [2024, 2034]
     # ...but with one background db the score equals the static LCA exactly.
     assert tlca.static_score == pytest.approx(slca.score, rel=1e-9)
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_zero_amount_exchange_in_descended_background(
+    background_td_zero_exchange_db, graph_traversal
+):
+    """Descending into a background process that has a zero-amount technosphere
+    exchange (ubiquitous in real ecoinvent) must not crash.
+
+    Convolving the incoming TD with a zero edge yields an all-zero array, which
+    ``temporal_convolution`` drops, previously raising
+    ``ValueError("Empty array")``. The descent must skip zero-amount exchanges;
+    they contribute nothing, so the static score is unaffected (here: 2 fu *
+    5 bg_B * 1 kg CO2 = 10 kg)."""
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal=graph_traversal,
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    assert tlca.static_score == pytest.approx(10.0, rel=1e-9)
+    # The zero edge means bg_C never enters the inventory.
+    assert "bg_C" not in set(tlca.timeline["producer_name"])
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_max_calc_bounds_background_descent(
+    background_td_deep_chain_db, graph_traversal
+):
+    """max_calc must bound the background proxy descent, not only the
+    referenced-variant traversal (as the build_timeline docstring promises).
+
+    With a generous max_calc the full chain bg_0..bg_5 is descended; with a tiny
+    max_calc the descent stops early, so the deepest node never reaches the
+    timeline (and the build does not run away)."""
+
+    def producers(max_calc):
+        t = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+        t.build_timeline(
+            starting_datetime="2024-01-01",
+            graph_traversal=graph_traversal,
+            traverse_background=True,
+            max_calc=max_calc,
+        )
+        return set(t.timeline["producer_name"])
+
+    full = producers(10_000)
+    assert {"bg_0", "bg_5"} <= full  # whole chain descended
+
+    bounded = producers(3)
+    assert "bg_5" not in bounded  # deepest node cut off by the budget
+    assert len(bounded) < len(full)

--- a/tests/test_lci_cache.py
+++ b/tests/test_lci_cache.py
@@ -9,6 +9,7 @@ from bw_timex._lci_cache import (
     BACKGROUND_UNIT_LCI_CACHE,
     BIOSPHERE_EXCHANGES_CACHE,
     LCI_SOLVE_CACHE,
+    NODES_CACHE,
 )
 
 
@@ -220,6 +221,53 @@ class TestModuleLevelLCICache:
         tlca_warm = _build_tlca()
         tlca_warm.static_lcia()
         assert tlca_warm.static_score == pytest.approx(cold_score)
+
+    @staticmethod
+    def _nodes_keys(db="db_2020"):
+        modified = bd.databases[db].get("modified")
+        project = bd.projects.current
+        return [
+            k
+            for k in NODES_CACHE
+            if k[0] == "nodes"
+            and k[1] == project
+            and k[2] == db
+            and k[3] == modified
+        ]
+
+    def test_nodes_cache_populated_per_database(self):
+        tlca = _build_tlca()
+        # One entry per database in database_dates (db_2020 + foreground).
+        assert self._nodes_keys("db_2020")
+        assert self._nodes_keys("foreground")
+        # Cached node proxies are exactly what the object exposes.
+        cached = {}
+        for k in NODES_CACHE:
+            cached.update(NODES_CACHE[k])
+        assert set(cached) == set(tlca.nodes)
+
+    def test_nodes_cache_reused_across_objects(self):
+        tlca1 = _build_tlca()
+        key = self._nodes_keys("db_2020")[0]
+        cached_db = NODES_CACHE[key]
+
+        tlca2 = _build_tlca()
+        # Same per-db dict object reused, not re-queried.
+        assert self._nodes_keys("db_2020") == [key]
+        assert NODES_CACHE[key] is cached_db
+        # Proxies are shared across objects.
+        node_id = next(iter(cached_db))
+        assert tlca1.nodes[node_id] is tlca2.nodes[node_id]
+
+    def test_nodes_cache_opt_out_does_not_use_global(self):
+        _build_tlca(use_global_lci_cache=False)
+        assert len(NODES_CACHE) == 0
+
+    def test_clear_background_lci_cache_clears_nodes_too(self):
+        _build_tlca()
+        assert len(NODES_CACHE) > 0
+        bw_timex.clear_background_lci_cache()
+        assert len(NODES_CACHE) == 0
 
     def test_opt_out_produces_same_score_as_global(self):
         tlca_global = _build_tlca()

--- a/uv.lock
+++ b/uv.lock
@@ -129,7 +129,7 @@ wheels = [
 
 [[package]]
 name = "bw-graph-tools"
-version = "0.6"
+version = "0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bw-processing" },
@@ -140,9 +140,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/4d/2ec231e2e1df7ff6603f2801a18df71499fc8cf8512da029308a292adc25/bw_graph_tools-0.6.tar.gz", hash = "sha256:15ca2c056ba00499a8f4319b740499fae91b519dea5e776067d95a313817acf1", size = 27498, upload-time = "2025-06-26T03:17:04.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/58/1e53c178a2779295c0094006db9b6ec23fb78266eb900d4845d69cebbfb0/bw_graph_tools-0.9.tar.gz", hash = "sha256:881fa4504b45880e4be782ba1a64678cfe9dbcd0841c3f71f41d285de53dc984", size = 36684, upload-time = "2026-06-18T08:45:51.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/b0/3fcac887970463c0662538c0157afcc03833cd729c63d1b5391a5b70f226/bw_graph_tools-0.6-py3-none-any.whl", hash = "sha256:1487603150b327a812a4a5936ae437f44c20a336fa84f77e59de1ed3dd0b6de2", size = 29368, upload-time = "2025-06-26T03:17:03.382Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9e/d3656424524ebd300ce38c32af70a42238f65e055f1aa9e62933ed60bf48/bw_graph_tools-0.9-py3-none-any.whl", hash = "sha256:e60d21c53671cb2d0700a7fb7134e42acc9eb4763a8ce847e2ebab78c5d46428", size = 32716, upload-time = "2026-06-18T08:45:50.068Z" },
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bw-graph-tools", specifier = ">=0.4" },
+    { name = "bw-graph-tools", specifier = ">=0.9" },
     { name = "bw-temporalis", specifier = ">=1.1" },
     { name = "bw2calc", specifier = ">=2.4" },
     { name = "bw2data", specifier = ">=4.6" },


### PR DESCRIPTION
Release 1.1.1.

* Added module-level caching of database node proxies so repeated `TimexLCA` objects in a session reuse them instead of re-querying
* Fixed `traverse_background` crashing on zero-amount background exchanges
* Fixed `max_calc` not bounding the background traversal