### PR TITLE
fix: resolve temporalized producers by node id, not code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Fixed `lci()` raising `MultipleResults` when a temporalized process' code also exists in another database of the project, by resolving producers by node id instead of by code
 * Fixed supply scaling in `lci(expand_technosphere=False)` for processes with a production amount other than 1, whose supplies were mis-scaled and, for negative production amounts (waste treatment), sign-flipped
 * Fixed `temporal_market_lcis` being corrupted when several timeline rows share a time-mapped temporal market
 * Added the pending-solve planning and technosphere factorization to `lci(expand_technosphere=False)`, which previously only ran for the expanded path

--- a/bw_timex/dynamic_biosphere_builder.py
+++ b/bw_timex/dynamic_biosphere_builder.py
@@ -32,6 +32,7 @@ class DynamicBiosphereBuilder:
         interdatabase_activity_mapping: SetList,
         expand_technosphere: bool = True,
         background_unit_lci_cache: dict | None = None,
+        nodes: dict | None = None,
     ) -> None:
         """
         Initializes the DynamicBiosphereBuilder object.
@@ -66,6 +67,10 @@ class DynamicBiosphereBuilder:
         expand_technosphere : bool, optional
             A boolean indicating if the dynamic biosphere matrix is built via expanded matrices or directly from the timeline.
             Default is True.
+        nodes : dict, optional
+            A dictionary mapping node ids to their bw2data node proxies, as collected by
+            `TimexLCA`. Used to resolve producers by id instead of by code, which is only
+            unique within a database.
 
         Returns
         -------
@@ -117,6 +122,7 @@ class DynamicBiosphereBuilder:
         self.database_dates_static = database_dates_static
         self.timeline = timeline
         self.interdatabase_activity_mapping = interdatabase_activity_mapping
+        self.nodes = nodes if nodes is not None else {}
         self._matrix_entries = {}  # (row, col) -> amount
         # Biosphere exchanges of foreground/background producers are read
         # from the bw2data SQL store; share results across TimexLCA objects.
@@ -244,7 +250,9 @@ class DynamicBiosphereBuilder:
                     )
 
                 for input_id, exc_amount, temporal_distribution in (
-                    self.get_biosphere_exchanges(original_db, original_code)
+                    self.get_biosphere_exchanges(
+                        original_db, original_code, producer_id=row.producer
+                    )
                 ):
                     if temporal_distribution:
                         td_dates = temporal_distribution.date
@@ -465,12 +473,25 @@ class DynamicBiosphereBuilder:
         if key not in self._matrix_entries:
             self._matrix_entries[key] = amount
 
-    def get_biosphere_exchanges(self, original_db, original_code):
+    def get_biosphere_exchanges(self, original_db, original_code, producer_id=None):
         """Return cached biosphere exchanges for a producer.
 
         Keyed by the source database's `modified` token so foreground or
         background edits invalidate stale entries automatically.
