### PR TITLE
Fix supply scaling and solve planning when building the LCI from the timeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Fixed supply scaling in `lci(expand_technosphere=False)` for processes with a production amount other than 1, whose supplies were mis-scaled and, for negative production amounts (waste treatment), sign-flipped
+* Fixed `temporal_market_lcis` being corrupted when several timeline rows share a time-mapped temporal market
+* Added the pending-solve planning and technosphere factorization to `lci(expand_technosphere=False)`, which previously only ran for the expanded path
 
 ## [1.1.2]
 * Fixed the option to calculate the lci from the timeline. This option is called with lci(expand_technosphere=False) which speeds up the calculation significantly for for large systems, but does not allow for detailed contribution analysis of background processes. https://github.com/brightway-lca/bw_timex/commit/12853dbd799764f6d2d2fa2335d6f6f19a97abed

--- a/bw_timex/dynamic_biosphere_builder.py
+++ b/bw_timex/dynamic_biosphere_builder.py
@@ -6,7 +6,11 @@ from bw_temporalis import TemporalDistribution
 from scipy import sparse as sp
 
 from .helper_classes import SetList
-from .utils import convert_date_string_to_datetime, get_temporal_evolution_factor
+from .utils import (
+    convert_date_string_to_datetime,
+    get_reference_product_production_amount,
+    get_temporal_evolution_factor,
+)
 
 
 class DynamicBiosphereBuilder:
@@ -99,9 +103,9 @@ class DynamicBiosphereBuilder:
             # `Edge.cumulative_amount_producer` / `_join_cumulative_amount`) and
             # is the correct quantity to scale each timeline row's biosphere/
             # market contribution by.
-            self.dynamic_supply_array = timeline.cumulative_amount.values.astype(
-                float
-            )  # get the (cumulative) supply vector directly from the timeline
+            self.dynamic_supply_array = self._supply_array_from_timeline(
+                timeline, node_collections
+            )
 
         self.activity_time_mapping = activity_time_mapping
         self.biosphere_time_mapping = biosphere_time_mapping
@@ -134,6 +138,35 @@ class DynamicBiosphereBuilder:
         # within one build_dynamic_biosphere_matrix run.
         self._rebuilt_unit_lci_cache = {}
         self.temporal_market_cols = []  # To keep track of temporal market columns
+
+    @staticmethod
+    def _supply_array_from_timeline(
+        timeline: pd.DataFrame, node_collections: dict
+    ) -> np.ndarray:
+        """Per-timeline-row supply, used instead of a solved supply array when
+        the dynamic inventory is built directly from the timeline.
+
+        `timeline.cumulative_amount` is the supply-chain-scaled amount of the
+        producer's PRODUCT (the local, per-consumer `timeline.amount` scaled by
+        all upstream edges). That is what the temporal markets need, since their
+        background unit LCIs are also per unit of product. A temporalized
+        process, however, is scaled by its own production amount when its
+        biosphere exchanges are read (those are per production amount, not per
+        unit of product), which the expanded technosphere gets for free from the
+        solve. So convert those rows to process units here.
+        """
+        supply = timeline.cumulative_amount.values.astype(float)
+        temporalized = node_collections["temporalized_processes"]
+        production_amounts = {}
+        for position, row in enumerate(timeline.itertuples()):
+            if row.time_mapped_producer not in temporalized:
+                continue
+            if row.producer not in production_amounts:
+                production_amounts[row.producer] = (
+                    get_reference_product_production_amount(row.producer)
+                )
+            supply[position] /= production_amounts[row.producer]
+        return supply
 
     def build_dynamic_biosphere_matrix(
         self,
@@ -257,6 +290,11 @@ class DynamicBiosphereBuilder:
                         )
 
             elif idx in self.node_collections["temporal_markets"]:
