### PR TITLE
Allow several background databases per point in time

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed supply scaling in `lci(expand_technosphere=False)` for processes with a production amount other than 1, whose supplies were mis-scaled and, for negative production amounts (waste treatment), sign-flipped
 * Fixed `temporal_market_lcis` being corrupted when several timeline rows share a time-mapped temporal market
 * Added the pending-solve planning and technosphere factorization to `lci(expand_technosphere=False)`, which previously only ran for the expanded path
+* Added support for several background databases sharing the same point in time in `database_dates`, by resolving temporal market shares per producer instead of per date ([#205](https://github.com/brightway-lca/bw_timex/pull/205))
 
 ## [1.1.2]
 * Fixed the option to calculate the lci from the timeline. This option is called with lci(expand_technosphere=False) which speeds up the calculation significantly for for large systems, but does not allow for detailed contribution analysis of background processes. https://github.com/brightway-lca/bw_timex/commit/12853dbd799764f6d2d2fa2335d6f6f19a97abed

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -10,6 +10,7 @@ import numpy as np
 from bw2data.backends.schema import ActivityDataset as AD
 from bw2data.backends.schema import ExchangeDataset as ED
 from bw_temporalis import TemporalDistribution, TemporalisLCA, loader_registry
+from loguru import logger
 
 from .utils import (
     get_reference_product_production_amount,
@@ -112,12 +113,29 @@ class VariantBackgroundMixin:
     - ``self.cutoff`` and a ``self.edge_ff`` edge-filter callable.
     """
 
+    def _node_identity(self, node_id: int) -> str:
+        """Human-readable identity of a node for error/warning messages.
+
+        Falls back to the bare id if the bw2data proxy is unavailable.
+        """
+        node = self.bw_node_proxies.get(node_id)
+        if node is None:
+            return f"id {node_id}"
+        return (
+            f"'{node['name']}' (reference product: '{node.get('reference product')}', "
+            f"location: '{node['location']}')"
+        )
+
     def _candidate_databases_for_node(self, node_id: int) -> dict:
         """``{date: database_name}`` for the static databases holding a match.
 
         Candidates come from the interdatabase mapping (built up front by
         ``TimexLCA.add_full_interdatabase_activity_mapping`` whenever the
         background is traversed), plus the node's own database.
+
+        Called once per producer cohort date during descent, so a node whose
+        coverage is partial is warned about here at most once (deduplicated
+        via ``self._warned_partial_coverage_node_ids``), not once per date.
         """
         dates_static = getattr(self, "database_dates_static", None) or {}
         try:
@@ -136,12 +154,31 @@ class VariantBackgroundMixin:
                 continue
             if date in candidates:
                 raise ValueError(
-                    f"Node {node_id} was found in more than one database at "
-                    f"{date:%Y-%m-%d}: '{candidates[date]}' and '{db_name}'. "
-                    "bw_timex cannot tell which one to use. Give the copy a "
-                    "distinct name, reference product or location."
+                    f"Node {self._node_identity(node_id)} was found in more than "
+                    f"one database at {date:%Y-%m-%d}: '{candidates[date]}' and "
+                    f"'{db_name}'. bw_timex cannot tell which one to use. Give "
+                    "the copy a distinct name, reference product or location, "
+                    "or remove one of the two databases from `database_dates`."
                 )
             candidates[date] = db_name
+
+        number_of_dates = len(set(dates_static.values()))
+        if candidates and len(candidates) < number_of_dates:
+            warned = getattr(self, "_warned_partial_coverage_node_ids", None)
+            if warned is None:
+                warned = set()
+                self._warned_partial_coverage_node_ids = warned
+            if node_id not in warned:
+                warned.add(node_id)
+                logger.warning(
+                    "Producer {} was only found in {} of {} time-explicit "
+                    "database date(s): {}. Its temporal market can only draw "
+                    "on those.",
+                    self._node_identity(node_id),
+                    len(candidates),
+                    number_of_dates,
+                    sorted(candidates.values()),
+                )
         return candidates
 
     def _variant_shares_for_date(self, producer_date, node_id: int) -> dict:

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -112,18 +112,49 @@ class VariantBackgroundMixin:
     - ``self.cutoff`` and a ``self.edge_ff`` edge-filter callable.
     """
 
-    def _variant_shares_for_date(self, producer_date) -> dict:
+    def _candidate_databases_for_node(self, node_id: int) -> dict:
+        """``{date: database_name}`` for the static databases holding a match.
+
+        Candidates come from the interdatabase mapping (built up front by
+        ``TimexLCA.add_full_interdatabase_activity_mapping`` whenever the
+        background is traversed), plus the node's own database.
+        """
+        dates_static = getattr(self, "database_dates_static", None) or {}
+        try:
+            siblings = dict(self.interdatabase_activity_mapping[node_id])
+        except KeyError:
+            siblings = {}
+        db_names = set(siblings)
+        node = self.bw_node_proxies.get(node_id)
+        if node is not None:
+            db_names.add(node["database"])
+
+        candidates = {}
+        for db_name in sorted(db_names):
+            date = dates_static.get(db_name)
+            if date is None:
+                continue
+            if date in candidates:
+                raise ValueError(
+                    f"Node {node_id} was found in more than one database at "
+                    f"{date:%Y-%m-%d}: '{candidates[date]}' and '{db_name}'. "
+                    "bw_timex cannot tell which one to use. Give the copy a "
+                    "distinct name, reference product or location."
+                )
+            candidates[date] = db_name
+        return candidates
+
+    def _variant_shares_for_date(self, producer_date, node_id: int) -> dict:
         """Return ``{db_name: weight}`` interpolation shares for a cohort date.
 
-        Maps the producer's absolute cohort date onto the available static
-        background databases, using the same interpolation as the timeline
-        builder so leaf and descended routing agree.
+        Maps the producer's absolute cohort date onto the static background
+        databases that actually hold the producer, using the same interpolation
+        as the timeline builder so leaf and descended routing agree.
         """
         from datetime import datetime as _dt
 
-        dates_static = getattr(self, "database_dates_static", None) or {}
-        dates_to_db = {v: k for k, v in dates_static.items() if isinstance(v, _dt)}
-        sorted_dates = tuple(sorted(dates_to_db))
+        candidates = self._candidate_databases_for_node(node_id)
+        sorted_dates = tuple(sorted(candidates))
         if not sorted_dates:
             return {}
 
@@ -134,7 +165,7 @@ class VariantBackgroundMixin:
             weights = nearest_date_weight(producer_date, sorted_dates)
         else:
             weights = linear_interpolation_weights(producer_date, sorted_dates)
-        return {dates_to_db[d]: w for d, w in (weights or {}).items()}
+        return {candidates[d]: w for d, w in (weights or {}).items()}
 
     def _resolve_in_variant(self, node_id: int, db_name: str) -> int:
         """Return the id of ``node_id``'s sibling in database ``db_name``.
@@ -376,7 +407,9 @@ class VariantBackgroundMixin:
         # Route each producer cohort date to its variant(s).
         variant_keep: dict[str, dict] = {}
         for date in abs_td_producer.date:
-            for db_name, weight in self._variant_shares_for_date(date).items():
+            for db_name, weight in self._variant_shares_for_date(
+                date, producer_process
+            ).items():
                 variant_keep.setdefault(db_name, {})[date] = weight
 
         edges = []

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -1,6 +1,6 @@
 from bisect import bisect_left
 from datetime import datetime, timedelta
-from typing import Callable, KeysView, Union
+from typing import Callable, KeysView
 
 import bw2data as bd
 import numpy as np
@@ -505,6 +505,59 @@ class TimelineBuilder:
                 leaves.add(producer)
         return leaves
 
+    def candidate_databases_for_producers(self, producers: set) -> dict:
+        """Map each producer to the static databases that hold a match for it.
+
+        Returns ``{producer_id: {date: database_name}}``. A candidate is a static
+        background database containing a node with the same ``(name, reference
+        product, location)`` as the producer. Several databases may share a date;
+        if two of them hold a match for the same producer, the model is ambiguous
+        and this raises.
+
+        As a side effect, ``self.market_producer_matches`` is filled with
+        ``{producer_id: {database_name: node_id}}``, which is exactly what
+        ``TimexLCA.add_interdatabase_activity_mapping_from_timeline`` needs.
+        """
+        triplets = {}
+        for producer in producers:
+            node = self.nodes[producer]
+            key = (node["name"], node.get("reference product"), node["location"])
+            triplets.setdefault(key, []).append(producer)
+
+        candidates = {producer: {} for producer in producers}
+        matches = {producer: {} for producer in producers}
+        for node in self.nodes.values():
+            date = self.database_dates_static.get(node["database"])
+            if date is None:
+                continue
+            key = (node["name"], node.get("reference product"), node["location"])
+            for producer in triplets.get(key, ()):
+                already = candidates[producer].get(date)
+                if already is not None and already != node["database"]:
+                    raise ValueError(
+                        f"Producer '{node['name']}' was found in more than one database "
+                        f"at {date:%Y-%m-%d}: '{already}' and '{node['database']}'. "
+                        "bw_timex cannot tell which one its temporal market should use. "
+                        "Give the copy a distinct name, reference product or location."
+                    )
+                candidates[producer][date] = node["database"]
+                matches[producer][node["database"]] = node.id
+
+        number_of_dates = len(set(self.database_dates_static.values()))
+        for producer, producer_candidates in candidates.items():
+            if len(producer_candidates) < number_of_dates:
+                logger.warning(
+                    "Producer '{}' was only found in {} of {} time-explicit database "
+                    "date(s): {}. Its temporal market can only draw on those.",
+                    self.nodes[producer]["name"],
+                    len(producer_candidates),
+                    number_of_dates,
+                    sorted(producer_candidates.values()),
+                )
+
+        self.market_producer_matches = matches
+        return candidates
+
     def add_column_temporal_market_shares_to_timeline(
         self,
         tl_df: pd.DataFrame,
@@ -535,40 +588,10 @@ class TimelineBuilder:
             )
             return tl_df
 
-        dates_list = [
-            date
-            for date in self.database_dates_static.values()
-            if isinstance(date, datetime)
-        ]
         if "date_producer" not in list(tl_df.columns):
             raise ValueError("The timeline does not contain dates.")
 
-        sorted_dates = tuple(sorted(dates_list))
-
-        # create reversed dict {date: database} with only static "background" db's
-        self.reversed_database_dates = {
-            v: k
-            for k, v in self.database_dates_static.items()
-            if isinstance(v, datetime)
-        }
-
-        unique_producer_dates = tl_df["date_producer"].unique()
-
-        if interpolation_type == "nearest":
-            interpolation_weights = {
-                date: self.find_closest_date(date, sorted_dates)
-                for date in unique_producer_dates
-            }
-
-        elif interpolation_type == "linear":
-            interpolation_weights = {
-                date: self.get_weights_for_interpolation_between_nearest_years(
-                    date, sorted_dates, interpolation_type
-                )
-                for date in unique_producer_dates
-            }
-
-        else:
+        if interpolation_type not in ("linear", "nearest"):
             raise ValueError(
                 f"Sorry, but {interpolation_type} interpolation is not available yet."
             )
@@ -578,20 +601,42 @@ class TimelineBuilder:
         else:
             market_producers = self.node_collections["first_level_background_static"]
 
-        remapped_interpolation_weights = {
-            producer_date: {
-                self.reversed_database_dates[date]: share
-                for date, share in weights.items()
-            }
-            for producer_date, weights in interpolation_weights.items()
-        }
-
-        tl_df["temporal_market_shares"] = [
-            remapped_interpolation_weights[producer_date]
+        producers_in_timeline = {
+            producer
+            for producer in tl_df["producer"].unique()
             if producer in market_producers
-            else None
-            for producer, producer_date in zip(tl_df["producer"], tl_df["date_producer"])
-        ]
+        }
+        candidate_databases = self.candidate_databases_for_producers(
+            producers_in_timeline
+        )
+
+        weight_cache = {}
+        shares = []
+        for producer, producer_date in zip(tl_df["producer"], tl_df["date_producer"]):
+            if producer not in producers_in_timeline:
+                shares.append(None)
+                continue
+            candidates = candidate_databases[producer]
+            sorted_dates = tuple(sorted(candidates))
+            # The cache key must include which database each date maps to, not
+            # just the set of dates: two producers can share the same vintage
+            # dates while drawing from different database families (e.g. an
+            # untouched background producer vs. a foreground-modified copy
+            # kept in its own database), and only the mapping distinguishes them.
+            cache_key = (tuple(sorted(candidates.items())), producer_date)
+            if cache_key not in weight_cache:
+                if interpolation_type == "nearest":
+                    weights = self.find_closest_date(producer_date, sorted_dates)
+                else:
+                    weights = self.get_weights_for_interpolation_between_nearest_years(
+                        producer_date, sorted_dates, interpolation_type
+                    )
+                weight_cache[cache_key] = {
+                    candidates[date]: share for date, share in weights.items()
+                }
+            shares.append(weight_cache[cache_key])
+
+        tl_df["temporal_market_shares"] = shares
 
         return tl_df
 
@@ -663,34 +708,6 @@ class TimelineBuilder:
                 self._logged_reference_date_above_range = True
 
         return linear_interpolation_weights(reference_date, dates_list)
-
-    def add_interpolation_weights_at_intersection_to_background(
-        self, row
-    ) -> Union[dict, None]:
-        """
-        returns the interpolation weights to background databases only for those exchanges,
-        where the producing process actually comes from a background database (temporal markets).
-
-        Only these processes are receiving inputs from the background databases.
-        All other process in the timeline are not directly linked to the background,
-        so the interpolation weight info is not needed and set to None
-
-        Parameters
-        ----------
-        row : pd.Series
-            Row of the timeline DataFrame
-        Returns
-        -------
-        dict
-            Dictionary with the name of databases and interpolation weights.
-        """
-
-        if row["producer"] in self.node_collections["first_level_background_static"]:
-            return {
-                self.reversed_database_dates[x]: v
-                for x, v in row["temporal_market_shares"].items()
-            }
-        return None
 
     def get_consumer_name(self, idx: int) -> str:
         """

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -538,7 +538,8 @@ class TimelineBuilder:
                         f"Producer '{node['name']}' was found in more than one database "
                         f"at {date:%Y-%m-%d}: '{already}' and '{node['database']}'. "
                         "bw_timex cannot tell which one its temporal market should use. "
-                        "Give the copy a distinct name, reference product or location."
+                        "Give the copy a distinct name, reference product or location, "
+                        "or remove one of the two databases from `database_dates`."
                     )
                 candidates[producer][date] = node["database"]
                 matches[producer][node["database"]] = node.id

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -1523,6 +1523,15 @@ class TimexLCA:
                 "Timeline not yet built. Call TimexLCA.build_timeline() first."
             )
 
+        # The timeline builder already resolved every temporal-market producer to
+        # its counterparts while computing the market shares. Reuse that instead
+        # of scanning every background node a second time.
+        matches = getattr(self.timeline_builder, "market_producer_matches", None)
+        if matches:
+            self.interdatabase_activity_mapping.update(matches)
+            self.interdatabase_activity_mapping.make_reciprocal()
+            return
+
         filtered_timeline = self.timeline.loc[
             self.timeline.temporal_market_shares.notnull()
         ]

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -87,6 +87,9 @@ class TimexLCA:
             'my_background_database_one': datetime.strptime("2020", "%Y"),
             'my_background_database_two': datetime.strptime("2030", "%Y"),
             'my_background_database_three': datetime.strptime("2040", "%Y"),
+            # Several databases may share the same date, e.g. to keep your own
+            # modified copies of background processes in their own database:
+            'my_modified_background_2020': datetime.strptime("2020", "%Y"),
             'my_foreground_database':'dynamic'
         }
     >>> tlca = TimexLCA(demand, method, database_dates)