+
+        Temporalized producers are stored in the activity time mapping under
+        the pseudo-database "temporalized", which does not identify a node:
+        codes are only unique *within* a database, so the same code can exist
+        in several databases of a project (e.g. a benchmark copy of a
+        foreground, or a background process copied into every vintage). The
+        timeline's `producer` id is unambiguous, so resolve the real node from
+        it and key the cache on its actual database.
         """
+        act = None
+        if original_db == "temporalized" and producer_id is not None:
+            act = self.nodes.get(producer_id) or bd.get_node(id=producer_id)
+            original_db = act["database"]
+
         modified = (
             bd.databases[original_db].get("modified")
             if original_db in bd.databases
@@ -478,10 +499,11 @@ class DynamicBiosphereBuilder:
         )
         cache_key = (bd.projects.current, original_db, original_code, modified)
         if cache_key not in self._activity_biosphere_exchange_cache:
-            if original_db == "temporalized":
-                act = bd.get_node(code=original_code)
-            else:
-                act = bd.get_node(database=original_db, code=original_code)
+            if act is None:
+                if original_db == "temporalized":
+                    act = bd.get_node(code=original_code)
+                else:
+                    act = bd.get_node(database=original_db, code=original_code)
             self._activity_biosphere_exchange_cache[cache_key] = [
                 (exc.input.id, exc["amount"], exc.get("temporal_distribution"))
                 for exc in act.biosphere()

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -558,6 +558,7 @@ class TimexLCA:
                     self.interdatabase_activity_mapping,
                     expand_technosphere=True,
                     background_unit_lci_cache=self._background_unit_lci_cache,
+                    nodes=self.nodes,
                 )
                 pending = shadow.count_pending_background_solves()
                 self._lci_pending_solves = pending
@@ -612,6 +613,7 @@ class TimexLCA:
                     self.interdatabase_activity_mapping,
                     expand_technosphere=False,
                     background_unit_lci_cache=self._background_unit_lci_cache,
+                    nodes=self.nodes,
                 )
                 pending = shadow.count_pending_background_solves()
                 self._lci_pending_solves = pending
@@ -1067,6 +1069,7 @@ class TimexLCA:
             self.interdatabase_activity_mapping,
             expand_technosphere=expand_technosphere,
             background_unit_lci_cache=self._background_unit_lci_cache,
+            nodes=self.nodes,
         )
 
         # The pending-solve count + factorize decision is now made upfront

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from .fixtures.explicit_background_td_db_fixture import explicit_background_td_d
 from .fixtures.background_td_multdate_consumer_fixture import (
     background_td_multidate_consumer_db,
 )
+from .fixtures.duplicate_code_db_fixture import duplicate_code_db
 from .fixtures.dynamic_biomatrix_db_fixture import dynamic_biosphere_matrix_db
 from .fixtures.explicit_process_product_db_fixture import explicit_process_product_db
 from .fixtures.nonunitary_db_fixture import nonunitary_db

--- a/tests/fixtures/duplicate_code_db_fixture.py
+++ b/tests/fixtures/duplicate_code_db_fixture.py
@@ -1,0 +1,84 @@
+import bw2data as bd
+import pytest
+from bw2data.tests import bw2test
+
+
+@pytest.fixture
+@bw2test
+def duplicate_code_db():
+    """fu -> grid, where an unrelated database re-uses the foreground code "fu".
+
+    Codes are only unique *within* a database in Brightway, so any project can
+    contain several nodes sharing a code (e.g. a benchmark/scenario copy of a
+    foreground). The decoy database is written *before* the foreground so its
+    node has the lower id, i.e. a lookup that simply takes the first match by
+    code picks the wrong node and its (very different) biosphere exchange.
+    """
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    # Decoy: same code as the foreground node, different biosphere amount.
+    # Not part of the studied product system and not in `database_dates`.
+    bd.Database("decoy").write(
+        {
+            ("decoy", "fu"): {
+                "name": "fu",
+                "unit": "unit",
+                "location": "GLO",
+                "reference product": "fu",
+                "exchanges": [
+                    {"input": ("decoy", "fu"), "amount": 1, "type": "production"},
+                    {"input": ("bio", "co2"), "amount": 1000, "type": "biosphere"},
+                ],
+            }
+        }
+    )
+
+    for db_name, co2_amount in (("background_2020", 10), ("background_2030", 2)):
+        bd.Database(db_name).write(
+            {
+                (db_name, "grid"): {
+                    "name": "grid",
+                    "unit": "kWh",
+                    "location": "GLO",
+                    "reference product": "electricity",
+                    "exchanges": [
+                        {
+                            "input": (db_name, "grid"),
+                            "amount": 1,
+                            "type": "production",
+                        },
+                        {
+                            "input": ("bio", "co2"),
+                            "amount": co2_amount,
+                            "type": "biosphere",
+                        },
+                    ],
+                }
+            }
+        )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "fu"): {
+                "name": "fu",
+                "unit": "unit",
+                "location": "GLO",
+                "reference product": "fu",
+                "exchanges": [
+                    {"input": ("foreground", "fu"), "amount": 1, "type": "production"},
+                    {"input": ("bio", "co2"), "amount": 5, "type": "biosphere"},
+                    {
+                        "input": ("background_2020", "grid"),
+                        "amount": 3,
+                        "type": "technosphere",
+                    },
+                ],
+            }
+        }
+    )
+
+    for db in bd.databases:
+        bd.Database(db).process()

--- a/tests/test_duplicate_code.py
+++ b/tests/test_duplicate_code.py
@@ -1,0 +1,31 @@
+"""Codes are only unique within a database, not within a project."""
+
+from datetime import datetime
+
+import pytest
+
+from bw_timex import TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+
+
+@pytest.mark.usefixtures("duplicate_code_db")
+def test_biosphere_exchanges_of_duplicated_code_come_from_the_right_database():
+    """An unrelated database sharing a foreground code must not confuse the
+    dynamic biosphere build: neither raising `MultipleResults` nor silently
+    reading the decoy node's exchanges."""
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2024-01-01")
+    tlca.lci()
+    tlca.static_lcia()
+
+    # 5 kg CO2 direct from fu + 3 kWh grid, interpolated between the 2020
+    # (10 kg/kWh) and 2030 (2 kg/kWh) database. The decoy node emits 1000 kg
+    # and must not contribute at all.
+    assert tlca.static_score < 100
+    assert tlca.dynamic_inventory.sum() == pytest.approx(tlca.static_score)


### PR DESCRIPTION
## Problem

`TimexLCA.lci()` crashes with `bw2data.errors.MultipleResults: Found 2 results for the given search` whenever a temporalized process' code also exists in another database of the project:

```
File bw_timex/dynamic_biosphere_builder.py:482, in DynamicBiosphereBuilder.get_biosphere_exchanges
    if original_db == "temporalized":
        act = bd.get_node(code=original_code)
```

Temporalized producers are stored in the activity time mapping under the pseudo-database `"temporalized"`, which does not identify a node. Codes are only unique *within* a database, so the code-only lookup relies on an invariant Brightway never promises. A project holding a benchmark or scenario copy of the foreground, an older foreground, or a background process copied into every vintage database (the standard `premise` idiom — `act.copy(code="...", database=db.name)` in a loop) trips it. Had the lookup resolved to a single node, it could just as well have been the wrong one, silently returning another node's biosphere exchanges.

`timeline_builder.py` already keeps the real database name for producers reached by `traverse_background`; the foreground/temporalized path had no equivalent.

## Fix

Pass the timeline row's `producer` id — unambiguous — into `get_biosphere_exchanges` and resolve the node from the already-collected `TimexLCA.nodes` proxies, so no extra query is needed.

As a side effect the biosphere-exchange cache is now keyed on the producer's real database and its `modified` token. Previously temporalized entries were keyed `(project, "temporalized", code, None)`, which is both ambiguous across databases and never invalidated when a foreground was edited between `TimexLCA` objects in one session.

## Tests

`tests/test_duplicate_code.py` with a fixture whose decoy database is written *before* the foreground, so the decoy node has the lower id: a lookup that simply takes the first match by code reads the decoy's biosphere exchange and fails the test. Reproduces `MultipleResults` on `main`, passes with the fix. Full suite green.