### PR TITLE
Expose a flat top-level bw_timex namespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Added a flat top-level namespace: `TemporalDistribution`, `easy_timedelta_distribution` and `easy_datetime_distribution` are re-exported from `bw_temporalis`, and the user-facing helpers from `bw_timex.utils` (`add_temporal_distribution_to_exchange`, `add_temporal_evolution_to_exchange`, `add_flows_to_characterization_functions`, `get_exchange`, `get_temporal_evolution_factor`, `interactive_td_widget`, `plot_characterized_inventory_as_waterfall`) are now importable directly from `bw_timex`
 * Fixed `lci()` raising `MultipleResults` when a temporalized process' code also exists in another database of the project, by resolving producers by node id instead of by code ([#203](https://github.com/brightway-lca/bw_timex/pull/203))
 * Fixed supply scaling in `lci(expand_technosphere=False)` for processes with a production amount other than 1, whose supplies were mis-scaled and, for negative production amounts (waste treatment), sign-flipped ([#200](https://github.com/brightway-lca/bw_timex/pull/200))
 * Fixed `temporal_market_lcis` being corrupted when several timeline rows share a time-mapped temporal market ([#200](https://github.com/brightway-lca/bw_timex/pull/200))

--- a/bw_timex/__init__.py
+++ b/bw_timex/__init__.py
@@ -1,3 +1,9 @@
+from bw_temporalis import (
+    TemporalDistribution,
+    easy_datetime_distribution,
+    easy_timedelta_distribution,
+)
+
 from ._lci_cache import clear_background_lci_cache
 from .dynamic_biosphere_builder import DynamicBiosphereBuilder
 from .edge_extractor import EdgeExtractor
@@ -6,9 +12,36 @@ from .matrix_modifier import MatrixModifier
 from .timeline_builder import TimelineBuilder
 from .timex_lca import TimexLCA
 from .utils import (
+    add_flows_to_characterization_functions,
     add_temporal_distribution_to_exchange,
     add_temporal_evolution_to_exchange,
+    get_exchange,
     get_temporal_evolution_factor,
+    interactive_td_widget,
+    plot_characterized_inventory_as_waterfall,
 )
 
 __version__ = "1.1.2"
+
+__all__ = [
+    # forwarded from bw_temporalis for convenience
+    "TemporalDistribution",
+    "easy_datetime_distribution",
+    "easy_timedelta_distribution",
+    # core classes
+    "TimexLCA",
+    "TimelineBuilder",
+    "MatrixModifier",
+    "DynamicBiosphereBuilder",
+    "EdgeExtractor",
+    "SetList",
+    # utils
+    "add_flows_to_characterization_functions",
+    "add_temporal_distribution_to_exchange",
+    "add_temporal_evolution_to_exchange",
+    "clear_background_lci_cache",
+    "get_exchange",
+    "get_temporal_evolution_factor",
+    "interactive_td_widget",
+    "plot_characterized_inventory_as_waterfall",
+]

--- a/docs/content/examples/example_electric_vehicle_premise.ipynb
+++ b/docs/content/examples/example_electric_vehicle_premise.ipynb
@@ -343,7 +343,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bw_temporalis import TemporalDistribution, easy_timedelta_distribution\n",
+    "from bw_timex import TemporalDistribution, easy_timedelta_distribution\n",
     "import numpy as np\n",
     "\n",
     "td_assembly_and_delivery = TemporalDistribution(\n",

--- a/docs/content/examples/example_simple_dynamic_characterization.ipynb
+++ b/docs/content/examples/example_simple_dynamic_characterization.ipynb
@@ -58,7 +58,7 @@
             "source": [
                 "import bw2data as bd\n",
                 "import numpy as np\n",
-                "from bw_temporalis import TemporalDistribution\n",
+                "from bw_timex import TemporalDistribution\n",
                 "\n",
                 "project_name = \"timex_example_dynamic_characterization\"\n",
                 "if project_name in bd.projects:\n",

--- a/docs/content/examples/paper_case_study.ipynb
+++ b/docs/content/examples/paper_case_study.ipynb
@@ -601,7 +601,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bw_temporalis import TemporalDistribution, easy_timedelta_distribution\n",
+    "from bw_timex import TemporalDistribution, easy_timedelta_distribution\n",
     "import numpy as np\n",
     "\n",
     "td_assembly_and_delivery = TemporalDistribution(\n",

--- a/docs/content/getting_started/adding_temporal_information.md
+++ b/docs/content/getting_started/adding_temporal_information.md
@@ -151,7 +151,7 @@ end
 
 ```python
 import numpy as np
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 from bw_timex.utils import add_temporal_distribution_to_exchange
 
 # Starting with the exchange between A and B

--- a/docs/content/theory.md
+++ b/docs/content/theory.md
@@ -54,7 +54,7 @@ Let's say we have two temporal distributions. The first dates 30% of some exchan
 
 ```python
 import numpy as np
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 two_and_four_years_ahead = TemporalDistribution(
     date=np.array([2, 4], dtype="timedelta64[Y]"),

--- a/notebooks/background_temporalization.ipynb
+++ b/notebooks/background_temporalization.ipynb
@@ -422,7 +422,7 @@
    ],
    "source": [
     "import numpy as np\n",
-    "from bw_temporalis import TemporalDistribution\n",
+    "from bw_timex import TemporalDistribution\n",
     "from bw_timex.utils import add_temporal_distribution_to_exchange\n",
     "\n",
     "td_c_to_b = TemporalDistribution(\n",

--- a/notebooks/background_temporalization_premise.ipynb
+++ b/notebooks/background_temporalization_premise.ipynb
@@ -169,7 +169,7 @@
     }
    ],
    "source": [
-    "from bw_temporalis import TemporalDistribution\n",
+    "from bw_timex import TemporalDistribution\n",
     "import numpy as np\n",
     "\n",
     "# the exchange P1 -> P2 (glider)\n",

--- a/notebooks/example_electric_vehicle_premise.ipynb
+++ b/notebooks/example_electric_vehicle_premise.ipynb
@@ -340,7 +340,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bw_temporalis import TemporalDistribution, easy_timedelta_distribution\n",
+    "from bw_timex import TemporalDistribution, easy_timedelta_distribution\n",
     "import numpy as np\n",
     "\n",
     "td_assembly_and_delivery = TemporalDistribution(\n",

--- a/notebooks/example_electric_vehicle_standalone.ipynb
+++ b/notebooks/example_electric_vehicle_standalone.ipynb
@@ -386,7 +386,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "from bw_temporalis import TemporalDistribution, easy_timedelta_distribution\n",
+                "from bw_timex import TemporalDistribution, easy_timedelta_distribution\n",
                 "import numpy as np\n",
                 "\n",
                 "td_assembly_and_delivery = TemporalDistribution(\n",

--- a/notebooks/example_simple_dynamic_characterization.ipynb
+++ b/notebooks/example_simple_dynamic_characterization.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import bw2data as bd\n",
     "import numpy as np\n",
-    "from bw_temporalis import TemporalDistribution\n",
+    "from bw_timex import TemporalDistribution\n",
     "\n",
     "project_name = \"timex_example_dynamic_characterization\"\n",
     "if project_name in bd.projects:\n",

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -423,7 +423,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from bw_temporalis import TemporalDistribution\n",
+    "from bw_timex import TemporalDistribution\n",
     "\n",
     "td_b_to_a = TemporalDistribution(\n",
     "    date=np.array([-2, 0, 4], dtype=\"timedelta64[Y]\"),\n",

--- a/notebooks/paper_case_study.ipynb
+++ b/notebooks/paper_case_study.ipynb
@@ -606,7 +606,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bw_temporalis import TemporalDistribution, easy_timedelta_distribution\n",
+    "from bw_timex import TemporalDistribution, easy_timedelta_distribution\n",
     "import numpy as np\n",
     "\n",
     "td_assembly_and_delivery = TemporalDistribution(\n",

--- a/notebooks/run_time_test_benchmarking.ipynb
+++ b/notebooks/run_time_test_benchmarking.ipynb
@@ -37,7 +37,7 @@
     "import numpy as np\n",
     "import bw2data as bd\n",
     "\n",
-    "from bw_temporalis import TemporalDistribution\n",
+    "from bw_timex import TemporalDistribution\n",
     "from datetime import datetime\n",
     "\n",
     "from cProfile import Profile\n",

--- a/notebooks/teaching/teaching_example_ev_premise.ipynb
+++ b/notebooks/teaching/teaching_example_ev_premise.ipynb
@@ -280,7 +280,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bw_temporalis import TemporalDistribution\n",
+    "from bw_timex import TemporalDistribution\n",
     "import numpy as np\n",
     "\n",
     "td_car_without_battery_production = TemporalDistribution(\n",
@@ -307,7 +307,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bw_temporalis import easy_timedelta_distribution\n",
+    "from bw_timex import easy_timedelta_distribution\n",
     "\n",
     "td_battery_production = easy_timedelta_distribution(\n",
     "    start=-9,\n",

--- a/notebooks/teaching/teaching_project_electric_vs_petrol_vehicle_premise.ipynb
+++ b/notebooks/teaching/teaching_project_electric_vs_petrol_vehicle_premise.ipynb
@@ -337,7 +337,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "from bw_temporalis import TemporalDistribution, easy_timedelta_distribution\n",
+    "from bw_timex import TemporalDistribution, easy_timedelta_distribution\n",
     "from bw_timex.utils import add_temporal_distribution_to_exchange"
    ]
   },

--- a/notebooks/teaching/teaching_project_electric_vs_petrol_vehicle_premise_with_solutions.ipynb
+++ b/notebooks/teaching/teaching_project_electric_vs_petrol_vehicle_premise_with_solutions.ipynb
@@ -443,7 +443,7 @@
     "import numpy as np\n",
     "\n",
     "from bw_timex.utils import add_temporal_distribution_to_exchange\n",
-    "from bw_temporalis import TemporalDistribution, easy_timedelta_distribution"
+    "from bw_timex import TemporalDistribution, easy_timedelta_distribution"
    ]
   },
   {

--- a/notebooks/uncertainty_analysis_with_datapackages.ipynb
+++ b/notebooks/uncertainty_analysis_with_datapackages.ipynb
@@ -354,7 +354,7 @@
    },
    "outputs": [],
    "source": [
-    "from bw_temporalis import TemporalDistribution, easy_timedelta_distribution\n",
+    "from bw_timex import TemporalDistribution, easy_timedelta_distribution\n",
     "import numpy as np\n",
     "\n",
     "td_assembly_and_delivery = TemporalDistribution(\n",

--- a/tests/dev/run_time_test_databases.ipynb
+++ b/tests/dev/run_time_test_databases.ipynb
@@ -30,7 +30,7 @@
     "import numpy as np\n",
     "import bw2data as bd\n",
     "\n",
-    "from bw_temporalis import TemporalDistribution\n",
+    "from bw_timex import TemporalDistribution\n",
     "from datetime import datetime\n",
     "\n",
     "from cProfile import Profile\n",

--- a/tests/fixtures/background_td_db_fixture.py
+++ b/tests/fixtures/background_td_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/background_td_deep_chain_db_fixture.py
+++ b/tests/fixtures/background_td_deep_chain_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 # Length of the linear background chain bg_0 -> bg_1 -> ... -> bg_{N-1}.
 CHAIN_LEN = 6

--- a/tests/fixtures/background_td_deep_db_fixture.py
+++ b/tests/fixtures/background_td_deep_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/background_td_deep_tdvar_db_fixture.py
+++ b/tests/fixtures/background_td_deep_tdvar_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/background_td_fg_and_bg_db_fixture.py
+++ b/tests/fixtures/background_td_fg_and_bg_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/background_td_multdate_consumer_fixture.py
+++ b/tests/fixtures/background_td_multdate_consumer_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/background_td_single_db_fixture.py
+++ b/tests/fixtures/background_td_single_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/background_td_zero_exchange_db_fixture.py
+++ b/tests/fixtures/background_td_zero_exchange_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/dynamic_biomatrix_db_fixture.py
+++ b/tests/fixtures/dynamic_biomatrix_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/explicit_background_td_db_fixture.py
+++ b/tests/fixtures/explicit_background_td_db_fixture.py
@@ -4,7 +4,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/explicit_process_product_db_fixture.py
+++ b/tests/fixtures/explicit_process_product_db_fixture.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import bw2data as bd
 import numpy as np
 import pytest
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/nonunitary_db_fixture.py
+++ b/tests/fixtures/nonunitary_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/process_at_base_database_time_db_fixture.py
+++ b/tests/fixtures/process_at_base_database_time_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/same_date_databases_fixture.py
+++ b/tests/fixtures/same_date_databases_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 def _write_same_date_databases(

--- a/tests/fixtures/substitution_db_fixture.py
+++ b/tests/fixtures/substitution_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/temporal_evolution_db_fixture.py
+++ b/tests/fixtures/temporal_evolution_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 from datetime import datetime
 
 

--- a/tests/fixtures/temporal_grouping_fixture.py
+++ b/tests/fixtures/temporal_grouping_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/vehicle_db_fixture.py
+++ b/tests/fixtures/vehicle_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/fixtures/vehicle_explicit_db_fixture.py
+++ b/tests/fixtures/vehicle_explicit_db_fixture.py
@@ -2,7 +2,7 @@ import bw2data as bd
 import numpy as np
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 
 @pytest.fixture

--- a/tests/test_absolute_rtd_supply_chain.py
+++ b/tests/test_absolute_rtd_supply_chain.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import bw2data as bd
 import numpy as np
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 from bw_timex import TimexLCA
 

--- a/tests/test_edge_extractor.py
+++ b/tests/test_edge_extractor.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 from bw_timex.edge_extractor import _join_datetime_and_timedelta_distributions
 

--- a/tests/test_explicit_process_product_end_to_end.py
+++ b/tests/test_explicit_process_product_end_to_end.py
@@ -4,7 +4,7 @@ import bw2calc as bc
 import bw2data as bd
 import numpy as np
 import pytest
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 from bw_timex import TimexLCA
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,38 @@
+"""Tests for what `bw_timex` exposes at the top level."""
+
+import bw_temporalis
+import pytest
+
+import bw_timex
+from bw_timex import utils
+
+FORWARDED_FROM_TEMPORALIS = [
+    "TemporalDistribution",
+    "easy_datetime_distribution",
+    "easy_timedelta_distribution",
+]
+
+EXPOSED_UTILS = [
+    "add_flows_to_characterization_functions",
+    "add_temporal_distribution_to_exchange",
+    "add_temporal_evolution_to_exchange",
+    "get_exchange",
+    "get_temporal_evolution_factor",
+    "interactive_td_widget",
+    "plot_characterized_inventory_as_waterfall",
+]
+
+
+@pytest.mark.parametrize("name", FORWARDED_FROM_TEMPORALIS)
+def test_temporalis_objects_are_forwarded(name):
+    assert getattr(bw_timex, name) is getattr(bw_temporalis, name)
+
+
+@pytest.mark.parametrize("name", EXPOSED_UTILS)
+def test_utils_are_exposed_at_top_level(name):
+    assert getattr(bw_timex, name) is getattr(utils, name)
+
+
+def test_all_names_are_importable():
+    for name in bw_timex.__all__:
+        assert hasattr(bw_timex, name), f"{name} in __all__ but not importable"

--- a/tests/test_temporal_evolution.py
+++ b/tests/test_temporal_evolution.py
@@ -80,7 +80,7 @@ class TestMutualExclusivity:
 import bw2data as bd
 import numpy as np
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 from bw_timex import TimexLCA
 

--- a/tests/test_temporal_grouping.py
+++ b/tests/test_temporal_grouping.py
@@ -9,7 +9,7 @@ import bw2calc as bc
 import bw2data as bd
 import numpy as np
 import pytest
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 from bw_timex import TimexLCA
 

--- a/tests/test_timex_lca.py
+++ b/tests/test_timex_lca.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from bw2data.tests import bw2test
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 from dynamic_characterization.classes import CharacterizedRow
 
 from bw_timex import TimexLCA

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from bw2data.errors import MultipleResults, UnknownObject
-from bw_temporalis import TemporalDistribution
+from bw_timex import TemporalDistribution
 
 from bw_timex.utils import (
     add_flows_to_characterization_functions,


### PR DESCRIPTION
## What

Makes `bw_timex` importable as one namespace, so a time-explicit LCA doesn't need imports from three places.

- Re-exports `TemporalDistribution`, `easy_timedelta_distribution` and `easy_datetime_distribution` from `bw_temporalis`
- Exposes the user-facing helpers from `bw_timex.utils` at package level: `add_temporal_distribution_to_exchange`, `add_temporal_evolution_to_exchange`, `add_flows_to_characterization_functions`, `get_exchange`, `get_temporal_evolution_factor`, `interactive_td_widget`, `plot_characterized_inventory_as_waterfall`
- Adds an explicit `__all__`

Before:

```python
from bw_temporalis import TemporalDistribution
from bw_timex import TimexLCA
from bw_timex.utils import add_temporal_distribution_to_exchange
```

After:

```python
from bw_timex import TemporalDistribution, TimexLCA, add_temporal_distribution_to_exchange
```

Purely additive — the `bw_timex.utils.*` and `bw_temporalis.*` import paths keep working unchanged.

## Also in here

Docs, notebooks and test fixtures now import `TemporalDistribution` (and `easy_timedelta_distribution`) from `bw_timex`. Library internals still import from `bw_temporalis` directly.

## Tests

New `tests/test_public_api.py` pins each re-export to identity with its source object and checks that everything in `__all__` is importable. Full suite passes (256 passed).