@@ -120,7 +123,10 @@ class TimexLCA:
                 Tuple defining the LCIA method, such as `('foo', 'bar')` or default methods, such as
                 `("EF v3.1", "climate change", "global warming potential (GWP100)")`
         database_dates : dict, optional
-                Dictionary mapping database names to dates.
+                Dictionary mapping database names to dates. Several databases may
+                share the same date, e.g. to keep your own modified copies of
+                background processes in their own database instead of writing
+                them into the shared background database for that vintage.
         use_global_lci_cache : bool, optional
                 If True (default), background unit LCI matrices are cached at
                 module level and reused across `TimexLCA` objects within the

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -1526,6 +1526,9 @@ class TimexLCA:
         # The timeline builder already resolved every temporal-market producer to
         # its counterparts while computing the market shares. Reuse that instead
         # of scanning every background node a second time.
+        # The builder's scan is scoped to static databases only; this is inert
+        # because the mapping is only ever queried for static db names (drawn
+        # from temporal_market_shares in the timeline, which excludes foreground).
         matches = getattr(self.timeline_builder, "market_producer_matches", None)
         if matches:
             self.interdatabase_activity_mapping.update(matches)

--- a/docs/content/getting_started/adding_temporal_information.md
+++ b/docs/content/getting_started/adding_temporal_information.md
@@ -270,6 +270,34 @@ database_dates = {
 You can use whatever data source you want for the time-specific process data. A nice package from the Brightway cosmos that can help you is [premise](https://premise.readthedocs.io/en/latest/introduction.html).
 :::
 
+### Several databases for the same point in time
+
+More than one database may carry the same date. This is useful when you modify
+background processes: keep the modified copies in your own database per point in
+time, instead of writing them into ecoinvent or premise.
+
+```python
+database_dates = {
+    "ecoinvent_2020": datetime.strptime("2020", "%Y"),
+    "ecoinvent_2030": datetime.strptime("2030", "%Y"),
+    "my_background_2020": datetime.strptime("2020", "%Y"),  # your modified copies
+    "my_background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+```
+
+For each process, `bw_timex` interpolates only between the databases that actually
+contain it, matched on `name`, `reference product` and `location`. A copy that only
+exists in `my_background_2020` and `my_background_2030` is therefore sourced from
+those two, while an untouched process is sourced from the `ecoinvent_*` ones.
+
+!!! warning
+
+    Give your copies a distinct `name`, `reference product` or `location`. If the
+    same triplet occurs in two databases that share a date, `bw_timex` cannot tell
+    which one you mean and raises an error. A process that exists in only some of
+    the points in time is used unchanged for all of them, and logs a warning.
+
 ## Temporal evolution of foreground exchanges (`bw_timex>0.3.4`)
 
 The approaches above handle temporal variation in the *background* system — different database snapshots for different points in time. But what if a *foreground* exchange itself changes over time? For example, an industrial process might become more energy-efficient over the years, so its electricity consumption per unit of output decreases.

--- a/docs/content/getting_started/adding_temporal_information.md
+++ b/docs/content/getting_started/adding_temporal_information.md
@@ -295,8 +295,10 @@ those two, while an untouched process is sourced from the `ecoinvent_*` ones.
 
     Give your copies a distinct `name`, `reference product` or `location`. If the
     same triplet occurs in two databases that share a date, `bw_timex` cannot tell
-    which one you mean and raises an error. A process that exists in only some of
-    the points in time is used unchanged for all of them, and logs a warning.
+    which one you mean and raises an error. A process that exists at only some of
+    the points in time is sourced from the ones it does exist at: it is interpolated
+    between those, or — if it exists at only one of them — used unchanged for every
+    point in time. Either way, `bw_timex` logs a warning naming the databases it used.
 
 ## Temporal evolution of foreground exchanges (`bw_timex>0.3.4`)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,11 @@ from .fixtures.nonunitary_db_fixture import nonunitary_db
 from .fixtures.process_at_base_database_time_db_fixture import (
     process_at_base_database_time_db,
 )
-from .fixtures.same_date_databases_fixture import same_date_db, same_date_deep_db
+from .fixtures.same_date_databases_fixture import (
+    same_date_db,
+    same_date_db_three_dates,
+    same_date_deep_db,
+)
 from .fixtures.substitution_db_fixture import substitution_db
 from .fixtures.temporal_grouping_fixture import (
     temporal_grouping_db_daily,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from .fixtures.nonunitary_db_fixture import nonunitary_db
 from .fixtures.process_at_base_database_time_db_fixture import (
     process_at_base_database_time_db,
 )
-from .fixtures.same_date_databases_fixture import same_date_db
+from .fixtures.same_date_databases_fixture import same_date_db, same_date_deep_db
 from .fixtures.substitution_db_fixture import substitution_db
 from .fixtures.temporal_grouping_fixture import (
     temporal_grouping_db_daily,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from .fixtures.nonunitary_db_fixture import nonunitary_db
 from .fixtures.process_at_base_database_time_db_fixture import (
     process_at_base_database_time_db,
 )
+from .fixtures.same_date_databases_fixture import same_date_db
 from .fixtures.substitution_db_fixture import substitution_db
 from .fixtures.temporal_grouping_fixture import (
     temporal_grouping_db_daily,

--- a/tests/fixtures/same_date_databases_fixture.py
+++ b/tests/fixtures/same_date_databases_fixture.py
@@ -19,9 +19,15 @@ def _write_same_date_databases(with_background_chain: bool = False):
     electricity 10 (2020) / 5 (2030), steel 20 (2020) / 10 (2030).
 
     With `with_background_chain=True`, each modified database also holds a
-    `smelting` process that the copy consumes through a temporal distribution.
-    It exists only in the modified family and is reached only when the
-    background is traversed.
+    `smelting` process that the copy consumes through a temporal distribution,
+    and `smelting` in turn consumes a `coke` process via a plain technosphere
+    edge. Both exist only in the modified family and are reached only when the
+    background is traversed. `smelting` having its own technosphere input
+    (`coke`) matters: `_emit_variant_split` only splits a producer that itself
+    has further technosphere inputs, so without `coke`, `smelting` would be a
+    technosphere dead end and never reach the per-node routing code at all —
+    it would fall through as an ordinary background leaf, resolved entirely by
+    `TimelineBuilder`'s (already-correct) temporal-market logic instead.
     """
     biosphere = bd.Database("biosphere")
     biosphere.write({("biosphere", "CO2"): {"type": "emission", "name": "carbon dioxide"}})
@@ -31,6 +37,7 @@ def _write_same_date_databases(with_background_chain: bool = False):
         "background_2020": {"electricity": 10, "steel": 20},
         "background_2030": {"electricity": 5, "steel": 10},
     }
+    coke_co2_amounts = {"2020": 30, "2030": 15}
 
     for year in ("2020", "2030"):
         background = bd.Database(f"background_{year}")
@@ -89,6 +96,23 @@ def _write_same_date_databases(with_background_chain: bool = False):
             )
             copy_to_smelting.save()
 
+            # `smelting`'s own technosphere input, so the split guard
+            # (`producer has technosphere inputs`) is satisfied and `smelting`
+            # is resolved to its candidate databases via
+            # `_candidate_databases_for_node` rather than falling through as a
+            # technosphere-dead-end leaf.
+            coke = modified.new_node("coke", name="coke", unit="kg")
+            coke["reference product"] = "coke"
+            coke["location"] = "GLO"
+            coke.save()
+            coke.new_edge(input=coke, amount=1, type="production").save()
+            coke.new_edge(
+                input=node_co2,
+                amount=coke_co2_amounts[year],
+                type="biosphere",
+            ).save()
+            smelting.new_edge(input=coke, amount=1, type="technosphere").save()
+
     foreground = bd.Database("foreground")
     foreground.register()
     fu = foreground.new_node("fu", name="fu", unit="unit")
@@ -121,5 +145,6 @@ def same_date_db():
 @pytest.fixture
 @bw2test
 def same_date_deep_db():
-    """Same as `same_date_db`, plus a `smelting` chain in the modified family."""
+    """Same as `same_date_db`, plus a `smelting` -> `coke` chain in the
+    modified family."""
     _write_same_date_databases(with_background_chain=True)

--- a/tests/fixtures/same_date_databases_fixture.py
+++ b/tests/fixtures/same_date_databases_fixture.py
@@ -5,8 +5,10 @@ from bw2data.tests import bw2test
 from bw_temporalis import TemporalDistribution
 
 
-def _write_same_date_databases(with_background_chain: bool = False):
-    """Write four static background databases on two dates.
+def _write_same_date_databases(
+    with_background_chain: bool = False, years: tuple[str, ...] = ("2020", "2030")
+):
+    """Write static background databases on the given dates (two by default).
 
     `background_2020` / `background_2030` hold an untouched `electricity`
     process. `modified_2020` / `modified_2030` hold a copy of `steel` with its
@@ -16,7 +18,11 @@ def _write_same_date_databases(with_background_chain: bool = False):
     own family of databases.
 
     CO2 amounts differ per vintage so the interpolation is visible in the score:
-    electricity 10 (2020) / 5 (2030), steel 20 (2020) / 10 (2030).
+    electricity 10 (2020) / 5 (2030) / 2 (2040), steel 20 (2020) / 10 (2030) /
+    5 (2040). Passing a third year via `years` (e.g. `("2020", "2030",
+    "2040")`) writes a third `background_*` / `modified_*` pair without
+    touching the amounts used by the two-year fixtures, whose scores other
+    tests assert.
 
     With `with_background_chain=True`, each modified database also holds a
     `smelting` process that the copy consumes through a temporal distribution,
@@ -34,12 +40,13 @@ def _write_same_date_databases(with_background_chain: bool = False):
     node_co2 = biosphere.get("CO2")
 
     amounts = {
-        "background_2020": {"electricity": 10, "steel": 20},
-        "background_2030": {"electricity": 5, "steel": 10},
+        "2020": {"electricity": 10, "steel": 20},
+        "2030": {"electricity": 5, "steel": 10},
+        "2040": {"electricity": 2, "steel": 5},
     }
-    coke_co2_amounts = {"2020": 30, "2030": 15}
+    coke_co2_amounts = {"2020": 30, "2030": 15, "2040": 8}
 
-    for year in ("2020", "2030"):
+    for year in years:
         background = bd.Database(f"background_{year}")
         background.register()
         modified = bd.Database(f"modified_{year}")
@@ -52,7 +59,7 @@ def _write_same_date_databases(with_background_chain: bool = False):
         electricity.new_edge(input=electricity, amount=1, type="production").save()
         electricity.new_edge(
             input=node_co2,
-            amount=amounts[f"background_{year}"]["electricity"],
+            amount=amounts[year]["electricity"],
             type="biosphere",
         ).save()
 
@@ -63,7 +70,7 @@ def _write_same_date_databases(with_background_chain: bool = False):
         steel.new_edge(input=steel, amount=1, type="production").save()
         steel.new_edge(
             input=node_co2,
-            amount=amounts[f"background_{year}"]["steel"],
+            amount=amounts[year]["steel"],
             type="biosphere",
         ).save()
 
@@ -83,7 +90,7 @@ def _write_same_date_databases(with_background_chain: bool = False):
             smelting.new_edge(input=smelting, amount=1, type="production").save()
             smelting.new_edge(
                 input=node_co2,
-                amount=amounts[f"background_{year}"]["steel"],
+                amount=amounts[year]["steel"],
                 type="biosphere",
             ).save()
 
@@ -148,3 +155,12 @@ def same_date_deep_db():
     """Same as `same_date_db`, plus a `smelting` -> `coke` chain in the
     modified family."""
     _write_same_date_databases(with_background_chain=True)
+
+
+@pytest.fixture
+@bw2test
+def same_date_db_three_dates():
+    """Same as `same_date_db`, but with a third `2040` vintage in each
+    family, so partial-coverage interpolation across more than two
+    candidate dates can be exercised."""
+    _write_same_date_databases(years=("2020", "2030", "2040"))

--- a/tests/fixtures/same_date_databases_fixture.py
+++ b/tests/fixtures/same_date_databases_fixture.py
@@ -1,12 +1,12 @@
 import bw2data as bd
+import numpy as np
 import pytest
 from bw2data.tests import bw2test
+from bw_temporalis import TemporalDistribution
 
 
-@pytest.fixture
-@bw2test
-def same_date_db():
-    """Four static background databases on two dates.
+def _write_same_date_databases(with_background_chain: bool = False):
+    """Write four static background databases on two dates.
 
     `background_2020` / `background_2030` hold an untouched `electricity`
     process. `modified_2020` / `modified_2030` hold a copy of `steel` with its
@@ -17,6 +17,11 @@ def same_date_db():
 
     CO2 amounts differ per vintage so the interpolation is visible in the score:
     electricity 10 (2020) / 5 (2030), steel 20 (2020) / 10 (2030).
+
+    With `with_background_chain=True`, each modified database also holds a
+    `smelting` process that the copy consumes through a temporal distribution.
+    It exists only in the modified family and is reached only when the
+    background is traversed.
     """
     biosphere = bd.Database("biosphere")
     biosphere.write({("biosphere", "CO2"): {"type": "emission", "name": "carbon dioxide"}})
@@ -61,6 +66,29 @@ def same_date_db():
         steel_copy["reference product"] = "steel, without EOL"
         steel_copy.save()
 
+        if with_background_chain:
+            # Reached only by descending into the background. The 10-year offset
+            # pushes it towards the 2030 vintage of the modified family.
+            smelting = modified.new_node("smelting", name="smelting", unit="kg")
+            smelting["reference product"] = "smelting"
+            smelting["location"] = "GLO"
+            smelting.save()
+            smelting.new_edge(input=smelting, amount=1, type="production").save()
+            smelting.new_edge(
+                input=node_co2,
+                amount=amounts[f"background_{year}"]["steel"],
+                type="biosphere",
+            ).save()
+
+            copy_to_smelting = steel_copy.new_edge(
+                input=smelting, amount=1, type="technosphere"
+            )
+            copy_to_smelting["temporal_distribution"] = TemporalDistribution(
+                date=np.array([10], dtype="timedelta64[Y]"),
+                amount=np.array([1.0]),
+            )
+            copy_to_smelting.save()
+
     foreground = bd.Database("foreground")
     foreground.register()
     fu = foreground.new_node("fu", name="fu", unit="unit")
@@ -81,3 +109,17 @@ def same_date_db():
 
     for dbname in bd.databases:
         bd.Database(dbname).process()
+
+
+@pytest.fixture
+@bw2test
+def same_date_db():
+    """Four static background databases on two dates, no background chain."""
+    _write_same_date_databases()
+
+
+@pytest.fixture
+@bw2test
+def same_date_deep_db():
+    """Same as `same_date_db`, plus a `smelting` chain in the modified family."""
+    _write_same_date_databases(with_background_chain=True)

--- a/tests/fixtures/same_date_databases_fixture.py
+++ b/tests/fixtures/same_date_databases_fixture.py
@@ -1,0 +1,83 @@
+import bw2data as bd
+import pytest
+from bw2data.tests import bw2test
+
+
+@pytest.fixture
+@bw2test
+def same_date_db():
+    """Four static background databases on two dates.
+
+    `background_2020` / `background_2030` hold an untouched `electricity`
+    process. `modified_2020` / `modified_2030` hold a copy of `steel` with its
+    end-of-life removed, named `steel, without EOL`; they carry the *same*
+    dates as the two `background_*` databases. The foreground consumes one of
+    each, so both must become temporal markets that interpolate within their
+    own family of databases.
+
+    CO2 amounts differ per vintage so the interpolation is visible in the score:
+    electricity 10 (2020) / 5 (2030), steel 20 (2020) / 10 (2030).
+    """
+    biosphere = bd.Database("biosphere")
+    biosphere.write({("biosphere", "CO2"): {"type": "emission", "name": "carbon dioxide"}})
+    node_co2 = biosphere.get("CO2")
+
+    amounts = {
+        "background_2020": {"electricity": 10, "steel": 20},
+        "background_2030": {"electricity": 5, "steel": 10},
+    }
+
+    for year in ("2020", "2030"):
+        background = bd.Database(f"background_{year}")
+        background.register()
+        modified = bd.Database(f"modified_{year}")
+        modified.register()
+
+        electricity = background.new_node("electricity", name="electricity", unit="kWh")
+        electricity["reference product"] = "electricity"
+        electricity["location"] = "GLO"
+        electricity.save()
+        electricity.new_edge(input=electricity, amount=1, type="production").save()
+        electricity.new_edge(
+            input=node_co2,
+            amount=amounts[f"background_{year}"]["electricity"],
+            type="biosphere",
+        ).save()
+
+        steel = background.new_node("steel", name="steel", unit="kg")
+        steel["reference product"] = "steel"
+        steel["location"] = "GLO"
+        steel.save()
+        steel.new_edge(input=steel, amount=1, type="production").save()
+        steel.new_edge(
+            input=node_co2,
+            amount=amounts[f"background_{year}"]["steel"],
+            type="biosphere",
+        ).save()
+
+        # The study's own copy of `steel`, without EOL, in its own database.
+        steel_copy = steel.copy(code="steel_without_eol", database=f"modified_{year}")
+        steel_copy["name"] = "steel, without EOL"
+        steel_copy["reference product"] = "steel, without EOL"
+        steel_copy.save()
+
+    foreground = bd.Database("foreground")
+    foreground.register()
+    fu = foreground.new_node("fu", name="fu", unit="unit")
+    fu["reference product"] = "fu"
+    fu["location"] = "GLO"
+    fu.save()
+    fu.new_edge(input=fu, amount=1, type="production").save()
+    fu.new_edge(
+        input=bd.Database("background_2020").get("electricity"), amount=1, type="technosphere"
+    ).save()
+    fu.new_edge(
+        input=bd.Database("modified_2020").get("steel_without_eol"),
+        amount=1,
+        type="technosphere",
+    ).save()
+
+    bd.Method(("GWP", "example")).write([(("biosphere", "CO2"), 1)])
+
+    for dbname in bd.databases:
+        bd.Database(dbname).process()

--- a/tests/test_same_date_databases.py
+++ b/tests/test_same_date_databases.py
@@ -81,8 +81,25 @@ def test_producer_in_a_single_vintage_warns_and_is_time_invariant(same_date_db):
 
 
 def test_background_traversal_routes_within_the_modified_family(same_date_deep_db):
-    """Descending into the background must not confuse same-date databases."""
-    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    """Descending into the background must not confuse same-date databases.
+
+    ``database_dates`` is given with the ``modified_*`` entries FIRST here
+    (unlike ``DATABASE_DATES`` above), so that a routing bug which resolves a
+    cohort date through a global, insertion-order-dependent ``{date:
+    database}`` inversion would pick ``background_*`` — the wrong family for
+    ``smelting``/``coke``, which exist only under ``modified_*`` — instead of
+    coincidentally landing on the right family. With the ordering used by the
+    other tests in this file, that same bug happens to resolve to the right
+    family by accident and this test would not catch it.
+    """
+    database_dates = {
+        "modified_2020": datetime.strptime("2020", "%Y"),
+        "modified_2030": datetime.strptime("2030", "%Y"),
+        "background_2020": datetime.strptime("2020", "%Y"),
+        "background_2030": datetime.strptime("2030", "%Y"),
+        "foreground": "dynamic",
+    }
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, database_dates)
     tlca.build_timeline(
         starting_datetime="2025-01-01",
         graph_traversal="bfs",
@@ -101,3 +118,38 @@ def test_background_traversal_routes_within_the_modified_family(same_date_deep_d
     tlca.lci()
     tlca.static_lcia()
     assert tlca.static_score > 0
+
+
+def test_background_traversal_same_triplet_at_same_date_raises(same_date_deep_db):
+    """A same-date, same-triplet collision reached only through background
+    descent must still raise loudly.
+
+    `smelting` is resolved to its candidate databases via
+    `_candidate_databases_for_node` (it is the node whose split the `coke`
+    input in `same_date_deep_db` was added to trigger — see that fixture's
+    docstring), not via `TimelineBuilder`'s temporal-market leaf logic. The
+    collision here is wired into `background_2020` only, never into the
+    foreground, so it is invisible to anything except the interdatabase
+    mapping the extractor consults mid-descent. Matching on
+    "cannot tell which one to use" (rather than the more generic "more than
+    one database", used by `test_same_triplet_at_same_date_raises` above) is
+    what pins this down to `_candidate_databases_for_node`'s wording
+    specifically, as opposed to `TimelineBuilder.candidate_databases_for_producers`'s
+    similarly-worded but distinct "...its temporal market should use" message.
+    """
+    collision = bd.Database("background_2020").new_node(
+        "smelting_collision", name="smelting", unit="kg"
+    )
+    collision["reference product"] = "smelting"
+    collision["location"] = "GLO"
+    collision.save()
+    collision.new_edge(input=collision, amount=1, type="production").save()
+    bd.Database("background_2020").process()
+
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    with pytest.raises(ValueError, match="cannot tell which one to use"):
+        tlca.build_timeline(
+            starting_datetime="2025-01-01",
+            graph_traversal="bfs",
+            traverse_background=True,
+        )

--- a/tests/test_same_date_databases.py
+++ b/tests/test_same_date_databases.py
@@ -1,0 +1,80 @@
+"""Several static background databases may share the same date."""
+
+from datetime import datetime
+
+import bw2data as bd
+import pytest
+from loguru import logger
+
+from bw_timex import TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "modified_2020": datetime.strptime("2020", "%Y"),
+    "modified_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+
+
+def _shares_by_producer(timeline):
+    return {
+        row.producer_name: row.temporal_market_shares
+        for row in timeline.itertuples()
+        if row.temporal_market_shares
+    }
+
+
+def test_shares_route_within_each_database_family(same_date_db):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2025-01-01")
+    shares = _shares_by_producer(tlca.timeline)
+
+    assert set(shares["electricity"]) == {"background_2020", "background_2030"}
+    assert set(shares["steel, without EOL"]) == {"modified_2020", "modified_2030"}
+    assert shares["electricity"]["background_2020"] == pytest.approx(0.5, abs=0.01)
+    assert shares["steel, without EOL"]["modified_2020"] == pytest.approx(0.5, abs=0.01)
+
+
+def test_score_interpolates_within_each_family(same_date_db):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2025-01-01")
+    tlca.lci()
+    tlca.static_lcia()
+    # electricity: 0.5*10 + 0.5*5 = 7.5; steel: 0.5*20 + 0.5*10 = 15
+    assert tlca.static_score == pytest.approx(22.5, abs=0.2)
+
+
+def test_same_triplet_at_same_date_raises(same_date_db):
+    """A copy that keeps name/reference product/location is ambiguous."""
+    collision = bd.Database("modified_2020").new_node(
+        "electricity_collision", name="electricity", unit="kWh"
+    )
+    collision["reference product"] = "electricity"
+    collision["location"] = "GLO"
+    collision.save()
+    collision.new_edge(input=collision, amount=1, type="production").save()
+    bd.Database("modified_2020").process()
+
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    with pytest.raises(ValueError, match="more than one database"):
+        tlca.build_timeline(starting_datetime="2025-01-01")
+
+
+def test_producer_in_a_single_vintage_warns_and_is_time_invariant(same_date_db):
+    """A copy made into only one vintage stays constant over time, with a warning."""
+    bd.Database("modified_2030").get("steel_without_eol").delete()
+    bd.Database("modified_2030").process()
+
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+        tlca.build_timeline(starting_datetime="2025-01-01")
+    finally:
+        logger.remove(sink_id)
+
+    shares = _shares_by_producer(tlca.timeline)
+    assert shares["steel, without EOL"] == {"modified_2020": 1}
+    assert any("steel, without EOL" in message for message in messages)

--- a/tests/test_same_date_databases.py
+++ b/tests/test_same_date_databases.py
@@ -78,3 +78,26 @@ def test_producer_in_a_single_vintage_warns_and_is_time_invariant(same_date_db):
     shares = _shares_by_producer(tlca.timeline)
     assert shares["steel, without EOL"] == {"modified_2020": 1}
     assert any("steel, without EOL" in message for message in messages)
+
+
+def test_background_traversal_routes_within_the_modified_family(same_date_deep_db):
+    """Descending into the background must not confuse same-date databases."""
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2025-01-01",
+        graph_traversal="bfs",
+        traverse_background=True,
+    )
+    producers = set(tlca.timeline["producer_name"])
+    assert "smelting" in producers
+
+    # `smelting` exists only in the modified family, so no background_* database
+    # may be picked up for it.
+    smelting_rows = tlca.timeline[tlca.timeline["producer_name"] == "smelting"]
+    for shares in smelting_rows["temporal_market_shares"]:
+        if shares:
+            assert set(shares) <= {"modified_2020", "modified_2030"}
+
+    tlca.lci()
+    tlca.static_lcia()
+    assert tlca.static_score > 0

--- a/tests/test_same_date_databases.py
+++ b/tests/test_same_date_databases.py
@@ -130,12 +130,16 @@ def test_background_traversal_same_triplet_at_same_date_raises(same_date_deep_db
     docstring), not via `TimelineBuilder`'s temporal-market leaf logic. The
     collision here is wired into `background_2020` only, never into the
     foreground, so it is invisible to anything except the interdatabase
-    mapping the extractor consults mid-descent. Matching on
-    "cannot tell which one to use" (rather than the more generic "more than
-    one database", used by `test_same_triplet_at_same_date_raises` above) is
-    what pins this down to `_candidate_databases_for_node`'s wording
-    specifically, as opposed to `TimelineBuilder.candidate_databases_for_producers`'s
-    similarly-worded but distinct "...its temporal market should use" message.
+    mapping the extractor consults mid-descent.
+
+    The assertion pins this down to `_candidate_databases_for_node`
+    specifically (rather than `TimelineBuilder.candidate_databases_for_producers`,
+    exercised by `test_same_triplet_at_same_date_raises` above) by matching on
+    the node identity `_candidate_databases_for_node` includes in its message
+    — name, reference product AND location — which only that path renders;
+    `TimelineBuilder`'s equivalent message names only the producer, not its
+    full triplet. This is about what's IN the message (the node under test),
+    not incidental differences in how the two messages are worded.
     """
     collision = bd.Database("background_2020").new_node(
         "smelting_collision", name="smelting", unit="kg"
@@ -147,12 +151,88 @@ def test_background_traversal_same_triplet_at_same_date_raises(same_date_deep_db
     bd.Database("background_2020").process()
 
     tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
-    with pytest.raises(ValueError, match="cannot tell which one to use"):
+    with pytest.raises(
+        ValueError,
+        match=r"'smelting' \(reference product: 'smelting', location: 'GLO'\)",
+    ):
         tlca.build_timeline(
             starting_datetime="2025-01-01",
             graph_traversal="bfs",
             traverse_background=True,
         )
+
+
+def test_partial_coverage_across_three_dates_interpolates_over_available(
+    same_date_db_three_dates,
+):
+    """A producer present at two of three configured points in time must
+    interpolate over the two it has, not collapse to a single candidate."""
+    bd.Database("modified_2040").get("steel_without_eol").delete()
+    bd.Database("modified_2040").process()
+
+    database_dates = {
+        "background_2020": datetime.strptime("2020", "%Y"),
+        "background_2030": datetime.strptime("2030", "%Y"),
+        "background_2040": datetime.strptime("2040", "%Y"),
+        "modified_2020": datetime.strptime("2020", "%Y"),
+        "modified_2030": datetime.strptime("2030", "%Y"),
+        "modified_2040": datetime.strptime("2040", "%Y"),
+        "foreground": "dynamic",
+    }
+
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, database_dates)
+        tlca.build_timeline(starting_datetime="2025-01-01")
+    finally:
+        logger.remove(sink_id)
+
+    shares = _shares_by_producer(tlca.timeline)
+    assert set(shares["steel, without EOL"]) == {"modified_2020", "modified_2030"}
+    assert shares["steel, without EOL"]["modified_2020"] == pytest.approx(0.5, abs=0.01)
+    assert any("steel, without EOL" in message for message in messages)
+
+
+def test_nearest_interpolation_stays_within_each_family(same_date_db):
+    """`interpolation_type="nearest"` must resolve each temporal market from
+    within its own family of same-date databases, exercising the `nearest`
+    branch of the per-producer loop with more than one database family
+    present at once."""
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2025-01-01", interpolation_type="nearest")
+    shares = _shares_by_producer(tlca.timeline)
+
+    assert shares["electricity"] in ({"background_2020": 1}, {"background_2030": 1})
+    assert shares["steel, without EOL"] in (
+        {"modified_2020": 1},
+        {"modified_2030": 1},
+    )
+
+
+def test_background_traversal_partial_coverage_warns(same_date_deep_db):
+    """A node reached mid-descent that exists in only one vintage of its
+    family must still trigger the partial-coverage warning, just like a
+    leaf temporal market does (`test_producer_in_a_single_vintage_warns_and_is_time_invariant`
+    above). Without this, a node pinned to a single vintage during background
+    traversal is silently pinned with no warning at all.
+    """
+    bd.Database("modified_2030").get("smelting").delete()
+    bd.Database("modified_2030").process()
+
+    messages = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+        tlca.build_timeline(
+            starting_datetime="2025-01-01",
+            graph_traversal="bfs",
+            traverse_background=True,
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert any("smelting" in message for message in messages)
 
 
 def test_interdatabase_mapping_is_filled_by_the_timeline_builder(same_date_db):

--- a/tests/test_same_date_databases.py
+++ b/tests/test_same_date_databases.py
@@ -176,3 +176,40 @@ def test_interdatabase_mapping_is_filled_by_the_timeline_builder(same_date_db):
     # The copy has no counterpart in the untouched family, and none is invented.
     with pytest.raises(KeyError):
         tlca.interdatabase_activity_mapping.find_match(steel_copy_2020.id, "background_2030")
+
+
+def test_foreground_triplet_collision_does_not_affect_timeline_results(same_date_db):
+    """A foreground node with a triplet collision is not added to the mapping.
+
+    The optimized path reuses only static background database matches,
+    deliberately excluding any foreground/dynamic databases. This test verifies
+    that omitting a foreground triplet collision is inert: the foreground node is
+    never queried through the mapping (only static db names are looked up), so
+    the score and temporal market shares remain unchanged.
+    """
+    # Add a foreground node with the same (name, reference product, location)
+    # as a background market producer.
+    fg_collision = bd.Database("foreground").new_node(
+        "electricity_fg_collision", name="electricity", unit="kWh"
+    )
+    fg_collision["reference product"] = "electricity"
+    fg_collision["location"] = "GLO"
+    fg_collision.save()
+    fg_collision.new_edge(input=fg_collision, amount=1, type="production").save()
+    bd.Database("foreground").process()
+
+    # Build timeline and compute results.
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2025-01-01")
+
+    # Verify the mapping only holds background databases (not the foreground).
+    shares = tlca.timeline.loc[
+        tlca.timeline["producer_name"] == "electricity", "temporal_market_shares"
+    ].iloc[0]
+    assert set(shares.keys()) == {"background_2020", "background_2030"}
+
+    # Compute LCA and verify the results are unaffected by the foreground collision.
+    tlca.lci()
+    tlca.static_lcia()
+    # electricity: 0.5*10 + 0.5*5 = 7.5; steel: 0.5*20 + 0.5*10 = 15
+    assert tlca.static_score == pytest.approx(22.5, abs=0.2)

--- a/tests/test_same_date_databases.py
+++ b/tests/test_same_date_databases.py
@@ -153,3 +153,26 @@ def test_background_traversal_same_triplet_at_same_date_raises(same_date_deep_db
             graph_traversal="bfs",
             traverse_background=True,
         )
+
+
+def test_interdatabase_mapping_is_filled_by_the_timeline_builder(same_date_db):
+    """The builder's triplet scan feeds the mapping; no second scan is needed."""
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2025-01-01")
+
+    steel_copy_2020 = bd.Database("modified_2020").get("steel_without_eol")
+    steel_copy_2030 = bd.Database("modified_2030").get("steel_without_eol")
+    assert (
+        tlca.interdatabase_activity_mapping.find_match(steel_copy_2020.id, "modified_2030")
+        == steel_copy_2030.id
+    )
+
+    electricity_2020 = bd.Database("background_2020").get("electricity")
+    electricity_2030 = bd.Database("background_2030").get("electricity")
+    assert (
+        tlca.interdatabase_activity_mapping.find_match(electricity_2020.id, "background_2030")
+        == electricity_2030.id
+    )
+    # The copy has no counterpart in the untouched family, and none is invented.
+    with pytest.raises(KeyError):
+        tlca.interdatabase_activity_mapping.find_match(steel_copy_2020.id, "background_2030")


### PR DESCRIPTION
## What

`database_dates` maps each background database to the point in time it represents. Internally the mapping was inverted into `{date: database}` in two places, so two databases sharing a date collapsed into one. That forced users to keep modified copies of background processes inside the ecoinvent/premise database they were copied from.

Several databases may now share a date:

```python
database_dates = {
    "ecoinvent_2020": datetime(2020, 1, 1),
    "ecoinvent_2030": datetime(2030, 1, 1),
    "my_background_2020": datetime(2020, 1, 1),   # your modified copies
    "my_background_2030": datetime(2030, 1, 1),
    "foreground": "dynamic",
}
```

No API change — duplicate values were always syntactically valid, they just broke internally.

## How

Temporal market shares resolve **per producer** instead of per date. A producer's candidate databases are the static databases containing a `(name, reference product, location)` match for it, and interpolation runs over the dates of those candidates only. A copy that exists only in `my_background_*` interpolates over those; an untouched process interpolates over the `ecoinvent_*` ones. No configuration needed for either.

- `TimelineBuilder.candidate_databases_for_producers` replaces the global `reversed_database_dates` inversion.
- `VariantSplitMixin._candidate_databases_for_node` does the same for the `traverse_background=True` descent, which had its own inversion.
- The same triplet in two databases sharing a date raises `ValueError` naming the process and both databases, rather than silently picking one. The remedy is a distinct name/reference product/location, or dropping one of the two databases from `database_dates`.
- A process present at only some of the points in time is sourced from the ones it does exist at, with a warning naming the databases used.
- `TimexLCA.add_interdatabase_activity_mapping_from_timeline` now reuses the matches the timeline builder already resolved instead of repeating the same scan over the background.

## Tests

11 new tests in `tests/test_same_date_databases.py` over two fixtures with two same-date database families: routing within each family, score interpolation, the ambiguity error on both code paths, partial coverage (collapsing to one vintage and interpolating over two of three), `interpolation_type="nearest"` with multiple families, background traversal, and the foreground-triplet-collision case. Full suite: 245 passed.

## Docs

`docs/content/getting_started/adding_temporal_information.md` gains a section on databases sharing a point in time, and the `database_dates` API docs mention it.