+                if expand_technosphere and idx in temporal_market_lcis:
+                    # Several timeline rows (one per consumer) can share a
+                    # time-mapped market, but with expanded matrices they all
+                    # map to the same column, whose supply already sums them up.
+                    continue
                 self.temporal_market_cols.append(process_col_index)
                 (
                     (original_db, original_code),
@@ -269,20 +307,30 @@ class DynamicBiosphereBuilder:
                     demand = self.demand_from_timeline(row)
 
                 if demand:
+                    # lci of all background activities of the temporal market,
+                    # per unit of market output. Built per timeline row: the
+                    # same time-mapped market can occur in several rows (one per
+                    # consumer), and when building from the timeline each of
+                    # those rows is its own column with its own supply.
+                    unit_lci_total = None
                     for act, amount in demand.items():
-                        unit_lci = self.get_background_unit_lci(act)
-                        # add lci of both background activities of the temporal market and save total lci
-                        if idx not in temporal_market_lcis.keys():
-                            temporal_market_lcis[idx] = unit_lci * amount
-                        else:
-                            temporal_market_lcis[idx] += unit_lci * amount
+                        unit_lci = self.get_background_unit_lci(act) * amount
+                        unit_lci_total = (
+                            unit_lci
+                            if unit_lci_total is None
+                            else unit_lci_total + unit_lci
+                        )
 
-                    aggregated_inventory = temporal_market_lcis[idx].sum(axis=1)
+                    aggregated_inventory = unit_lci_total.sum(axis=1)
 
                     # multiply LCI with supply of temporal market
-                    temporal_market_lcis[idx] *= self.dynamic_supply_array[
-                        process_col_index
-                    ]
+                    scaled_lci = (
+                        unit_lci_total * self.dynamic_supply_array[process_col_index]
+                    )
+                    if idx not in temporal_market_lcis:
+                        temporal_market_lcis[idx] = scaled_lci
+                    else:
+                        temporal_market_lcis[idx] += scaled_lci
 
                     for row_idx, amount in enumerate(aggregated_inventory.A1):
                         bioflow = self.lca_obj.dicts.biosphere.reversed[row_idx]
@@ -544,20 +592,17 @@ class DynamicBiosphereBuilder:
         technosphere upfront is worth it; factorization only pays off once
         the number of pending solves exceeds the break-even point.
         """
-        if not self._expand_technosphere:
-            # Non-expand path: demands come from the timeline rows and we
-            # cannot cheaply enumerate without effectively running the build.
-            # Be conservative and report unknown-many so callers can fall
-            # back to the default factorize policy if they care.
-            return len(self.node_collections.get("temporal_markets", ()))
-
         pending_keys = set()
         for row in self.timeline.itertuples():
             idx = row.time_mapped_producer
             if idx not in self.node_collections["temporal_markets"]:
                 continue
-            process_col_index = self.activity_dict[idx]
-            demand = self.demand_from_technosphere(idx, process_col_index)
+            if self._expand_technosphere:
+                demand = self.demand_from_technosphere(idx, self.activity_dict[idx])
+            else:
+                # Timeline path: the demands come from the row's temporal
+                # market shares, which is a plain mapping lookup — no solve.
+                demand = self.demand_from_timeline(row)
             if not demand:
                 continue
             for act in demand:

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -523,7 +523,10 @@ class VariantBackgroundMixin:
                     td_producer, cur_abs_td
                 )
                 abs_cumulative_producer = _join_cumulative_amount(
-                    td_producer, cur_abs_td, cur_abs_cumulative.amount
+                    td_producer,
+                    cur_abs_td,
+                    cur_abs_cumulative.amount,
+                    scaling=_cumulative_hop_scaling(production_amount),
                 )
 
                 if isinstance(td_producer_raw, TemporalDistribution):
@@ -733,11 +736,25 @@ class EdgeExtractor(VariantBackgroundMixin, TemporalisLCA):
                 )
                 abs_td_consumer = self.t0
 
-            # At the FU seed there is no ancestor to scale by (the functional
-            # unit's own cumulative throughput is 1 by definition, self.t0.amount
-            # == [1]), so the cumulative amount is numerically identical to the
-            # local `abs_td_producer` computed above.
-            cumulative_amount_producer = abs_td_producer
+            # At the FU seed there is no ancestor to scale by, but the cumulative
+            # amount is the demanded amount of the product, which
+            # `abs_td_producer` only carries in the explicit process/product
+            # branch above (where it also picked up the sign of the production
+            # edge, which is divided out again here).
+            if row_id != col_id:
+                fu_production_amount = get_reference_product_production_amount(
+                    col_id, reference_product=row_id, lca=self.lca_object
+                )
+                cumulative_amount_producer = TemporalDistribution(
+                    date=abs_td_producer.date,
+                    amount=abs_td_producer.amount
+                    * _cumulative_hop_scaling(fu_production_amount),
+                )
+            else:
+                cumulative_amount_producer = TemporalDistribution(
+                    date=abs_td_producer.date,
+                    amount=abs_td_producer.amount * edge.amount,
+                )
 
             heappush(
                 heap,
@@ -794,6 +811,9 @@ class EdgeExtractor(VariantBackgroundMixin, TemporalisLCA):
                     "temporal_evolution_reference", "producer"
                 )
 
+                consumer_production_amount = get_reference_product_production_amount(
+                    node.activity_datapackage_id, lca=self.lca_object
+                )
                 td_producer = (  # td_producer is the TemporalDistribution of the edge
                     self._exchange_value(
                         exchange=exchange,
@@ -801,14 +821,13 @@ class EdgeExtractor(VariantBackgroundMixin, TemporalisLCA):
                         col_id=col_id,
                         matrix_label="technosphere_matrix",
                     )
-                    / abs(
-                        get_reference_product_production_amount(
-                            node.activity_datapackage_id, lca=self.lca_object
-                        )
-                    )
+                    / abs(consumer_production_amount)
                 )
                 producer = self.nodes[edge.producer_unique_id]
                 leaf = self.edge_ff(row_id)
+                # Only set in the explicit process/product branch below, where
+                # `td_producer` picks up the sign of the production edge.
+                producer_production_amount = None
 
                 # If an edge does not have a TD, give it a td with timedelta=0 and the amount= 'edge value'
                 if isinstance(td_producer, Number):
@@ -848,6 +867,13 @@ class EdgeExtractor(VariantBackgroundMixin, TemporalisLCA):
                                 amount=np.array([production_td]),
                             )
                         td_producer = (td_producer * production_td).simplify()
+                        producer_production_amount = (
+                            get_reference_product_production_amount(
+                                row_id,
+                                reference_product=product_id,
+                                lca=self.lca_object,
+                            )
+                        )
 
                 distribution = (
                     td * td_producer
@@ -857,7 +883,12 @@ class EdgeExtractor(VariantBackgroundMixin, TemporalisLCA):
                     td_producer, abs_td
                 )
                 cumulative_amount_producer = _join_cumulative_amount(
-                    td_producer, abs_td, cumulative_amount_parent.amount
+                    td_producer,
+                    abs_td,
+                    cumulative_amount_parent.amount,
+                    scaling=_cumulative_hop_scaling(
+                        consumer_production_amount, producer_production_amount
+                    ),
                 )
 
                 # Variant-aware split at the FIRST crossing from the referenced
@@ -1227,9 +1258,12 @@ class EdgeExtractorBFS(VariantBackgroundMixin):
             # no such TD, so the original behaviour is preserved exactly.
             production_td = self._get_normalized_production_edge_td(fu_id)
             if production_td is None:
-                # No ancestor to scale by at the FU seed (the functional unit's
-                # own cumulative throughput is 1 by definition), so the
-                # cumulative amount is numerically identical to `abs_td_producer`.
+                # No ancestor to scale by at the FU seed, so the cumulative
+                # amount is just the demanded amount (`abs_td_producer` is
+                # normalized to 1 and carries the timing only).
+                fu_cumulative = TemporalDistribution(
+                    date=self.t0.date, amount=self.t0.amount * fu_amount
+                )
                 timeline.append(
                     Edge(
                         edge_type="production",
@@ -1240,16 +1274,28 @@ class EdgeExtractorBFS(VariantBackgroundMixin):
                         td_producer=fu_amount,
                         td_consumer=self.t0,
                         abs_td_producer=self.t0,
-                        cumulative_amount_producer=self.t0,
+                        cumulative_amount_producer=fu_cumulative,
                     )
                 )
-                queue.append((fu_id, td, self.t0, self.t0, self.t0, abs(fu_amount)))
+                queue.append(
+                    (fu_id, td, self.t0, self.t0, fu_cumulative, abs(fu_amount))
+                )
             else:
                 # Cohort-spread the FU so the producing process is registered at
                 # every cohort time (each cohort gets its own time-mapped column).
                 seed_td = (td * production_td).simplify()
                 seed_abs_td = _join_datetime_and_timedelta_distributions(
                     production_td, self.t0
+                )
+                # Cumulative amounts are in units of the produced product, so
+                # the 1/alpha that `production_td` carries is taken back out
+                # (the builder re-applies it, signed, per process) and the
+                # demanded amount is applied instead.
+                fu_cumulative = TemporalDistribution(
+                    date=seed_abs_td.date,
+                    amount=seed_abs_td.amount
+                    * abs(self._get_production_amount(fu_id))
+                    * fu_amount,
                 )
                 timeline.append(
                     Edge(
@@ -1262,11 +1308,11 @@ class EdgeExtractorBFS(VariantBackgroundMixin):
                         td_consumer=self.t0,
                         abs_td_producer=seed_abs_td,
                         abs_td_consumer=self.t0,
-                        cumulative_amount_producer=seed_abs_td,
+                        cumulative_amount_producer=fu_cumulative,
                     )
                 )
                 queue.append(
-                    (fu_id, seed_td, self.t0, seed_abs_td, seed_abs_td, abs(fu_amount))
+                    (fu_id, seed_td, self.t0, seed_abs_td, fu_cumulative, abs(fu_amount))
                 )
 
         while queue:
@@ -1306,7 +1352,10 @@ class EdgeExtractorBFS(VariantBackgroundMixin):
                     td_producer, abs_td
                 )
                 abs_cumulative_producer = _join_cumulative_amount(
-                    td_producer, abs_td, cumulative_amount_parent.amount
+                    td_producer,
+                    abs_td,
+                    cumulative_amount_parent.amount,
+                    scaling=_cumulative_hop_scaling(production_amount),
                 )
 
                 if isinstance(td_producer_raw, TemporalDistribution):
@@ -1472,10 +1521,51 @@ def _join_datetime_and_timedelta_distributions(
         )
 
 
+def _cumulative_hop_scaling(
+    consumer_production_amount: float,
+    producer_production_amount: float | None = None,
+) -> float:
+    """Correction factor turning a local edge coefficient into a supply factor.
+
+    ``td_producer`` normalizes an edge by the *consumer's absolute* production
+    amount, which is what the matrix modifier expects (it multiplies that
+    normalization back out when it builds the expanded technosphere). A linear
+    solve instead divides by the *signed* production amount:
+    ``supply_consumer = cumulative_consumer / production_amount_consumer``.
+
+    Dropping that sign is harmless for the timeline's local ``amount`` column,
+    but not for ``cumulative_amount``, which is used as the supply array when
+    the dynamic inventory is built straight from the timeline
+    (``expand_technosphere=False``). A process with a negative production amount
+    (the usual waste-treatment convention) would otherwise flip the sign of its
+    whole upstream subtree.
+
+    Parameters
+    ----------
+    consumer_production_amount : float
+        Production amount of the consuming process, as used to normalize
+        ``td_producer``.
+    producer_production_amount : float, optional
+        Only for explicit process/product setups, where ``td_producer`` picked
+        up the sign of the producer's off-diagonal production edge. Cumulative
+        amounts are in units of the produced product, so that sign is divided
+        out again.
+
+    Returns
+    -------
+    float
+    """
+    scaling = abs(consumer_production_amount) / consumer_production_amount
+    if producer_production_amount is not None:
+        scaling *= abs(producer_production_amount) / producer_production_amount
+    return scaling
+
+
 def _join_cumulative_amount(
     td_producer: TemporalDistribution,
     td_consumer: TemporalDistribution,
     cumulative_amount_consumer: np.ndarray,
+    scaling: float = 1.0,
 ) -> TemporalDistribution:
     """
     Companion to ``_join_datetime_and_timedelta_distributions``, used to build
@@ -1509,6 +1599,8 @@ def _join_cumulative_amount(
         dates (i.e. the consumer edge's own ``cumulative_amount_producer.amount``,
         or an array of 1s at the root, where the functional unit's cumulative
         scale is 1 by definition).
+    scaling : float
+        Factor applied to all resulting amounts, see `_cumulative_hop_scaling`.
 
     Returns
     -------
@@ -1523,7 +1615,7 @@ def _join_cumulative_amount(
     ):
         return TemporalDistribution(
             date=td_consumer.date,
-            amount=cumulative_amount_consumer * float(td_producer),
+            amount=cumulative_amount_consumer * float(td_producer) * scaling,
         )
 
     if isinstance(td_producer, TemporalDistribution) and isinstance(
@@ -1550,7 +1642,7 @@ def _join_cumulative_amount(
         amount = (
             cumulative_amount_consumer.reshape((-1, 1))
             * td_producer.amount.reshape((1, -1))
-        ).ravel()
+        ).ravel() * scaling
         return TemporalDistribution(date, amount)
     else:
         raise ValueError(

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -595,6 +595,33 @@ class TimexLCA:
                     self.lca.redo_lci(self.fu)
                     self._lci_did_reset = True
             else:
+                # Same planning as above, minus the functional-unit solve: the
+                # supply comes from the timeline, so only the background
+                # unit-LCI solves during the build matter here.
+                self.lca.load_lci_data()
+                shadow = DynamicBiosphereBuilder(
+                    self.lca,
+                    self.activity_time_mapping,
+                    TimeMappingDict(start_id=0),
+                    self.demand_timing,
+                    self.node_collections,
+                    self.temporal_grouping,
+                    self.database_dates,
+                    self.database_dates_static,
+                    self.timeline,
+                    self.interdatabase_activity_mapping,
+                    expand_technosphere=False,
+                    background_unit_lci_cache=self._background_unit_lci_cache,
+                )
+                pending = shadow.count_pending_background_solves()
+                self._lci_pending_solves = pending
+
+                if pending >= FACTORIZE_SOLVES_THRESHOLD:
+                    # Many `redo_lci`s coming; pay the LU factorization once.
+                    # No solve needed, just the factorized technosphere.
+                    self.lca.decompose_technosphere()
+                    self._lci_did_factorize = True
+
                 self.calculate_dynamic_inventory(expand_technosphere=False)
 
     def disaggregate_background_lci(self) -> None:

--- a/tests/test_background_traversal.py
+++ b/tests/test_background_traversal.py
@@ -428,3 +428,28 @@ def test_max_calc_bounds_background_descent(
     bounded = producers(3)
     assert "bg_5" not in bounded  # deepest node cut off by the budget
     assert len(bounded) < len(full)
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_background_td_explicit_product_paradigm_from_timeline(
+    explicit_background_td_db, graph_traversal
+):
+    """Same hand-computed 56.4 kg CO2 as
+    `test_background_td_with_explicit_product_paradigm`, but with the dynamic
+    inventory built directly from the timeline instead of expanded matrices.
+    """
+    product = bd.get_node(database="foreground", code="service_product")
+
+    tlca = TimexLCA(
+        demand={product.key: 1},
+        method=METHOD,
+        database_dates=explicit_background_td_db,
+    )
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal=graph_traversal,
+        traverse_background=True,
+    )
+    tlca.lci(expand_technosphere=False)
+
+    assert tlca.dynamic_inventory.sum() == pytest.approx(56.4, rel=1e-9)

--- a/tests/test_electric_vehicle_explicit.py
+++ b/tests/test_electric_vehicle_explicit.py
@@ -128,3 +128,34 @@ class TestClass_EV_Explicit:
         )
 
         assert self.tlca.static_score == pytest.approx(expected_timex_score, abs=0.5)
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_from_timeline_matches_expanded(vehicle_explicit_db, graph_traversal):
+    """The dynamic inventory built directly from the timeline must match the one
+    built via expanded matrices, also in the explicit process/product paradigm
+    (where the timeline's producers are products, not chimaera nodes).
+    """
+    ev_product = bd.get_node(database="foreground", code="EV_product")
+    database_dates = {
+        "db_2020": datetime.strptime("2020", "%Y"),
+        "db_2030": datetime.strptime("2030", "%Y"),
+        "db_2040": datetime.strptime("2040", "%Y"),
+        "foreground": "dynamic",
+    }
+
+    inventories = {}
+    for expand_technosphere in (True, False):
+        tlca = TimexLCA(
+            demand={ev_product.key: 1},
+            method=("GWP", "example"),
+            database_dates=database_dates,
+        )
+        tlca.build_timeline(
+            starting_datetime=datetime.strptime("2024-01-02", "%Y-%m-%d"),
+            graph_traversal=graph_traversal,
+        )
+        tlca.lci(expand_technosphere=expand_technosphere)
+        inventories[expand_technosphere] = tlca.dynamic_inventory.sum()
+
+    assert inventories[False] == pytest.approx(inventories[True])

--- a/tests/test_explicit_process_product_end_to_end.py
+++ b/tests/test_explicit_process_product_end_to_end.py
@@ -500,17 +500,8 @@ def test_multi_vintage_demand_splits_across_cohorts():
     assert tlca.static_score == pytest.approx(0.5 * 0.40 + 0.5 * 0.10)
 
 
-def test_explicit_output_coefficient_alpha_scales_inputs():
-    """Production output coefficient alpha != 1 must scale the supply chain by 1/alpha.
-
-    A process produces *2* units of its product per invocation and consumes 4
-    units of background input. Demanding 1 unit of the product therefore runs
-    the process at scale 1/2, so the input is consumed at 0.5 * 4 = 2.0 and the
-    score is 2.0 (background = 1 kg CO2 per input unit, GWP = 1).
-
-    Every existing explicit fixture uses production amount = 1, so the 1/alpha
-    division is otherwise never exercised: a bug there would be invisible.
-    """
+def _write_explicit_alpha_db():
+    """Explicit process/product setup with a production output coefficient of 2."""
     bd.projects.set_current("__test_explicit_alpha_scaling__")
     bd.databases.clear()
     bd.methods.clear()
@@ -572,6 +563,20 @@ def test_explicit_output_coefficient_alpha_scales_inputs():
     for db in bd.databases:
         bd.Database(db).process()
 
+
+def test_explicit_output_coefficient_alpha_scales_inputs():
+    """Production output coefficient alpha != 1 must scale the supply chain by 1/alpha.
+
+    A process produces *2* units of its product per invocation and consumes 4
+    units of background input. Demanding 1 unit of the product therefore runs
+    the process at scale 1/2, so the input is consumed at 0.5 * 4 = 2.0 and the
+    score is 2.0 (background = 1 kg CO2 per input unit, GWP = 1).
+
+    Every existing explicit fixture uses production amount = 1, so the 1/alpha
+    division is otherwise never exercised: a bug there would be invisible.
+    """
+    _write_explicit_alpha_db()
+
     product = bd.get_node(database="foreground", code="product")
     method = ("GWP", "example")
     demand = {product.key: 1}
@@ -602,6 +607,30 @@ def test_explicit_output_coefficient_alpha_scales_inputs():
         for row in input_rows.itertuples()
     )
     assert observed == pytest.approx([(2030, 2030, 2.0), (2031, 2031, 2.0)])
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_explicit_output_coefficient_alpha_from_timeline(graph_traversal):
+    """Same alpha != 1 setup, but with the dynamic inventory built directly from
+    the timeline. `cumulative_amount` is in units of the produced product, so
+    the 1/alpha scaling has to be applied exactly once, when the process's own
+    biosphere exchanges are read - not zero times and not twice.
+    """
+    _write_explicit_alpha_db()
+
+    product = bd.get_node(database="foreground", code="product")
+    demand = {product.key: 1}
+    method = ("GWP", "example")
+    database_dates = {"background": datetime(2030, 1, 1), "foreground": "dynamic"}
+
+    tlca = TimexLCA(demand=demand, method=method, database_dates=database_dates)
+    tlca.build_timeline(
+        starting_datetime=datetime(2030, 1, 1), graph_traversal=graph_traversal
+    )
+    tlca.lci(expand_technosphere=False)
+
+    # 1 unit of product = 0.5 process invocations = 2 units of input = 2 kg CO2
+    assert tlca.dynamic_inventory.sum() == pytest.approx(2.0)
 
 
 def _write_explicit_two_background_cohort_db():

--- a/tests/test_lci_cache.py
+++ b/tests/test_lci_cache.py
@@ -13,7 +13,7 @@ from bw_timex._lci_cache import (
 )
 
 
-def _build_tlca(**kwargs):
+def _build_tlca(expand_technosphere=True, **kwargs):
     node_a = bd.get_node(database="foreground", code="A")
     database_dates = {
         "db_2020": datetime.strptime("2020", "%Y"),
@@ -26,7 +26,9 @@ def _build_tlca(**kwargs):
         **kwargs,
     )
     tlca.build_timeline(starting_datetime=datetime.strptime("2024-01-02", "%Y-%m-%d"))
-    tlca.lci(expand_technosphere=True, build_dynamic_biosphere=True)
+    tlca.lci(
+        expand_technosphere=expand_technosphere, build_dynamic_biosphere=True
+    )
     return tlca
 
 
@@ -192,6 +194,46 @@ class TestModuleLevelLCICache:
         assert len(BIOSPHERE_EXCHANGES_CACHE) > 0
         bw_timex.clear_background_lci_cache()
         assert len(BIOSPHERE_EXCHANGES_CACHE) == 0
+
+    def test_from_timeline_counts_pending_background_solves(self):
+        # Building from the timeline needs the same background unit LCIs as the
+        # expanded path, so it has to plan its solves the same way.
+        tlca = _build_tlca(expand_technosphere=False)
+        assert tlca._lci_pending_solves > 0
+        tlca_warm = _build_tlca(expand_technosphere=False)
+        assert tlca_warm._lci_pending_solves == 0
+
+    def test_from_timeline_factorizes_when_above_threshold(self, monkeypatch):
+        import bw_timex.timex_lca as tlca_mod
+
+        monkeypatch.setattr(tlca_mod, "FACTORIZE_SOLVES_THRESHOLD", 1)
+        tlca = _build_tlca(expand_technosphere=False)
+        assert tlca._lci_did_factorize is True
+
+    def test_from_timeline_skips_factorization_when_below_threshold(self, monkeypatch):
+        import bw_timex.timex_lca as tlca_mod
+
+        monkeypatch.setattr(tlca_mod, "FACTORIZE_SOLVES_THRESHOLD", 1000)
+        tlca = _build_tlca(expand_technosphere=False)
+        assert tlca._lci_did_factorize is False
+
+    def test_from_timeline_warm_cache_skips_factorization(self, monkeypatch):
+        import bw_timex.timex_lca as tlca_mod
+
+        monkeypatch.setattr(tlca_mod, "FACTORIZE_SOLVES_THRESHOLD", 1)
+        _build_tlca(expand_technosphere=False)
+        # Everything the second run needs is cached, so there is nothing left
+        # to factorize for.
+        tlca_warm = _build_tlca(expand_technosphere=False)
+        assert tlca_warm._lci_did_factorize is False
+
+    def test_from_timeline_matches_expanded_score(self):
+        tlca_expanded = _build_tlca(expand_technosphere=True)
+        tlca_expanded.static_lcia()
+        tlca_timeline = _build_tlca(expand_technosphere=False)
+        assert tlca_timeline.dynamic_inventory.sum() == pytest.approx(
+            tlca_expanded.dynamic_inventory.sum()
+        )
 
     def test_warm_skips_initial_lca_solve(self):
         # First run populates both unit-LCI cache and solve cache.

--- a/tests/test_nonunitary_unitprocess.py
+++ b/tests/test_nonunitary_unitprocess.py
@@ -12,6 +12,14 @@ def test_nonunitary_db_fixture(nonunitary_db):
     assert len(bd.databases) == 3
 
 
+EXPECTED_SCORE = (  #
+    0.75 / 0.8 * 1.5 / 3 * 0.5  # all d at A
+    + 0.75 / 0.8 * 4 / 7 * 0.9  # all direct CO2 emissions at all 3 b
+    + 0.75 / 0.8 * 4 / 7 * -2 / -1 * 6  # all direct CO2 emissions at all 3 c
+    + 0.75 / 0.8 * 4 / 7 * -2 / -1 * -1 / 3 * 0.5  # all d via C at B
+)
+
+
 @pytest.mark.usefixtures("nonunitary_db")
 class TestClass_EV:
 
@@ -38,11 +46,37 @@ class TestClass_EV:
 
     def test_non_unitary_timex_lca_score(self):
 
-        expected_score = (  #
-            0.75 / 0.8 * 1.5 / 3 * 0.5  # all d at A
-            + 0.75 / 0.8 * 4 / 7 * 0.9  # all direct CO2 emissions at all 3 b
-            + 0.75 / 0.8 * 4 / 7 * -2 / -1 * 6  # all direct CO2 emissions at all 3 c
-            + 0.75 / 0.8 * 4 / 7 * -2 / -1 * -1 / 3 * 0.5  # all d via C at B
-        )
+        assert math.isclose(self.tlca.static_score, EXPECTED_SCORE, rel_tol=1e-7)
 
-        assert math.isclose(self.tlca.static_score, expected_score, rel_tol=1e-7)
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+@pytest.mark.usefixtures("nonunitary_db")
+def test_non_unitary_production_amounts_from_timeline(graph_traversal):
+    """Building the dynamic inventory from the timeline (`expand_technosphere=False`)
+    must scale each process by the same supply the expanded solve would give it.
+
+    `timeline.cumulative_amount` normalizes every edge by the *consumer's*
+    absolute production amount, while a linear solve scales each process by its
+    *own, signed* production amount. Processes whose production amount is not
+    +1 (here: c produces -1, b produces 7, d produces 3) therefore ended up with
+    wrong supplies - for negative production amounts even with a flipped sign.
+    """
+    node_a = bd.get_node(database="foreground", code="A")
+    tlca = TimexLCA(
+        demand={node_a: 0.75},
+        method=("GWP", "example"),
+        database_dates={
+            "db_2020": datetime.strptime("2020", "%Y"),
+            "foreground": "dynamic",
+        },
+    )
+    tlca.build_timeline(
+        starting_datetime=datetime.strptime("2024-01-02", "%Y-%m-%d"),
+        graph_traversal=graph_traversal,
+    )
+    tlca.lci(expand_technosphere=False, build_dynamic_biosphere=True)
+
+    # CO2 is the only flow and its characterization factor is 1
+    assert math.isclose(
+        tlca.dynamic_inventory.sum(), EXPECTED_SCORE, rel_tol=1e-7
+    )


### PR DESCRIPTION
## Wrong supplies

`timeline.cumulative_amount` is the supply array of `lci(expand_technosphere=False)`, but it normalized every edge by the **consumer's absolute** production amount, whereas a solve scales each process by its **own signed** one (`s_producer = amount * s_consumer / production_amount_producer`). So processes with a production amount != 1 got mis-scaled supplies, and negative production amounts - the usual waste-treatment convention, e.g. a `used vehicle` node producing -1 - flipped the sign of their entire upstream subtree, making end-of-life count as a credit. The functional unit's demanded amount was dropped from the chain as well (invisible for a demand of 1).

Cumulative amounts are now consistently in units of the produced product, and `DynamicBiosphereBuilder` converts them to process units where the biosphere exchanges are read (temporal markets keep product units, matching their unit LCIs). Both traversal engines and the explicit process/product paradigm are covered.

Second, independent bug in the same path: `temporal_market_lcis[idx]` was accumulated **and** supply-scaled per timeline row, so rows sharing a time-mapped market fed each other already-scaled values.

On a cradle-to-grave EV case study with ecoinvent 3.12 + premise backgrounds, both paths now agree bit for bit (956.7111070680055 kg CO2-eq dynamic GWP100); building from the timeline previously returned 866.88.

## Solve planning

The pending-solve count and factorization decision in `lci()` sat inside the `expand_technosphere` branch, so every background unit-LCI `redo_lci` in the timeline path was an unfactorized solve. Counting works fine without the expanded technosphere, so that path now plans the same way, minus the functional-unit solve it does not need. On the EV/premise case this turned ~1.3x slower into ~1.1x faster than the expanded matrices.

## Tests

Twelve new tests, parametrized over `priority` and `bfs`: non-unitary production amounts from the timeline (returned `-3.35` instead of `6.97` before), explicit process/product with output coefficient alpha != 1 (`bfs` returned `1.0` instead of `2.0`), explicit EV from-timeline vs expanded parity, explicit paradigm with background temporal distributions and `traverse_background=True`, plus solve-planning and warm-cache behaviour. Full suite: 233 passed.