### PR TITLE
perf: make TimexLCA setup independent of background size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed supply scaling in `lci(expand_technosphere=False)` for processes with a production amount other than 1, whose supplies were mis-scaled and, for negative production amounts (waste treatment), sign-flipped
 * Fixed `temporal_market_lcis` being corrupted when several timeline rows share a time-mapped temporal market
 * Added the pending-solve planning and technosphere factorization to `lci(expand_technosphere=False)`, which previously only ran for the expanded path
+* Improved `TimexLCA` setup speed by making it independent of the background database size, via lazy node proxies and a base LCA restricted to the demand-relevant databases ([#204](https://github.com/brightway-lca/bw_timex/pull/204))
 
 ## [1.1.2]
 * Fixed the option to calculate the lci from the timeline. This option is called with lci(expand_technosphere=False) which speeds up the calculation significantly for for large systems, but does not allow for detailed contribution analysis of background processes. https://github.com/brightway-lca/bw_timex/commit/12853dbd799764f6d2d2fa2335d6f6f19a97abed

--- a/bw_timex/helper_classes.py
+++ b/bw_timex/helper_classes.py
@@ -1,6 +1,90 @@
 import warnings
 
+from bw2data.backends.proxies import Activity
+from bw2data.backends.schema import ActivityDataset
 from loguru import logger
+
+
+class LazyActivity(Activity):
+    """An `Activity` proxy that reads its pickled `data` blob only when needed.
+
+    `TimexLCA` keeps a proxy for every node of every database in
+    `database_dates`, which is hundreds of thousands of nodes for real
+    background databases, while only a handful of them are ever used for
+    anything but their metadata. Unpickling the `data` blob of all of them
+    dominates the setup time, so this proxy is built from the scalar columns of
+    `ActivityDataset` instead. Those cover the keys that are read in bulk
+    (`name`, `reference product`, `location`, `code`, `database`, `type`); any
+    other key, and anything that needs the full dataset (exchange iteration,
+    saving, ...), loads the row from the database on first use.
+    """
+
+    # Keys that are stored as their own column, and therefore don't require the
+    # `data` blob. Values are the position in the row tuple passed to __init__.
+    _COLUMNS = {
+        "id": 0,
+        "code": 1,
+        "database": 2,
+        "name": 3,
+        "location": 4,
+        "reference product": 5,
+        "type": 6,
+    }
+
+    #: The columns to select, in the order `__init__` expects them.
+    COLUMN_NAMES = ("id", "code", "database", "name", "location", "product", "type")
+
+    def __init__(self, row: tuple):
+        """`row` holds the columns named in `COLUMN_NAMES`, in that order."""
+        self._row = row
+        self._lazy_document = None
+        self._lazy_data = None
+
+    @property
+    def _document(self):
+        if self._lazy_document is None:
+            self._lazy_document = ActivityDataset.get_by_id(self._row[0])
+        return self._lazy_document
+
+    @_document.setter
+    def _document(self, value):
+        self._lazy_document = value
+
+    @property
+    def _data(self):
+        if self._lazy_data is None:
+            document = self._document
+            self._lazy_data = document.data
+            self._lazy_data["code"] = document.code
+            self._lazy_data["database"] = document.database
+            self._lazy_data["id"] = document.id
+        return self._lazy_data
+
+    @_data.setter
+    def _data(self, value):
+        self._lazy_data = value
+
+    @property
+    def id(self):
+        return self._row[0]
+
+    @property
+    def key(self):
+        return (self._row[2], self._row[1])
+
+    def __getitem__(self, key):
+        if key == 0:
+            return self._row[2]
+        if key == 1:
+            return self._row[1]
+        position = self._COLUMNS.get(key)
+        if position is not None:
+            value = self._row[position]
+            if value is not None:
+                return value
+            # A `None` column may mean "not set" or "not synced", so fall back
+            # to the blob to keep `Activity`'s KeyError behaviour exact.
+        return super().__getitem__(key)
 
 
 class SetList:

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -32,7 +32,7 @@ from ._lci_cache import BACKGROUND_UNIT_LCI_CACHE, LCI_SOLVE_CACHE, NODES_CACHE
 FACTORIZE_SOLVES_THRESHOLD = 8
 
 from .dynamic_biosphere_builder import DynamicBiosphereBuilder
-from .helper_classes import InterDatabaseMapping, TimeMappingDict
+from .helper_classes import InterDatabaseMapping, LazyActivity, TimeMappingDict
 from .matrix_modifier import MatrixModifier
 from .timeline_builder import TimelineBuilder
 from .utils import (
@@ -150,6 +150,10 @@ class TimexLCA:
             demand=self.demand, method=self.method, database_dates=self.database_dates
         )
 
+        # Filled in by `prepare_base_lca_inputs`: the databases the base LCA
+        # covers, which is a subset of `database_dates` plus their dependents.
+        self._base_lca_database_names = set()
+
         logger.info("Calculating base LCA...")
         # Calculate static LCA results using a custom prepare_lca_inputs function that includes all
         # background databases in the LCA. We need all the IDs for the time mapping dict.
@@ -190,10 +194,11 @@ class TimexLCA:
             key = ("nodes", project, db, modified)
             db_nodes = self._nodes_cache.get(key)
             if db_nodes is None:
-                rows = bd.backends.ActivityDataset.select().where(
-                    bd.backends.ActivityDataset.database == db
-                )
-                db_nodes = {row.id: bd.backends.Activity(row) for row in rows}
+                # Only the scalar columns are read here; the pickled `data`
+                # blob of a node is loaded lazily, if it is needed at all.
+                columns = [getattr(AD, name) for name in LazyActivity.COLUMN_NAMES]
+                rows = AD.select(*columns).where(AD.database == db).tuples()
+                db_nodes = {row[0]: LazyActivity(row) for row in rows}
                 self._nodes_cache[key] = db_nodes
             self.nodes.update(db_nodes)
             for node in db_nodes.values():
@@ -1229,7 +1234,20 @@ class TimexLCA:
         data_objs = []
         remapping_dicts = None
 
-        demand_database_names = list(self.database_dates.keys())
+        # The base LCA only needs the databases that the demand depends on: the
+        # dynamic (foreground) ones, the ones holding the demand, and whatever
+        # those link to. Time-specific background databases that nothing
+        # depends on would only inflate the base technosphere matrix here; they
+        # are brought in later, when `lci()` relinks the processes to them.
+        dynamic_database_names = {
+            db
+            for db, date in self.database_dates.items()
+            if not isinstance(date, datetime)
+        }
+        demand_database_names = list(
+            dynamic_database_names
+            | {bd.get_node(id=get_id(key))["database"] for key in (demand or {})}
+        )
 
         if demand_database_names:
             database_names = set.union(
@@ -1243,6 +1261,11 @@ class TimexLCA:
                 database_names = [
                     x for x in database_names if x not in demand_database_names
                 ] + demand_database_names
+
+            # Remembered so that `create_activity_time_mapping` knows for which
+            # databases the base LCA's matrix is the authority on which nodes
+            # get a technosphere column.
+            self._base_lca_database_names = set(database_names)
 
             data_objs.extend([Database(obj).datapackage() for obj in database_names])
 
@@ -1439,11 +1462,18 @@ class TimexLCA:
             demand_dependent_database_names & self.database_dates_static.keys()
         )
 
-        background = {
-            node.id
-            for db in demand_dependent_background_database_names
-            for node in bd.Database(db)
-        }
+        # Only the ids are needed here, so we query them directly instead of
+        # instantiating a node proxy (and unpickling its data blob) for every
+        # process in the background databases.
+        if demand_dependent_background_database_names:
+            background = {
+                row[0]
+                for row in AD.select(AD.id)
+                .where(AD.database << list(demand_dependent_background_database_names))
+                .tuples()
+            }
+        else:
+            background = set()
         self.node_collections["background"] = background
 
         first_level_background_static = set()
@@ -1623,9 +1653,23 @@ class TimexLCA:
             db: time for db, time in self.database_dates.items() if isinstance(time, str)
         }
 
-        for idx in self.base_lca.dicts.activity.keys():  # activity ids
-            key = self.base_lca.remapping_dicts["activity"][idx]  # ('database', 'code')
+        # Only nodes that occupy a technosphere column are mapped. For the
+        # databases in the base LCA, its matrix says exactly which those are;
+        # the remaining time-specific databases are not in that matrix (they
+        # are relinked to later), so there we go by node type, excluding
+        # explicit product nodes, which are rows only.
+        base_activity_ids = set(self.base_lca.dicts.activity.keys())
+        base_lca_databases = self._base_lca_database_names
+        product_node_types = set(bd.labels.product_node_types)
+
+        for idx, node in self.nodes.items():  # activity ids
+            key = node.key  # ('database', 'code')
             db_name = key[0]
+            if db_name in base_lca_databases:
+                if idx not in base_activity_ids:
+                    continue
+            elif node.get("type") in product_node_types:
+                continue
             if db_name in dynamic_db_time_mapping:
                 self.activity_time_mapping.add(
                     (key, dynamic_db_time_mapping[db_name]), unique_id=idx

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -183,6 +183,9 @@ class TimexLCA:
         # database's `modified` token) so repeated TimexLCA objects in the same
         # session reuse them instead of re-querying. Opt out via
         # `use_global_lci_cache=False`.
+        logger.info(
+            f"Loading node metadata from {len(self.database_dates)} database(s)..."
+        )
         self._nodes_cache = NODES_CACHE if use_global_lci_cache else {}
         project = bd.projects.current
         self.nodes = {}
@@ -216,6 +219,8 @@ class TimexLCA:
         self._lci_used_cached_solve = False
         # Whether the last lci() call LU-factorized the expanded technosphere.
         self._lci_did_factorize = False
+
+        logger.info("TimexLCA initialized.")
 
     ########################################
     # Main functions to be called by users #
@@ -1178,6 +1183,36 @@ class TimexLCA:
     # For setup #
     #############
 
+    def clean_databases(self) -> None:
+        """
+        Reprocess the databases that have been modified since they were last processed.
+
+        Editing a database invalidates its datapackage, and the next calculation has to
+        rebuild it. For large background databases that takes tens of seconds each, so
+        the databases concerned are logged instead of the calculation appearing to hang.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        None
+        """
+        modified_databases = sorted(
+            name for name in databases if databases[name].get("dirty")
+        )
+        if not modified_databases:
+            return
+
+        logger.info(
+            f"Reprocessing {len(modified_databases)} modified database(s) before "
+            f"calculating: {', '.join(modified_databases)}. "
+            "This can take a while for large databases."
+        )
+        databases.clean()
+        logger.info("Done reprocessing modified databases.")
+
     def prepare_base_lca_inputs(
         self,
         demand=None,
@@ -1230,7 +1265,7 @@ class TimexLCA:
                 "Please use `projects.migrate_project_25` before calculating using Brightway 2.5"
             )
 
-        databases.clean()
+        self.clean_databases()
         data_objs = []
         remapping_dicts = None
 
@@ -1361,7 +1396,7 @@ class TimexLCA:
                 "Please use `projects.migrate_project_25` before calculating using Brightway 2.5"
             )
 
-        databases.clean()
+        self.clean_databases()
         data_objs = []
         remapping_dicts = None
 


### PR DESCRIPTION
Setting up a `TimexLCA` scaled with the total number of nodes in every database listed in `database_dates`, instead of with the foreground. On a project with three premise vintages of ecoinvent 3.12 (131k nodes), the constructor took **11.7 s** and 1.7 GB, and roughly doubled again with six vintages.

## Where the time went

| phase | before | after |
|---|---|---|
| `create_node_collections` | 3.18 s | 0.04 s |
| `self.nodes` build | 5.89 s | 0.99 s |
| base LCA (`prepare_base_lca_inputs` + `lci`) | 2.63 s | 0.72 s |
| **`TimexLCA(...)` total** | **11.70 s** | **1.75 s** |
| base technosphere | 131,038² | 43,654² |
| peak RSS | 1.74 GB | 0.84 GB |
| init with six vintages | 17.21 s | 2.64 s |

`build_timeline` also drops from 8.6 s to 5.2 s as a side effect, since the time mapping no longer walks all vintages' matrix columns.

## Changes

1. **`create_node_collections`** built the `background` id set by iterating `bd.Database(db)`, which instantiates a node proxy and unpickles a `data` blob for every background process — though only `.id` is used. It now selects the ids directly.

2. **`__init__`** materialized a full `Activity` proxy for every node of every database. Unpickling those blobs was the single largest cost, while a complete run looks up only a handful of nodes by key (11 of 131,038 on the EV example) and scans the rest for `name` / `reference product` / `location` only — all of which are real columns on `ActivityDataset`. Nodes are now built from those columns via a new `LazyActivity` proxy, which loads the row lazily when a caller needs anything else (`unit`, exchange iteration, `save`, …). It subclasses `Activity`, so `isinstance` checks and all proxy methods keep working.

3. **The base LCA** was built over every database in `database_dates`, so its technosphere contained all vintages at once, although only the demand-dependent ones take part in the solve and the graph traversal. It now covers the dynamic databases, the demand's database, and their graph dependents. The other vintages were only needed to pre-populate `activity_time_mapping`, which now walks `self.nodes` instead — the base matrix remains the authority for the databases it covers, and explicit product nodes are excluded for the ones it does not (they are matrix rows, not columns).

## Verification

- Full test suite: 234 passed.
- On the premise EV example (ecoinvent 3.12 + REMIND-EU SSP2-NDC 2020/2030/2040): `base_score` 23247.15112358249, `static_score` 10744.473494732374, `dynamic_score` 10655.763775235002 and the timeline DataFrame are all identical before and after.

Not addressed here: `lci()` is now the dominant step (~13 s on that project).