### PR TITLE
Make background traversal robust on real background databases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,14 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Improved `TimexLCA` setup speed by making it independent of the background database size, via lazy node proxies and a base LCA restricted to the demand-relevant databases ([#204](https://github.com/brightway-lca/bw_timex/pull/204))
 * Added support for several background databases sharing the same point in time in `database_dates`, by resolving temporal market shares per producer instead of per date ([#205](https://github.com/brightway-lca/bw_timex/pull/205))
 * Fixed `dynamic_lcia()` input validation to accept the prospective metrics supported by `dynamic_characterization`: `pGWP`, `pGTP`, and `prospective_radiative_forcing`
-* Fixed `MultipleTechnosphereExchanges` when several exchanges connect the same two nodes, by merging them into one edge
-* Fixed processes consuming their own product losing that loop in the technosphere matrix, and `graph_traversal="bfs"` counting it twice
-* Fixed `KeyError` in `build_timeline()` for node cohorts that receive no supply
-* Fixed `traverse_background` losing everything upstream of a `cutoff` or `max_calc` truncation
-* Fixed `ValueError: Empty array` for all-zero cohorts in the background descent
-* Added `static_lcia()` for inventories built from the timeline (`lci(expand_technosphere=False)`)
-* Added `lci(keep_activity_dimension=False)`, which accumulates the dynamic inventory per biosphere flow and time instead of per activity, trading contribution analysis for much lower memory use
-* Reduced memory and runtime of `lci(expand_technosphere=False)` on large time-explicit systems
+* Fixed `MultipleTechnosphereExchanges` when several exchanges connect the same two nodes, by merging them into one edge ([#207](https://github.com/brightway-lca/bw_timex/pull/207))
+* Fixed processes consuming their own product losing that loop in the technosphere matrix, and `graph_traversal="bfs"` counting it twice ([#207](https://github.com/brightway-lca/bw_timex/pull/207))
+* Fixed `KeyError` in `build_timeline()` for node cohorts that receive no supply ([#207](https://github.com/brightway-lca/bw_timex/pull/207))
+* Fixed `traverse_background` losing everything upstream of a `cutoff` or `max_calc` truncation ([#207](https://github.com/brightway-lca/bw_timex/pull/207))
+* Fixed `ValueError: Empty array` for all-zero cohorts in the background descent ([#207](https://github.com/brightway-lca/bw_timex/pull/207))
+* Added `static_lcia()` for inventories built from the timeline (`lci(expand_technosphere=False)`) ([#207](https://github.com/brightway-lca/bw_timex/pull/207))
+* Added `lci(keep_activity_dimension=False)`, which accumulates the dynamic inventory per biosphere flow and time instead of per activity, trading contribution analysis for much lower memory use ([#207](https://github.com/brightway-lca/bw_timex/pull/207))
+* Reduced memory and runtime of `lci(expand_technosphere=False)` on large time-explicit systems ([#207](https://github.com/brightway-lca/bw_timex/pull/207))
 
 ## [1.1.2]
 * Fixed the option to calculate the lci from the timeline. This option is called with lci(expand_technosphere=False) which speeds up the calculation significantly for for large systems, but does not allow for detailed contribution analysis of background processes. https://github.com/brightway-lca/bw_timex/commit/12853dbd799764f6d2d2fa2335d6f6f19a97abed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,9 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the pending-solve planning and technosphere factorization to `lci(expand_technosphere=False)`, which previously only ran for the expanded path ([#200](https://github.com/brightway-lca/bw_timex/pull/200))
 * Improved `TimexLCA` setup speed by making it independent of the background database size, via lazy node proxies and a base LCA restricted to the demand-relevant databases ([#204](https://github.com/brightway-lca/bw_timex/pull/204))
 * Added support for several background databases sharing the same point in time in `database_dates`, by resolving temporal market shares per producer instead of per date ([#205](https://github.com/brightway-lca/bw_timex/pull/205))
-
-## [1.1.3] - 2026-08-13
 * Fixed `dynamic_lcia()` input validation to accept the prospective metrics supported by `dynamic_characterization`: `pGWP`, `pGTP`, and `prospective_radiative_forcing`
+* Fixed `MultipleTechnosphereExchanges` when several exchanges connect the same two nodes, by merging them into one edge
+* Fixed processes consuming their own product losing that loop in the technosphere matrix, and `graph_traversal="bfs"` counting it twice
+* Fixed `KeyError` in `build_timeline()` for node cohorts that receive no supply
+* Fixed `traverse_background` losing everything upstream of a `cutoff` or `max_calc` truncation
+* Fixed `ValueError: Empty array` for all-zero cohorts in the background descent
+* Added `static_lcia()` for inventories built from the timeline (`lci(expand_technosphere=False)`)
+* Added `lci(keep_activity_dimension=False)`, which accumulates the dynamic inventory per biosphere flow and time instead of per activity, trading contribution analysis for much lower memory use
+* Reduced memory and runtime of `lci(expand_technosphere=False)` on large time-explicit systems
 
 ## [1.1.2]
 * Fixed the option to calculate the lci from the timeline. This option is called with lci(expand_technosphere=False) which speeds up the calculation significantly for for large systems, but does not allow for detailed contribution analysis of background processes. https://github.com/brightway-lca/bw_timex/commit/12853dbd799764f6d2d2fa2335d6f6f19a97abed

--- a/bw_timex/__init__.py
+++ b/bw_timex/__init__.py
@@ -21,7 +21,7 @@ from .utils import (
     plot_characterized_inventory_as_waterfall,
 )
 
-__version__ = "1.1.3"
+__version__ = "1.1.2"
 
 __all__ = [
     # forwarded from bw_temporalis for convenience

--- a/bw_timex/dynamic_biosphere_builder.py
+++ b/bw_timex/dynamic_biosphere_builder.py
@@ -33,6 +33,7 @@ class DynamicBiosphereBuilder:
         expand_technosphere: bool = True,
         background_unit_lci_cache: dict | None = None,
         nodes: dict | None = None,
+        keep_activity_dimension: bool = True,
     ) -> None:
         """
         Initializes the DynamicBiosphereBuilder object.
@@ -92,6 +93,11 @@ class DynamicBiosphereBuilder:
         # matrix is rebuilt to *this* lca_obj's biosphere/technosphere
         # index space (see `_rebuild_unit_lci`).
         self._expand_technosphere = bool(expand_technosphere)
+        # With the activity dimension dropped, every emission goes into a single
+        # column, already scaled by its activity's supply. That is all a score -
+        # static or dynamic - needs, and it keeps the entry count proportional to
+        # the number of (flow, time) pairs instead of (flow, time, activity).
+        self.keep_activity_dimension = bool(keep_activity_dimension)
 
         if expand_technosphere:
             self.technosphere_matrix = (
@@ -99,6 +105,9 @@ class DynamicBiosphereBuilder:
             )  # convert to csc as this is only used for column slicing
             self.dynamic_supply_array = lca_obj.supply_array
             self.activity_dict = lca_obj.dicts.activity
+            # Only used when building from the timeline, where each row is its
+            # own column; with expanded matrices the columns already collapse.
+            self.collapsed_market_rows = set()
         else:
             # `timeline.amount` is the LOCAL, per-edge exchange amount (per unit
             # of the immediate consumer); it does not carry the upstream
@@ -108,8 +117,8 @@ class DynamicBiosphereBuilder:
             # `Edge.cumulative_amount_producer` / `_join_cumulative_amount`) and
             # is the correct quantity to scale each timeline row's biosphere/
             # market contribution by.
-            self.dynamic_supply_array = self._supply_array_from_timeline(
-                timeline, node_collections
+            self.dynamic_supply_array, self.collapsed_market_rows = (
+                self._supply_array_from_timeline(timeline, node_collections)
             )
 
         self.activity_time_mapping = activity_time_mapping
@@ -148,7 +157,7 @@ class DynamicBiosphereBuilder:
     @staticmethod
     def _supply_array_from_timeline(
         timeline: pd.DataFrame, node_collections: dict
-    ) -> np.ndarray:
+    ) -> tuple[np.ndarray, set]:
         """Per-timeline-row supply, used instead of a solved supply array when
         the dynamic inventory is built directly from the timeline.
 
@@ -160,19 +169,39 @@ class DynamicBiosphereBuilder:
         biosphere exchanges are read (those are per production amount, not per
         unit of product), which the expanded technosphere gets for free from the
         solve. So convert those rows to process units here.
+
+        Rows that share a time-mapped temporal market are collapsed onto the
+        first of them: they all carry the same background LCI per unit of market
+        output, so the inventory only depends on their summed supply. Returns
+        the supply array and the positions of the collapsed-away rows, whose
+        columns are left empty.
         """
         supply = timeline.cumulative_amount.values.astype(float)
         temporalized = node_collections["temporalized_processes"]
+        markets = node_collections["temporal_markets"]
         production_amounts = {}
+        market_positions = {}
         for position, row in enumerate(timeline.itertuples()):
-            if row.time_mapped_producer not in temporalized:
-                continue
-            if row.producer not in production_amounts:
-                production_amounts[row.producer] = (
-                    get_reference_product_production_amount(row.producer)
+            if row.time_mapped_producer in temporalized:
+                if row.producer not in production_amounts:
+                    production_amounts[row.producer] = (
+                        get_reference_product_production_amount(row.producer)
+                    )
+                supply[position] /= production_amounts[row.producer]
+            elif row.time_mapped_producer in markets:
+                market_positions.setdefault(row.time_mapped_producer, []).append(
+                    position
                 )
-            supply[position] /= production_amounts[row.producer]
-        return supply
+
+        collapsed_market_rows = set()
+        for positions in market_positions.values():
+            if len(positions) == 1:
+                continue
+            keep, rest = positions[0], positions[1:]
+            supply[keep] += supply[rest].sum()
+            supply[rest] = 0.0
+            collapsed_market_rows.update(rest)
+        return supply, collapsed_market_rows
 
     def build_dynamic_biosphere_matrix(
         self,
@@ -213,6 +242,9 @@ class DynamicBiosphereBuilder:
 
         for row in self.timeline.itertuples():
             idx = row.time_mapped_producer
+            # Deduplicates repeated (flow, time) entries within one activity,
+            # which the per-activity columns do implicitly.
+            seen_rows = set()
 
             if expand_technosphere:
                 process_col_index = self.activity_dict[
@@ -291,10 +323,11 @@ class DynamicBiosphereBuilder:
                         )
 
                         # populate lists with which sparse matrix is constructed
-                        self.add_matrix_entry_for_biosphere_flows(
+                        self._add_entry(
                             row=time_mapped_matrix_idx,
                             col=process_col_index,
                             amount=amount,
+                            seen_rows=seen_rows,
                         )
 
             elif idx in self.node_collections["temporal_markets"]:
@@ -302,6 +335,10 @@ class DynamicBiosphereBuilder:
                     # Several timeline rows (one per consumer) can share a
                     # time-mapped market, but with expanded matrices they all
                     # map to the same column, whose supply already sums them up.
+                    continue
+                if row.Index in self.collapsed_market_rows:
+                    # Built from the timeline: this row's market is served by
+                    # another row's column, which carries their summed supply.
                     continue
                 self.temporal_market_cols.append(process_col_index)
                 (
@@ -329,43 +366,53 @@ class DynamicBiosphereBuilder:
                             else unit_lci_total + unit_lci
                         )
 
-                    aggregated_inventory = unit_lci_total.sum(axis=1)
+                    aggregated_inventory = np.asarray(
+                        unit_lci_total.sum(axis=1)
+                    ).ravel()
 
-                    # multiply LCI with supply of temporal market
-                    scaled_lci = (
-                        unit_lci_total * self.dynamic_supply_array[process_col_index]
-                    )
-                    if idx not in temporal_market_lcis:
-                        temporal_market_lcis[idx] = scaled_lci
-                    else:
-                        temporal_market_lcis[idx] += scaled_lci
+                    if expand_technosphere:
+                        # Only used to disaggregate the background of temporal
+                        # markets, which needs the expanded technosphere. Keeping
+                        # one scaled LCI per market row otherwise just burns
+                        # memory (real background systems have hundreds of
+                        # thousands of market rows).
+                        scaled_lci = (
+                            unit_lci_total * self.dynamic_supply_array[process_col_index]
+                        )
+                        if idx not in temporal_market_lcis:
+                            temporal_market_lcis[idx] = scaled_lci
+                        else:
+                            temporal_market_lcis[idx] += scaled_lci
 
-                    for row_idx, amount in enumerate(aggregated_inventory.A1):
+                    time_in_datetime = convert_date_string_to_datetime(
+                        self.temporal_grouping, str(time)
+                    )  # now time is a datetime
+
+                    date = TemporalDistribution(
+                        date=np.array([str(time_in_datetime)], dtype=self.time_res),
+                        amount=np.array([1]),
+                    ).date[0]
+
+                    # A background LCI touches a few hundred of the thousands of
+                    # biosphere flows; the rest would only add explicit zeros.
+                    for row_idx in np.flatnonzero(aggregated_inventory):
                         bioflow = self.lca_obj.dicts.biosphere.reversed[row_idx]
-                        ((_, _), time) = self.activity_time_mapping.reversed[idx]
-
-                        time_in_datetime = convert_date_string_to_datetime(
-                            self.temporal_grouping, str(time)
-                        )  # now time is a datetime
-
-                        td_producer = TemporalDistribution(
-                            date=np.array([str(time_in_datetime)], dtype=self.time_res),
-                            amount=np.array([1]),
-                        ).date
-                        date = td_producer[0]
 
                         time_mapped_matrix_idx = self.biosphere_time_mapping.add(
                             (bioflow, date)
                         )
 
-                        self.add_matrix_entry_for_biosphere_flows(
+                        self._add_entry(
                             row=time_mapped_matrix_idx,
                             col=process_col_index,
-                            amount=amount,
+                            amount=aggregated_inventory[row_idx],
+                            seen_rows=seen_rows,
                         )
 
         # now build the dynamic biosphere matrix
-        if expand_technosphere:
+        if not self.keep_activity_dimension:
+            ncols = 1
+        elif expand_technosphere:
             ncols = len(self.activity_time_mapping)
         else:
             ncols = len(self.timeline)
@@ -373,15 +420,19 @@ class DynamicBiosphereBuilder:
         if not self._matrix_entries:
             return sp.csr_matrix((0, ncols)), temporal_market_lcis
 
-        rows = []
-        cols = []
-        values = []
-        for (row, col), amount in self._matrix_entries.items():
-            rows.append(row)
-            cols.append(col)
-            values.append(amount)
+        # Filled element-wise into pre-sized arrays rather than via Python
+        # lists: real background systems reach tens of millions of entries,
+        # where boxed ints cost several GB more than the arrays themselves.
+        n_entries = len(self._matrix_entries)
+        rows = np.empty(n_entries, dtype=np.int64)
+        cols = np.empty(n_entries, dtype=np.int64)
+        values = np.empty(n_entries, dtype=float)
+        for position, ((row, col), amount) in enumerate(self._matrix_entries.items()):
+            rows[position] = row
+            cols[position] = col
+            values[position] = amount
 
-        shape = (max(rows) + 1, ncols)
+        shape = (rows.max() + 1, ncols)
         dynamic_biosphere_matrix = sp.coo_matrix(
             (values, (rows, cols)), shape
         )
@@ -446,6 +497,27 @@ class DynamicBiosphereBuilder:
         }
 
         return demand
+
+    def _add_entry(self, row, col, amount, seen_rows=None):
+        """Add one dynamic biosphere entry, honouring `keep_activity_dimension`.
+
+        With the activity dimension dropped, entries of different activities land
+        in the same column, so they are summed rather than deduplicated - and the
+        activity's supply is applied here, since there is no per-activity column
+        left to scale afterwards. `seen_rows` keeps the deduplication *within* an
+        activity that `add_matrix_entry_for_biosphere_flows` does.
+        """
+        if self.keep_activity_dimension:
+            self.add_matrix_entry_for_biosphere_flows(row=row, col=col, amount=amount)
+            return
+        if row in seen_rows:
+            return
+        seen_rows.add(row)
+        key = (row, 0)
+        self._matrix_entries[key] = (
+            self._matrix_entries.get(key, 0.0)
+            + amount * self.dynamic_supply_array[col]
+        )
 
     def add_matrix_entry_for_biosphere_flows(self, row, col, amount):
         """
@@ -617,6 +689,9 @@ class DynamicBiosphereBuilder:
         pending_keys = set()
         for row in self.timeline.itertuples():
             idx = row.time_mapped_producer
+            # Deduplicates repeated (flow, time) entries within one activity,
+            # which the per-activity columns do implicitly.
+            seen_rows = set()
             if idx not in self.node_collections["temporal_markets"]:
                 continue
             if self._expand_technosphere:

--- a/bw_timex/edge_extractor.py
+++ b/bw_timex/edge_extractor.py
@@ -7,9 +7,11 @@ from numbers import Number
 from typing import Callable
 
 import numpy as np
+from bw2data import labels
 from bw2data.backends.schema import ActivityDataset as AD
 from bw2data.backends.schema import ExchangeDataset as ED
 from bw_temporalis import TemporalDistribution, TemporalisLCA, loader_registry
+from bw_temporalis.lca import NoExchange
 from loguru import logger
 
 from .utils import (
@@ -87,6 +89,165 @@ def extract_temporal_evolution(exc_data: dict) -> dict | None:
     if has_factors:
         return exc_data["temporal_evolution_factors"]
     return None
+
+
+def load_temporal_distribution(value):
+    """Restore a ``TemporalDistribution`` that was serialized with a loader."""
+    if isinstance(value, str) and "__loader__" in value:
+        data = json.loads(value)
+        return loader_registry[data["__loader__"]](data)
+    return value
+
+
+class MergedExchange:
+    """Stand-in for a single ``ExchangeDataset`` when several exchanges link the
+    same (input, output) pair. Exposes ``.data``, which is what the edge
+    extractors read from an exchange.
+
+    ``netted_types`` marks the case where the duplicates have different types
+    (a process consuming its own product), so the technosphere matrix holds
+    their net rather than any single edge's amount. ``consuming_amount`` is
+    then the amount of the consuming part alone, which is what a traversal
+    following that input edge needs.
+    """
+
+    def __init__(self, data: dict, *, netted_types=False, consuming_amount=None):
+        self.data = data
+        self.netted_types = netted_types
+        self.consuming_amount = consuming_amount
+
+
+def carries_temporal_information(exchange_data: dict) -> bool:
+    """Whether an exchange has a temporal distribution or temporal evolution."""
+    return any(
+        exchange_data.get(key) is not None
+        for key in (
+            "temporal_distribution",
+            "temporal_evolution_amounts",
+            "temporal_evolution_factors",
+        )
+    )
+
+
+def _merge_untimed_exchanges_of_different_types(
+    exchange_datas: list[dict],
+) -> "MergedExchange":
+    """Merge duplicates of different types, none of which is temporalized.
+
+    A process consuming its own product is the common case: the same node pair
+    then carries both a ``production`` and a ``technosphere`` exchange. The
+    technosphere matrix holds their net, so the merged exchange reports which
+    type governs that net (so the sign comes out right) and keeps the consuming
+    amount separately, for traversals that follow the consuming edge.
+    """
+    positive_types = set(labels.technosphere_positive_edge_types)
+
+    def is_positive(data):
+        return data.get("type", "technosphere") in positive_types
+
+    net = sum(
+        data["amount"] if is_positive(data) else -data["amount"]
+        for data in exchange_datas
+    )
+    governing = [data for data in exchange_datas if is_positive(data) == (net >= 0)][0]
+
+    merged = dict(governing)
+    merged["amount"] = abs(net)
+    return MergedExchange(
+        merged,
+        netted_types=True,
+        consuming_amount=sum(
+            data["amount"] for data in exchange_datas if not is_positive(data)
+        ),
+    )
+
+
+def merge_duplicate_exchanges(exchange_datas: list[dict]) -> "MergedExchange":
+    """Merge several exchanges between the same two nodes into one.
+
+    Multiple exchanges between the same pair of nodes are a legitimate
+    modelling choice, and common in ecoinvent/premise background data. The
+    technosphere matrix already holds their sum, so the merged exchange carries
+    the summed ``amount`` and the amount-weighted combination of the individual
+    temporal distributions (duplicates without one count as happening at
+    timedelta 0) and temporal evolutions.
+    """
+    if len(exchange_datas) == 1:
+        return MergedExchange(exchange_datas[0])
+
+    types = {data.get("type", "technosphere") for data in exchange_datas}
+    if len(types) > 1:
+        if not any(carries_temporal_information(data) for data in exchange_datas):
+            # Nothing to merge in time, so the differing types are harmless.
+            return _merge_untimed_exchanges_of_different_types(exchange_datas)
+        raise ValueError(
+            f"Found {len(exchange_datas)} exchanges between "
+            f"{exchange_datas[0].get('input')} and {exchange_datas[0].get('output')} "
+            f"with different types ({sorted(types)}), at least one of them carrying "
+            f"temporal information. Merging those in time is ambiguous, because "
+            f"they enter the technosphere matrix with opposite signs."
+        )
+
+    amounts = [data["amount"] for data in exchange_datas]
+    total_amount = sum(amounts)
+    # Weights are only meaningful if the duplicates don't cancel out. If they
+    # do, the edge contributes nothing anyway, so weigh them equally.
+    if total_amount:
+        weights = [amount / total_amount for amount in amounts]
+    else:
+        weights = [1 / len(amounts)] * len(amounts)
+
+    merged = dict(exchange_datas[0])
+    merged["amount"] = total_amount
+
+    tds = [
+        load_temporal_distribution(data.get("temporal_distribution"))
+        for data in exchange_datas
+    ]
+    if any(isinstance(td, TemporalDistribution) for td in tds):
+        date_dtype = next(
+            td.date.dtype for td in tds if isinstance(td, TemporalDistribution)
+        )
+        combined_td = None
+        for td, weight in zip(tds, weights):
+            if not isinstance(td, TemporalDistribution):
+                # No temporal distribution means the exchange happens at the
+                # same time as its consumer, i.e. a unit pulse at timedelta 0.
+                td = TemporalDistribution(
+                    date=np.array([0], dtype=date_dtype),
+                    amount=np.array([1.0]),
+                )
+            part = td * weight
+            combined_td = part if combined_td is None else combined_td + part
+        merged["temporal_distribution"] = combined_td.simplify()
+    else:
+        merged.pop("temporal_distribution", None)
+
+    evolutions = [extract_temporal_evolution(data) for data in exchange_datas]
+    if any(evolution is not None for evolution in evolutions):
+        dates = set()
+        for evolution in evolutions:
+            if evolution is not None:
+                dates.update(evolution)
+        for evolution in evolutions:
+            if evolution is not None and set(evolution) != dates:
+                raise ValueError(
+                    f"Found {len(exchange_datas)} exchanges between "
+                    f"{exchange_datas[0].get('input')} and "
+                    f"{exchange_datas[0].get('output')} whose temporal evolutions "
+                    f"are given for different points in time. Merging them "
+                    f"requires the same dates on all of them."
+                )
+        merged.pop("temporal_evolution_amounts", None)
+        merged["temporal_evolution_factors"] = {
+            date: sum(
+                weight * (1.0 if evolution is None else evolution[date])
+                for evolution, weight in zip(evolutions, weights)
+            )
+            for date in dates
+        }
+
+    return MergedExchange(merged)
 
 
 class VariantBackgroundMixin:
@@ -251,32 +412,31 @@ class VariantBackgroundMixin:
         ``(td_or_amount, edge_type, temporal_evolution)`` tuple.
         """
         consumer = self.bw_node_proxies[output_id]
-        exc = None
-        for candidate in consumer.technosphere():
-            if candidate.input.id == input_id:
-                exc = candidate
-                break
-        if exc is None:
-            for candidate in consumer.exchanges():
-                if (
-                    candidate.input.id == input_id
-                    and candidate.get("type") != "production"
-                ):
-                    exc = candidate
-                    break
-        if exc is None:
+        # Several exchanges between the same two nodes are legitimate, so
+        # collect them all and merge them into one.
+        excs = [
+            candidate
+            for candidate in consumer.technosphere()
+            if candidate.input.id == input_id
+        ]
+        if not excs:
+            excs = [
+                candidate
+                for candidate in consumer.exchanges()
+                if candidate.input.id == input_id
+                and candidate.get("type") != "production"
+            ]
+        if not excs:
             raise ValueError(
                 f"No exchange from {input_id} to {output_id} found on proxy."
             )
 
-        edge_type = exc.get("type", "technosphere")
-        amount = exc["amount"]
-        temporal_evolution = extract_temporal_evolution(exc.as_dict())
+        exc_data = merge_duplicate_exchanges([exc.as_dict() for exc in excs]).data
+        edge_type = exc_data.get("type", "technosphere")
+        amount = exc_data["amount"]
+        temporal_evolution = extract_temporal_evolution(exc_data)
 
-        td = exc.get("temporal_distribution")
-        if isinstance(td, str) and "__loader__" in td:
-            data = json.loads(td)
-            td = loader_registry[data["__loader__"]](data)
+        td = load_temporal_distribution(exc_data.get("temporal_distribution"))
         if isinstance(td, TemporalDistribution):
             return td * amount, edge_type, temporal_evolution
         return amount, edge_type, temporal_evolution
@@ -564,6 +724,14 @@ class VariantBackgroundMixin:
                 queue.popleft()
             )
 
+            # A cohort that carries no amount contributes nothing, and everything
+            # below it would be zero too. It arises e.g. when the variant split
+            # routes a zero-weight date to one variant and the rest to another.
+            # Convolving it on would yield an empty TemporalDistribution, which
+            # `TemporalDistribution` refuses to construct, so stop here.
+            if isinstance(cur_td, TemporalDistribution) and not np.any(cur_td.amount):
+                continue
+
             production_amount = self._proxy_production_amount(cur_id)
             input_ids = self._proxy_technosphere_inputs(cur_id)
 
@@ -731,6 +899,22 @@ class EdgeExtractor(VariantBackgroundMixin, TemporalisLCA):
         # keyed by ``unique_id`` and contain only the referenced variant.
         self.variant_resolved_producers: set[int] = set()
         self.bw_node_proxies: dict = {}
+
+    def get_technosphere_exchange(self, input_id: int, output_id: int):
+        """Look up the exchange between two nodes.
+
+        Overrides ``TemporalisLCA.get_technosphere_exchange``, which raises
+        ``MultipleTechnosphereExchanges`` when several exchanges link the same
+        two nodes. That is a legitimate modelling choice and common in
+        background databases, so merge the duplicates into a single exchange
+        instead (see ``merge_duplicate_exchanges``).
+        """
+        exchanges = self._exchange_iterator(input_id, output_id)
+        if not exchanges:
+            return NoExchange
+        if len(exchanges) == 1:
+            return exchanges[0]
+        return merge_duplicate_exchanges([exc.data for exc in exchanges])
 
     def build_edge_timeline(self) -> list:
         """
@@ -1145,7 +1329,10 @@ class EdgeExtractorBFS(VariantBackgroundMixin):
         return self._ad_cache[activity_id]
 
     def _get_exchange(self, input_id: int, output_id: int):
-        """Look up exchange between two activities. Returns ExchangeDataset or None."""
+        """Look up exchange between two activities. Returns ExchangeDataset or None.
+
+        Several exchanges between the same two activities are merged into one
+        (see ``merge_duplicate_exchanges``)."""
         inp = self._get_activity_dataset(input_id)
         outp = self._get_activity_dataset(output_id)
         exchanges = list(
@@ -1159,9 +1346,7 @@ class EdgeExtractorBFS(VariantBackgroundMixin):
         if len(exchanges) == 1:
             return exchanges[0]
         elif len(exchanges) > 1:
-            raise ValueError(
-                f"Found {len(exchanges)} exchanges between {input_id} and {output_id}"
-            )
+            return merge_duplicate_exchanges([exc.data for exc in exchanges])
         return None
 
     def _get_exchange_td_and_type(self, input_id: int, output_id: int):
@@ -1183,8 +1368,17 @@ class EdgeExtractorBFS(VariantBackgroundMixin):
             return sign * matrix_value, "technosphere", None
 
         edge_type = exchange.data["type"]
-        sign = -1 if edge_type in ("generic consumption", "technosphere") else 1
-        amount = sign * matrix_value
+        if getattr(exchange, "netted_types", False):
+            # A process consuming its own product. The matrix cell holds the net
+            # of its production and its consumption, i.e. the process's net
+            # output - not the amount of the input edge being walked here. Take
+            # that from the exchange, so the loop is walked with its real
+            # coefficient (and converges like any other loop).
+            edge_type = "technosphere"
+            amount = exchange.consuming_amount
+        else:
+            sign = -1 if edge_type in ("generic consumption", "technosphere") else 1
+            amount = sign * matrix_value
 
         temporal_evolution = extract_temporal_evolution(exchange.data)
 
@@ -1469,6 +1663,13 @@ class EdgeExtractorBFS(VariantBackgroundMixin):
                     and self._is_static_background(node_id)
                     and self._is_static_background(producer_process)
                     and bool(self._proxy_technosphere_inputs(producer_process))
+                    # A process consuming its own product is not a crossing into
+                    # the background - it is already there. Splitting it would
+                    # emit the loop edge once per variant here AND once more
+                    # inside the variant descent, which is the same exchange
+                    # twice. Walk it like any other loop instead: the repeated
+                    # visits carry the amplification, bounded by cutoff/max_calc.
+                    and producer_process != node_id
                 )
 
                 if not variant_split:

--- a/bw_timex/matrix_modifier.py
+++ b/bw_timex/matrix_modifier.py
@@ -57,6 +57,11 @@ class MatrixModifier:
         self.name = name
         self.temporalized_process_ids = set()
         self.temporal_market_ids = set()
+        # Self-consumption of time-explicit processes (a process consuming its
+        # own product), accumulated per time-mapped id. It belongs on the
+        # diagonal, where the production entry already sits, so it is netted
+        # into that entry instead of being added as its own one.
+        self.self_consumption = {}
 
     def create_datapackage(self) -> None:
         """
@@ -113,12 +118,18 @@ class MatrixModifier:
                 new_nodes,
             )
 
-        # Adding the production exchanges for new nodes
+        # Adding the production exchanges for new nodes, net of any
+        # self-consumption (which shares the same diagonal position; the
+        # datapackage does not sum duplicate indices, so one would silently
+        # overwrite the other).
         for node_id, production_amount in new_nodes:
             datapackage_technosphere.add_persistent_vector(
                 matrix="technosphere_matrix",
                 name=uuid.uuid4().hex,
-                data_array=np.array([production_amount], dtype=float),
+                data_array=np.array(
+                    [production_amount - self.self_consumption.get(node_id, 0.0)],
+                    dtype=float,
+                ),
                 indices_array=np.array([(node_id, node_id)], dtype=bwp.INDICES_DTYPE),
             )
 
@@ -265,17 +276,25 @@ class MatrixModifier:
             )
             scaled_amount *= factor
 
-        # Add entry between exploded consumer and exploded producer (not in background database)
-        datapackage.add_persistent_vector(
-            matrix="technosphere_matrix",
-            name=uuid.uuid4().hex,
-            data_array=np.array([scaled_amount], dtype=float),
-            indices_array=np.array(
-                [(new_producer_id, new_consumer_id)],
-                dtype=bwp.INDICES_DTYPE,
-            ),
-            flip_array=np.array([True], dtype=bool),
-        )
+        if new_producer_id == new_consumer_id:
+            # A process consuming its own product: this lands on the diagonal,
+            # where the production entry goes too. Collect it and let that entry
+            # carry the net, so the loop survives into the matrix.
+            self.self_consumption[new_producer_id] = (
+                self.self_consumption.get(new_producer_id, 0.0) + scaled_amount
+            )
+        else:
+            # Add entry between exploded consumer and exploded producer (not in background database)
+            datapackage.add_persistent_vector(
+                matrix="technosphere_matrix",
+                name=uuid.uuid4().hex,
+                data_array=np.array([scaled_amount], dtype=float),
+                indices_array=np.array(
+                    [(new_producer_id, new_consumer_id)],
+                    dtype=bwp.INDICES_DTYPE,
+                ),
+                flip_array=np.array([True], dtype=bool),
+            )
 
         # A row is a temporal market iff it carries temporal_market_shares.
         # Leaf producers (background frontier) carry shares; producers traversed

--- a/bw_timex/timeline_builder.py
+++ b/bw_timex/timeline_builder.py
@@ -307,6 +307,8 @@ class TimelineBuilder:
         grouped_edges["hash_producer"] = grouped_edges["date_producer"].map(hash_cache)
         grouped_edges["hash_consumer"] = grouped_edges["date_consumer"].map(hash_cache)
 
+        grouped_edges = self._drop_edges_of_unsupplied_consumers(grouped_edges)
+
         # add new processes to activity_time_mapping
         static_dbs = set(self.database_dates_static.keys()) if self.traverse_background else set()
         for row in grouped_edges.itertuples():
@@ -458,6 +460,48 @@ class TimelineBuilder:
 
         raise TypeError(f"Unrecognized type in this edge: {edge_type}")
 
+    @staticmethod
+    def _drop_edges_of_unsupplied_consumers(grouped_edges: pd.DataFrame) -> pd.DataFrame:
+        """Drop edges whose consumer cohort is never produced.
+
+        Edges with ``amount == 0`` are dropped before grouping, so a node cohort
+        that is only reached via zero-amount edges (e.g. a background temporal
+        distribution with a zero weight at one of its dates) has no producing
+        row left. The edges *out* of that cohort do survive, because their own
+        exchange amounts are non-zero - but they carry no throughput, since
+        nothing supplies their consumer. Keeping them would ask the activity
+        time mapping for a consumer that was never registered (only producers
+        are), so drop them, and iteratively whatever hangs off them.
+        """
+        n_before = len(grouped_edges)
+        producer_instance = (
+            grouped_edges["producer"].astype(str)
+            + "|"
+            + grouped_edges["producer_grouping_time"]
+        )
+        consumer_instance = (
+            grouped_edges["consumer"].astype(str)
+            + "|"
+            + grouped_edges["consumer_grouping_time"]
+        )
+        is_functional_unit = grouped_edges["consumer"] == -1
+        while True:
+            # Dropping edges can orphan their producer, so iterate to a fixpoint.
+            keep = is_functional_unit | consumer_instance.isin(set(producer_instance))
+            if keep.all():
+                break
+            grouped_edges = grouped_edges[keep]
+            producer_instance = producer_instance[keep]
+            consumer_instance = consumer_instance[keep]
+            is_functional_unit = is_functional_unit[keep]
+
+        if len(grouped_edges) < n_before:
+            logger.info(
+                f"Dropped {n_before - len(grouped_edges)} edge(s) from the timeline "
+                f"whose consuming process received no supply."
+            )
+        return grouped_edges.reset_index(drop=True)
+
     def get_time_mapping_key(self, node_id: int, node_hash: int) -> int:
         """
         Returns the time_mapping_id (key) from the activity_time_mapping for a given node.
@@ -487,19 +531,17 @@ class TimelineBuilder:
         background db. These are the temporal-market frontier."""
         consumers = set(edges_df["consumer"].unique())
         static_dbs = set(self.database_dates_static.keys())
-        # Producers that the BFS already resolved to their respective variant
-        # database during a variant-aware descent are temporalized (rebuilt from
-        # their own real db), not temporal markets — otherwise their already
-        # variant-routed amounts would be re-interpolated.
-        variant_resolved = getattr(
-            self.edge_extractor, "variant_resolved_producers", set()
-        )
         leaves = set()
         for producer in edges_df["producer"].unique():
             if producer in consumers:
                 continue  # traversed into -> temporalized, not a market
-            if producer in variant_resolved:
-                continue  # already variant-resolved -> temporalized
+            # Producers the descent resolved to their variant database but never
+            # descended into (cut off by `cutoff` or the `max_calc` budget) are
+            # leaves like any other: nothing upstream of them is in the timeline,
+            # so they need their full background LCI. Their already-resolved
+            # variant is preserved by pinning their market to their own database
+            # in `add_column_temporal_market_shares_to_timeline`, so the routing
+            # made during the descent is not interpolated a second time.
             node = self.nodes.get(producer)
             if node is not None and node["database"] in static_dbs:
                 leaves.add(producer)
@@ -611,11 +653,21 @@ class TimelineBuilder:
             producers_in_timeline
         )
 
+        # Producers the background descent already routed to a specific variant
+        # database. When such a producer ends up a market (descent stopped there),
+        # it keeps that database instead of being interpolated a second time.
+        variant_resolved = getattr(
+            self.edge_extractor, "variant_resolved_producers", set()
+        )
+
         weight_cache = {}
         shares = []
         for producer, producer_date in zip(tl_df["producer"], tl_df["date_producer"]):
             if producer not in producers_in_timeline:
                 shares.append(None)
+                continue
+            if producer in variant_resolved:
+                shares.append({self.nodes[producer]["database"]: 1})
                 continue
             candidates = candidate_databases[producer]
             sorted_dates = tuple(sorted(candidates))

--- a/bw_timex/timex_lca.py
+++ b/bw_timex/timex_lca.py
@@ -446,6 +446,7 @@ class TimexLCA:
         self,
         build_dynamic_biosphere: Optional[bool] = True,
         expand_technosphere: Optional[bool] = True,
+        keep_activity_dimension: Optional[bool] = True,
     ) -> None:
         """
         Calculates the time-explicit LCI.
@@ -474,6 +475,14 @@ class TimexLCA:
             if False, creates no new technosphere, but calculates the dynamic inventory directly
             from the timeline. Building from the timeline currently only works if
             `build_dynamic_biosphere` is also True.
+        keep_activity_dimension: bool
+            if True (default), the dynamic inventory keeps one column per emitting
+            activity, which is what a contribution analysis needs.
+            if False, emissions are accumulated per (biosphere flow, time) only, in a
+            single column. Scores - static and dynamic - are identical, and so is the
+            timing of the emissions, but they can no longer be attributed to the
+            activities that caused them. Use this for large time-explicit systems,
+            where the per-activity columns dominate memory.
 
         Returns
         -------
@@ -493,6 +502,7 @@ class TimexLCA:
         LCIInputs(
             build_dynamic_biosphere=build_dynamic_biosphere,
             expand_technosphere=expand_technosphere,
+            keep_activity_dimension=keep_activity_dimension,
         )
 
         if hasattr(self, "dynamic_inventory"):
@@ -532,7 +542,7 @@ class TimexLCA:
             data_obs = self.data_objs + self.datapackage
             self.expanded_technosphere = True  # set flag for later static lcia usage
         else:  # setup for timeline approach
-            logger.warning(
+            logger.info(
                 "Disaggregated lci is not yet implemented with this option.\n" \
                 "Please use expand_technosphere=True if you want to perform a contribution analysis on the background processes."
             )
@@ -604,7 +614,10 @@ class TimexLCA:
                         self.lca.inventory.copy(),
                     )
 
-                self.calculate_dynamic_inventory(expand_technosphere=True)
+                self.calculate_dynamic_inventory(
+                    expand_technosphere=True,
+                    keep_activity_dimension=keep_activity_dimension,
+                )
                 # Restore the fu inventory only if the build actually mutated
                 # `self.lca.inventory` via at least one `redo_lci` call
                 # (i.e. there was a cache miss). With everything cached, the
@@ -641,7 +654,10 @@ class TimexLCA:
                     self.lca.decompose_technosphere()
                     self._lci_did_factorize = True
 
-                self.calculate_dynamic_inventory(expand_technosphere=False)
+                self.calculate_dynamic_inventory(
+                    expand_technosphere=False,
+                    keep_activity_dimension=keep_activity_dimension,
+                )
 
     def disaggregate_background_lci(self) -> None:
         """
@@ -753,12 +769,33 @@ class TimexLCA:
         """
         if not hasattr(self, "lca"):
             raise AttributeError("LCI not yet calculated. Call TimexLCA.lci() first.")
-        if not self.expanded_technosphere:
-            raise ValueError(
-                "Currently the static lcia score can only be calculated if the expanded matrix has \
-                    been built. Please call TimexLCA.lci(expand_technosphere=True) first."
+        if self.expanded_technosphere:
+            self.lca.lcia()
+            self._static_score_from_timeline = None
+            return
+
+        # Without the expanded matrices there is no inventory on `self.lca` to
+        # characterize, but the dynamic inventory holds the same flows (just
+        # resolved in time), so characterize that with the static factors.
+        if not hasattr(self, "dynamic_inventory_df"):
+            raise AttributeError(
+                "Dynamic inventory not yet calculated. Call "
+                "TimexLCA.lci(expand_technosphere=False, build_dynamic_biosphere=True) first."
             )
-        self.lca.lcia()
+        self.lca.load_lcia_data()
+        diagonal = self.lca.characterization_matrix.diagonal()
+        characterization_factors = {
+            flow_id: diagonal[index]
+            for flow_id, index in self.lca.dicts.biosphere.items()
+        }
+        self._static_score_from_timeline = float(
+            (
+                self.dynamic_inventory_df["amount"]
+                * self.dynamic_inventory_df["flow"]
+                .map(characterization_factors)
+                .fillna(0.0)
+            ).sum()
+        )
 
     def dynamic_lcia(
         self,
@@ -929,6 +966,14 @@ class TimexLCA:
         """
         if not hasattr(self, "lca"):
             raise AttributeError("LCI not yet calculated. Call TimexLCA.lci() first.")
+        if not self.expanded_technosphere:
+            # Characterized from the dynamic inventory, not from `self.lca`,
+            # which has no expanded inventory to score.
+            if getattr(self, "_static_score_from_timeline", None) is None:
+                raise AttributeError(
+                    "Static score not yet calculated. Call TimexLCA.static_lcia() first."
+                )
+            return self._static_score_from_timeline
         return self.lca.score
 
     @property
@@ -1042,6 +1087,7 @@ class TimexLCA:
     def calculate_dynamic_inventory(
         self,
         expand_technosphere=True,
+        keep_activity_dimension=True,
     ) -> None:
         """
         Calculates the dynamic inventory, by first creating a dynamic biosphere matrix using the
@@ -1089,6 +1135,7 @@ class TimexLCA:
             expand_technosphere=expand_technosphere,
             background_unit_lci_cache=self._background_unit_lci_cache,
             nodes=self.nodes,
+            keep_activity_dimension=keep_activity_dimension,
         )
 
         # The pending-solve count + factorize decision is now made upfront
@@ -1104,16 +1151,21 @@ class TimexLCA:
         )
 
         # Build the dynamic inventory
-        count = len(self.dynamic_biosphere_builder.dynamic_supply_array)
-        # diagonalization of supply array keeps the dimension of the process, which we want to pass
-        # as additional information to the dynamic inventory dict
-        diagonal_supply_array = sparse.spdiags(
-            [self.dynamic_biosphere_builder.dynamic_supply_array], [0], count, count
-        )
-        self.dynamic_inventory = self.dynamic_biosphere_matrix @ diagonal_supply_array
+        if keep_activity_dimension:
+            count = len(self.dynamic_biosphere_builder.dynamic_supply_array)
+            # diagonalization of supply array keeps the dimension of the process, which we want to pass
+            # as additional information to the dynamic inventory dict
+            diagonal_supply_array = sparse.spdiags(
+                [self.dynamic_biosphere_builder.dynamic_supply_array], [0], count, count
+            )
+            self.dynamic_inventory = self.dynamic_biosphere_matrix @ diagonal_supply_array
+        else:
+            # There is no activity dimension left to scale: the builder already
+            # applied each activity's supply while accumulating.
+            self.dynamic_inventory = self.dynamic_biosphere_matrix
 
         self.dynamic_inventory_df = self.create_dynamic_inventory_dataframe(
-            expand_technosphere
+            expand_technosphere, keep_activity_dimension=keep_activity_dimension
         )
         self._dynamic_lcia_inventory_cache.clear()
 
@@ -1121,6 +1173,7 @@ class TimexLCA:
         self,
         expand_technosphere=True,
         use_disaggregated_lci=False,
+        keep_activity_dimension=True,
     ) -> pd.DataFrame:
         """
         Brings the dynamic inventory from its matrix form in `dynamic_inventory` into the
@@ -1161,7 +1214,11 @@ class TimexLCA:
         )
         dynamic_inventory = dynamic_inventory.tocoo()
 
-        if expand_technosphere:
+        if not keep_activity_dimension:
+            # Single aggregated column: the emissions are no longer attributable
+            # to an activity.
+            activities = [-1] * len(dynamic_inventory.col)
+        elif expand_technosphere:
             activities = [
                 self.lca.activity_dict.reversed[col] for col in dynamic_inventory.col
             ]

--- a/bw_timex/validation.py
+++ b/bw_timex/validation.py
@@ -134,6 +134,7 @@ class LCIInputs(BaseModel):
 
     build_dynamic_biosphere: bool = True
     expand_technosphere: bool = True
+    keep_activity_dimension: bool = True
 
     @model_validator(mode="after")
     def validate_combination(self) -> "LCIInputs":
@@ -142,6 +143,11 @@ class LCIInputs(BaseModel):
                 "Currently, it is not possible to skip the construction of the dynamic "
                 "biosphere when building the inventories from the timeline. "
                 "Please either set build_dynamic_biosphere=True or expand_technosphere=True."
+            )
+        if not self.keep_activity_dimension and not self.build_dynamic_biosphere:
+            raise ValueError(
+                "keep_activity_dimension=False only applies to the dynamic biosphere, "
+                "which is not being built. Please set build_dynamic_biosphere=True."
             )
         return self
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,12 @@ from .fixtures.background_td_multdate_consumer_fixture import (
     background_td_multidate_consumer_db,
 )
 from .fixtures.duplicate_code_db_fixture import duplicate_code_db
+from .fixtures.duplicate_exchange_db_fixture import (
+    duplicate_exchange_db,
+    duplicate_exchange_td_db,
+    self_loop_db,
+    self_loop_with_td_db,
+)
 from .fixtures.dynamic_biomatrix_db_fixture import dynamic_biosphere_matrix_db
 from .fixtures.explicit_process_product_db_fixture import explicit_process_product_db
 from .fixtures.nonunitary_db_fixture import nonunitary_db
@@ -23,6 +29,7 @@ from .fixtures.same_date_databases_fixture import (
     same_date_db_three_dates,
     same_date_deep_db,
 )
+from .fixtures.shared_market_db_fixture import shared_market_db
 from .fixtures.substitution_db_fixture import substitution_db
 from .fixtures.temporal_grouping_fixture import (
     temporal_grouping_db_daily,
@@ -34,4 +41,9 @@ from .fixtures.temporal_evolution_db_fixture import (
     temporal_evolution_db,
 )
 from .fixtures.vehicle_db_fixture import vehicle_db
+from .fixtures.zero_weight_background_td_db_fixture import (
+    single_date_background_td_db,
+    zero_weight_background_td_db,
+    zero_weight_first_background_td_db,
+)
 from .fixtures.vehicle_explicit_db_fixture import vehicle_explicit_db

--- a/tests/fixtures/duplicate_exchange_db_fixture.py
+++ b/tests/fixtures/duplicate_exchange_db_fixture.py
@@ -1,0 +1,193 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_timex import TemporalDistribution
+
+
+def _write_databases(td_on_first_duplicate=None):
+    """fu -> bg_A -> bg_B -> CO2, where bg_A consumes bg_B via TWO exchanges.
+
+    Several exchanges between the same pair of nodes are a legitimate modelling
+    choice (ecoinvent/premise do it all the time, e.g. two heat inputs from the
+    same market). Both exchanges must be picked up together when the background
+    is traversed.
+    """
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    for db_name, co2_amount in [("background_2020", 1.0), ("background_2030", 0.5)]:
+        first_duplicate = {
+            "input": (db_name, "bg_B"),
+            "amount": 2,
+            "type": "technosphere",
+        }
+        if td_on_first_duplicate is not None:
+            first_duplicate["temporal_distribution"] = td_on_first_duplicate
+
+        bd.Database(db_name).write(
+            {
+                (db_name, "bg_A"): {
+                    "name": "bg_A",
+                    "unit": "kg",
+                    "location": "GLO",
+                    "exchanges": [
+                        {
+                            "input": (db_name, "bg_A"),
+                            "amount": 1,
+                            "type": "production",
+                        },
+                        first_duplicate,
+                        {
+                            "input": (db_name, "bg_B"),
+                            "amount": 3,
+                            "type": "technosphere",
+                        },
+                    ],
+                },
+                (db_name, "bg_B"): {
+                    "name": "bg_B",
+                    "unit": "kg",
+                    "location": "GLO",
+                    "exchanges": [
+                        {
+                            "input": (db_name, "bg_B"),
+                            "amount": 1,
+                            "type": "production",
+                        },
+                        {
+                            "input": ("bio", "co2"),
+                            "amount": co2_amount,
+                            "type": "biosphere",
+                        },
+                    ],
+                },
+            }
+        )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "fu"): {
+                "name": "fu",
+                "unit": "unit",
+                "location": "GLO",
+                "reference product": "fu",
+                "exchanges": [
+                    {"input": ("foreground", "fu"), "amount": 1, "type": "production"},
+                    {
+                        "input": ("background_2020", "bg_A"),
+                        "amount": 1,
+                        "type": "technosphere",
+                    },
+                ],
+            }
+        }
+    )
+
+    for db in bd.databases:
+        bd.Database(db).process()
+
+
+def _write_self_loop_databases(td_on_self_loop=None):
+    """fu -> bg_A -> CO2, where bg_A consumes 0.2 kg of its own product.
+
+    The self-loop means the same node pair carries two exchanges of *different*
+    types: the production exchange and the technosphere self-input. The
+    technosphere matrix holds their net (1 - 0.2 = 0.8 kg of net product per
+    process run).
+    """
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    for db_name in ["background_2020", "background_2030"]:
+        self_input = {
+            "input": (db_name, "bg_A"),
+            "amount": 0.2,
+            "type": "technosphere",
+        }
+        if td_on_self_loop is not None:
+            self_input["temporal_distribution"] = td_on_self_loop
+
+        bd.Database(db_name).write(
+            {
+                (db_name, "bg_A"): {
+                    "name": "bg_A",
+                    "unit": "kg",
+                    "location": "GLO",
+                    "exchanges": [
+                        {"input": (db_name, "bg_A"), "amount": 1, "type": "production"},
+                        self_input,
+                        {"input": ("bio", "co2"), "amount": 1, "type": "biosphere"},
+                    ],
+                },
+            }
+        )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "fu"): {
+                "name": "fu",
+                "unit": "unit",
+                "location": "GLO",
+                "reference product": "fu",
+                "exchanges": [
+                    {"input": ("foreground", "fu"), "amount": 1, "type": "production"},
+                    {
+                        "input": ("background_2020", "bg_A"),
+                        "amount": 1,
+                        "type": "technosphere",
+                    },
+                ],
+            }
+        }
+    )
+
+    for db in bd.databases:
+        bd.Database(db).process()
+
+
+@pytest.fixture
+@bw2test
+def self_loop_db():
+    """Production and technosphere exchange between the same node pair, neither
+    carrying temporal information."""
+    _write_self_loop_databases()
+
+
+@pytest.fixture
+@bw2test
+def self_loop_with_td_db():
+    """Same as `self_loop_db`, but the technosphere self-input carries a
+    temporal distribution, so the two differently-typed exchanges would have to
+    be merged in time - which is ambiguous."""
+    _write_self_loop_databases(
+        td_on_self_loop=TemporalDistribution(
+            date=np.array([-2], dtype="timedelta64[Y]"),
+            amount=np.array([1.0]),
+        )
+    )
+
+
+@pytest.fixture
+@bw2test
+def duplicate_exchange_db():
+    """Duplicate bg_A -> bg_B exchanges (amounts 2 and 3), neither with a TD."""
+    _write_databases()
+
+
+@pytest.fixture
+@bw2test
+def duplicate_exchange_td_db():
+    """Duplicate bg_A -> bg_B exchanges where only the first one (amount 2)
+    carries a temporal distribution, shifting its share 10 years into the
+    future. The merged edge must keep both shares apart in time."""
+    _write_databases(
+        td_on_first_duplicate=TemporalDistribution(
+            date=np.array([10], dtype="timedelta64[Y]"),
+            amount=np.array([1.0]),
+        )
+    )

--- a/tests/fixtures/shared_market_db_fixture.py
+++ b/tests/fixtures/shared_market_db_fixture.py
@@ -1,0 +1,91 @@
+import bw2data as bd
+import pytest
+from bw2data.tests import bw2test
+
+
+@pytest.fixture
+@bw2test
+def shared_market_db():
+    """fu -> {fg_A, fg_B} -> bg_X -> CO2.
+
+    Two foreground processes consume the same background node at the same time,
+    so the timeline holds two rows sharing one time-mapped temporal market.
+    """
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    for db_name, co2_amount in [("background_2020", 1.0), ("background_2030", 0.5)]:
+        bd.Database(db_name).write(
+            {
+                (db_name, "bg_X"): {
+                    "name": "bg_X",
+                    "unit": "kg",
+                    "location": "GLO",
+                    "exchanges": [
+                        {"input": (db_name, "bg_X"), "amount": 1, "type": "production"},
+                        {
+                            "input": ("bio", "co2"),
+                            "amount": co2_amount,
+                            "type": "biosphere",
+                        },
+                    ],
+                },
+            }
+        )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "fu"): {
+                "name": "fu",
+                "unit": "unit",
+                "location": "GLO",
+                "reference product": "fu",
+                "exchanges": [
+                    {"input": ("foreground", "fu"), "amount": 1, "type": "production"},
+                    {
+                        "input": ("foreground", "fg_A"),
+                        "amount": 1,
+                        "type": "technosphere",
+                    },
+                    {
+                        "input": ("foreground", "fg_B"),
+                        "amount": 1,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+            ("foreground", "fg_A"): {
+                "name": "fg_A",
+                "unit": "unit",
+                "location": "GLO",
+                "reference product": "fg_A",
+                "exchanges": [
+                    {"input": ("foreground", "fg_A"), "amount": 1, "type": "production"},
+                    {
+                        "input": ("background_2020", "bg_X"),
+                        "amount": 2,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+            ("foreground", "fg_B"): {
+                "name": "fg_B",
+                "unit": "unit",
+                "location": "GLO",
+                "reference product": "fg_B",
+                "exchanges": [
+                    {"input": ("foreground", "fg_B"), "amount": 1, "type": "production"},
+                    {
+                        "input": ("background_2020", "bg_X"),
+                        "amount": 3,
+                        "type": "technosphere",
+                    },
+                ],
+            },
+        }
+    )
+
+    for db in bd.databases:
+        bd.Database(db).process()

--- a/tests/fixtures/zero_weight_background_td_db_fixture.py
+++ b/tests/fixtures/zero_weight_background_td_db_fixture.py
@@ -1,0 +1,124 @@
+import bw2data as bd
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+from bw_timex import TemporalDistribution
+
+
+def _write_databases(bg_a_to_b_td):
+    """fu -> bg_A -> bg_B -> bg_C -> CO2, background TD on bg_A -> bg_B."""
+    bd.Database("bio").write(
+        {("bio", "co2"): {"name": "carbon dioxide", "unit": "kg", "type": "emission"}}
+    )
+    bd.Method(("GWP", "example")).write([(("bio", "co2"), 1.0)])
+
+    for db_name, co2_amount in [("background_2020", 1.0), ("background_2030", 0.5)]:
+        bd.Database(db_name).write(
+            {
+                (db_name, "bg_A"): {
+                    "name": "bg_A",
+                    "unit": "kg",
+                    "location": "GLO",
+                    "exchanges": [
+                        {"input": (db_name, "bg_A"), "amount": 1, "type": "production"},
+                        {
+                            "input": (db_name, "bg_B"),
+                            "amount": 1,
+                            "type": "technosphere",
+                            "temporal_distribution": bg_a_to_b_td,
+                        },
+                    ],
+                },
+                (db_name, "bg_B"): {
+                    "name": "bg_B",
+                    "unit": "kg",
+                    "location": "GLO",
+                    "exchanges": [
+                        {"input": (db_name, "bg_B"), "amount": 1, "type": "production"},
+                        {
+                            "input": (db_name, "bg_C"),
+                            "amount": 1,
+                            "type": "technosphere",
+                        },
+                    ],
+                },
+                (db_name, "bg_C"): {
+                    "name": "bg_C",
+                    "unit": "kg",
+                    "location": "GLO",
+                    "exchanges": [
+                        {"input": (db_name, "bg_C"), "amount": 1, "type": "production"},
+                        {
+                            "input": ("bio", "co2"),
+                            "amount": co2_amount,
+                            "type": "biosphere",
+                        },
+                    ],
+                },
+            }
+        )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "fu"): {
+                "name": "fu",
+                "unit": "unit",
+                "location": "GLO",
+                "reference product": "fu",
+                "exchanges": [
+                    {"input": ("foreground", "fu"), "amount": 1, "type": "production"},
+                    {
+                        "input": ("background_2020", "bg_A"),
+                        "amount": 1,
+                        "type": "technosphere",
+                    },
+                ],
+            }
+        }
+    )
+
+    for db in bd.databases:
+        bd.Database(db).process()
+
+
+@pytest.fixture
+@bw2test
+def zero_weight_background_td_db():
+    """Background TD with a zero-weight date: bg_B is reached at t0 (weight 1)
+    and at t0+10a (weight 0). The zero-weight cohort of bg_B carries no supply,
+    but its own inputs (bg_B -> bg_C) do have non-zero exchange amounts, so the
+    edges out of that cohort survive while the edge into it does not."""
+    _write_databases(
+        TemporalDistribution(
+            date=np.array([0, 10], dtype="timedelta64[Y]"),
+            amount=np.array([1.0, 0.0]),
+        )
+    )
+
+
+@pytest.fixture
+@bw2test
+def zero_weight_first_background_td_db():
+    """Like `zero_weight_background_td_db`, but the zero weight is on the date
+    that routes to a different background variant than the non-zero one. The
+    variant split then hands the descent a cohort whose amounts are *all* zero.
+    """
+    _write_databases(
+        TemporalDistribution(
+            date=np.array([0, 10], dtype="timedelta64[Y]"),
+            amount=np.array([0.0, 1.0]),
+        )
+    )
+
+
+@pytest.fixture
+@bw2test
+def single_date_background_td_db():
+    """Reference for `zero_weight_background_td_db` with the zero-weight date
+    left out entirely. Must give the same score."""
+    _write_databases(
+        TemporalDistribution(
+            date=np.array([0], dtype="timedelta64[Y]"),
+            amount=np.array([1.0]),
+        )
+    )

--- a/tests/test_duplicate_exchanges.py
+++ b/tests/test_duplicate_exchanges.py
@@ -1,0 +1,130 @@
+"""Several exchanges between the same pair of nodes are legitimate modelling
+(ecoinvent/premise do it routinely). Traversing them must not raise, and the
+duplicates must be merged into one edge that carries their combined amount."""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from bw_timex import TemporalDistribution, TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+STARTING_DATETIME = "2024-01-01"
+
+# Linear interpolation weights of the 2024 flows between the 2020 and 2030 db
+# (rounded to 3 decimals, like `linear_interpolation_weights` does).
+W_2030 = round(
+    (datetime(2024, 1, 1) - datetime(2020, 1, 1)).days
+    / (datetime(2030, 1, 1) - datetime(2020, 1, 1)).days,
+    3,
+)
+W_2020 = 1 - W_2030
+# CO2 per unit of bg_B, per background vintage
+CO2_2020, CO2_2030 = 1.0, 0.5
+
+
+def _score(graph_traversal, traverse_background):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime=STARTING_DATETIME,
+        graph_traversal=graph_traversal,
+        traverse_background=traverse_background,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    return tlca.static_score
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_duplicate_exchanges_are_summed(duplicate_exchange_db, graph_traversal):
+    """bg_A consumes bg_B twice (2 + 3 kg). Traversing the background must see
+    the full 5 kg, and give the same score as not traversing it."""
+    expected = 5 * (W_2020 * CO2_2020 + W_2030 * CO2_2030)
+    assert _score(graph_traversal, True) == pytest.approx(expected, rel=1e-9)
+    assert _score(graph_traversal, False) == pytest.approx(expected, rel=1e-9)
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_self_consuming_process_from_timeline(self_loop_db, graph_traversal):
+    """Without an expanded matrix there is no solve to resolve the loop: the
+    traversal walks it until `cutoff` stops it, and the repeated visits carry
+    the amplification. It must converge to the same 1.25."""
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime=STARTING_DATETIME,
+        graph_traversal=graph_traversal,
+        traverse_background=True,
+        cutoff=1e-8,
+    )
+    tlca.lci(expand_technosphere=False, build_dynamic_biosphere=True)
+    tlca.static_lcia()
+    assert tlca.static_score == pytest.approx(1 / 0.8, rel=1e-6)
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+@pytest.mark.parametrize("traverse_background", [False, True])
+def test_self_consuming_process(self_loop_db, graph_traversal, traverse_background):
+    """A process consuming its own product has a production and a technosphere
+    exchange between the same node pair. Loops like this are everywhere in LCI
+    databases: the loop must survive into the matrix, where 1 kg of net product
+    takes 1/(1 - 0.2) process runs."""
+    expected = 1 / 0.8  # kg CO2 per kg of net product delivered
+    assert _score(graph_traversal, traverse_background) == pytest.approx(
+        expected, rel=1e-6
+    )
+
+
+def test_differently_typed_exchanges_with_temporal_information_raise():
+    """With a temporal distribution on one of them, the two exchanges would
+    have to be merged in time across incompatible signs. That is ambiguous, so
+    it must fail loudly rather than silently pick one."""
+    from bw_timex.edge_extractor import merge_duplicate_exchanges
+
+    with pytest.raises(ValueError, match="different types"):
+        merge_duplicate_exchanges(
+            [
+                {"amount": 1, "type": "production"},
+                {
+                    "amount": 0.2,
+                    "type": "technosphere",
+                    "temporal_distribution": TemporalDistribution(
+                        date=np.array([-2], dtype="timedelta64[Y]"),
+                        amount=np.array([1.0]),
+                    ),
+                },
+            ]
+        )
+
+
+def test_differently_typed_exchanges_are_netted():
+    """Without temporal information the duplicates are netted: the merged
+    exchange reports the type governing the net, and keeps the consumed amount
+    for a traversal that follows the input edge."""
+    from bw_timex.edge_extractor import merge_duplicate_exchanges
+
+    merged = merge_duplicate_exchanges(
+        [
+            {"amount": 1, "type": "production"},
+            {"amount": 0.2, "type": "technosphere"},
+        ]
+    )
+    assert merged.data["type"] == "production"
+    assert merged.data["amount"] == pytest.approx(0.8)
+    assert merged.netted_types is True
+    assert merged.consuming_amount == pytest.approx(0.2)
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_duplicate_exchanges_merge_temporal_distributions(
+    duplicate_exchange_td_db, graph_traversal
+):
+    """Only the amount-2 duplicate carries a TD (+10 years), so 2 kg of bg_B
+    happen in 2034 (sourced from the 2030 db) and 3 kg in 2024 (interpolated)."""
+    expected = 3 * (W_2020 * CO2_2020 + W_2030 * CO2_2030) + 2 * CO2_2030
+    assert _score(graph_traversal, True) == pytest.approx(expected, rel=1e-9)

--- a/tests/test_lci_cache.py
+++ b/tests/test_lci_cache.py
@@ -137,8 +137,16 @@ class TestModuleLevelLCICache:
             starting_datetime=datetime.strptime("2024-01-02", "%Y-%m-%d")
         )
         tlca_flat.lci(expand_technosphere=False, build_dynamic_biosphere=True)
-        with pytest.raises(ValueError, match="expanded matrix"):
-            tlca_flat.static_lcia()
+        # The flat build has its own (unexpanded) lca object: it must not have
+        # picked up the expanded run's cached solve, and its inventory - built
+        # from the timeline - must still give the same score.
+        assert tlca_flat.expanded_technosphere is False
+        assert tlca_flat._lci_used_cached_solve is False
+        tlca_flat.static_lcia()
+        tlca_expanded.static_lcia()
+        assert tlca_flat.static_score == pytest.approx(
+            tlca_expanded.static_score, rel=1e-9
+        )
 
     def test_warm_cache_skips_factorization(self):
         # First run populates the global cache.

--- a/tests/test_score_only_inventory.py
+++ b/tests/test_score_only_inventory.py
@@ -1,0 +1,67 @@
+"""`keep_activity_dimension=False` drops the per-activity columns of the
+dynamic inventory and accumulates emissions per (flow, time) only. Scores must
+be identical; only contribution analysis by activity is given up."""
+
+from datetime import datetime
+
+import pytest
+
+from bw_timex import TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+
+
+def _tlca(expand_technosphere, keep_activity_dimension, traverse_background=False):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01", traverse_background=traverse_background
+    )
+    tlca.lci(
+        expand_technosphere=expand_technosphere,
+        build_dynamic_biosphere=True,
+        keep_activity_dimension=keep_activity_dimension,
+    )
+    tlca.static_lcia()
+    return tlca
+
+
+@pytest.mark.parametrize("expand_technosphere", [False, True])
+@pytest.mark.parametrize("traverse_background", [False, True])
+def test_scores_are_unchanged(
+    background_td_db, expand_technosphere, traverse_background
+):
+    full = _tlca(expand_technosphere, True, traverse_background)
+    lean = _tlca(expand_technosphere, False, traverse_background)
+
+    assert full.static_score > 0
+    assert lean.static_score == pytest.approx(full.static_score, rel=1e-9)
+    assert lean.dynamic_inventory.sum() == pytest.approx(
+        full.dynamic_inventory.sum(), rel=1e-9
+    )
+
+
+@pytest.mark.parametrize("expand_technosphere", [False, True])
+def test_activity_dimension_is_dropped(background_td_db, expand_technosphere):
+    lean = _tlca(expand_technosphere, False)
+    assert lean.dynamic_biosphere_matrix.shape[1] == 1
+    assert lean.dynamic_inventory.shape[1] == 1
+    assert lean.dynamic_inventory_df["activity"].nunique() == 1
+
+
+def test_emissions_over_time_are_unchanged(background_td_db):
+    """Only the activity dimension goes; the timing of the emissions stays."""
+    full = _tlca(False, True)
+    lean = _tlca(False, False)
+
+    full_over_time = full.dynamic_inventory_df.groupby(["date", "flow"])[
+        "amount"
+    ].sum()
+    lean_over_time = lean.dynamic_inventory_df.groupby(["date", "flow"])["amount"].sum()
+    assert set(full_over_time.index) == set(lean_over_time.index)
+    for key, amount in full_over_time.items():
+        assert lean_over_time[key] == pytest.approx(amount, rel=1e-9)

--- a/tests/test_shared_temporal_markets.py
+++ b/tests/test_shared_temporal_markets.py
@@ -1,0 +1,51 @@
+"""Building the dynamic inventory from the timeline (`expand_technosphere=False`)
+gives every timeline row its own matrix column. Rows that share a time-mapped
+temporal market carry the same background LCI, so storing it once per row is
+pure duplication - real background systems reach hundreds of thousands of such
+rows. They are collapsed onto one column, with their supplies summed."""
+
+from datetime import datetime
+
+import pytest
+
+from bw_timex import TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+
+
+def _tlca(expand_technosphere):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2024-01-01")
+    tlca.lci(expand_technosphere=expand_technosphere, build_dynamic_biosphere=True)
+    tlca.static_lcia()
+    return tlca
+
+
+def test_shared_market_score_is_unchanged(shared_market_db):
+    """fg_A and fg_B together pull 5 kg of bg_X through one shared market."""
+    from_timeline = _tlca(False)
+    expanded = _tlca(True)
+    assert from_timeline.static_score == pytest.approx(
+        expanded.static_score, rel=1e-9
+    )
+    assert from_timeline.dynamic_inventory_df["amount"].sum() == pytest.approx(
+        expanded.dynamic_inventory_df["amount"].sum(), rel=1e-9
+    )
+
+
+def test_shared_market_uses_a_single_column(shared_market_db):
+    """Both bg_X rows are served by one column, not one each."""
+    tlca = _tlca(False)
+    timeline = tlca.timeline
+    market_rows = timeline.index[timeline["temporal_market_shares"].notna()]
+    assert len(market_rows) == 2, "fixture must produce two rows sharing one market"
+    assert timeline.loc[market_rows, "time_mapped_producer"].nunique() == 1
+
+    matrix = tlca.dynamic_biosphere_matrix.tocsc()
+    filled = [col for col in market_rows if matrix[:, col].nnz]
+    assert len(filled) == 1

--- a/tests/test_static_lcia_from_timeline.py
+++ b/tests/test_static_lcia_from_timeline.py
@@ -1,0 +1,50 @@
+"""`static_lcia` must also work when the dynamic inventory was built directly
+from the timeline (`expand_technosphere=False`): the time-explicit inventory is
+there, it just has to be characterized with the static factors."""
+
+from datetime import datetime
+
+import pytest
+
+from bw_timex import TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+
+
+def _tlca(traverse_background):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        traverse_background=traverse_background,
+    )
+    return tlca
+
+
+@pytest.mark.parametrize("traverse_background", [False, True])
+def test_static_score_from_timeline_matches_expanded(
+    background_td_db, traverse_background
+):
+    expanded = _tlca(traverse_background)
+    expanded.lci(expand_technosphere=True)
+    expanded.static_lcia()
+
+    from_timeline = _tlca(traverse_background)
+    from_timeline.lci(expand_technosphere=False, build_dynamic_biosphere=True)
+    from_timeline.static_lcia()
+
+    assert expanded.static_score > 0
+    assert from_timeline.static_score == pytest.approx(
+        expanded.static_score, rel=1e-9
+    )
+
+
+def test_static_score_before_static_lcia_raises(background_td_db):
+    tlca = _tlca(False)
+    tlca.lci(expand_technosphere=False, build_dynamic_biosphere=True)
+    with pytest.raises(AttributeError, match="static_lcia"):
+        tlca.static_score

--- a/tests/test_timex_lca.py
+++ b/tests/test_timex_lca.py
@@ -132,24 +132,32 @@ class TestTimexLCALabellingMethods:
         assert all(isinstance(v, str) for v in df["flow"].unique())
         assert all(isinstance(v, str) for v in df["activity"].unique())
 
-    def test_static_lcia_without_expand_raises(self):
+    def test_static_lcia_without_expand_characterizes_dynamic_inventory(self):
+        """Without the expanded matrices the static score is characterized from
+        the dynamic inventory, and must match the expanded one."""
         fu = bd.get_node(database="foreground", code="A")
         database_dates = {
             "db_2022": datetime.strptime("2022", "%Y"),
             "db_2024": datetime.strptime("2024", "%Y"),
             "foreground": "dynamic",
         }
-        tlca2 = TimexLCA(
-            demand={fu.key: 1},
-            method=("GWP", "example"),
-            database_dates=database_dates,
-        )
-        tlca2.build_timeline(
-            starting_datetime=datetime.strptime("2024-01-02", "%Y-%m-%d"),
-        )
-        tlca2.lci(expand_technosphere=False, build_dynamic_biosphere=True)
-        with pytest.raises(ValueError, match="expanded matrix"):
-            tlca2.static_lcia()
+
+        def score(expand_technosphere):
+            tlca = TimexLCA(
+                demand={fu.key: 1},
+                method=("GWP", "example"),
+                database_dates=database_dates,
+            )
+            tlca.build_timeline(
+                starting_datetime=datetime.strptime("2024-01-02", "%Y-%m-%d"),
+            )
+            tlca.lci(
+                expand_technosphere=expand_technosphere, build_dynamic_biosphere=True
+            )
+            tlca.static_lcia()
+            return tlca.static_score
+
+        assert score(False) == pytest.approx(score(True), rel=1e-9)
 
 
 # ─── Edge cases ───

--- a/tests/test_truncated_background_descent.py
+++ b/tests/test_truncated_background_descent.py
@@ -1,0 +1,55 @@
+"""When the background descent stops early (``max_calc`` budget or ``cutoff``),
+the nodes at the truncation frontier are leaves: nothing downstream of them is
+in the timeline. They must therefore be sourced as temporal markets, i.e. with
+their full background LCI, exactly like the background frontier of a run
+without ``traverse_background``. Otherwise everything upstream of the
+truncation is silently lost from the inventory."""
+
+from datetime import datetime
+
+import pytest
+
+from bw_timex import TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+
+
+def _score(max_calc, traverse_background, graph_traversal):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime="2024-01-01",
+        graph_traversal=graph_traversal,
+        traverse_background=traverse_background,
+        max_calc=max_calc,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    return tlca.static_score
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_truncated_descent_keeps_full_inventory(
+    background_td_deep_chain_db, graph_traversal
+):
+    """The whole chain's CO2 sits at its deepest node, which a small max_calc
+    cuts off. The score must not depend on how far the descent got."""
+    full = _score(10_000, True, graph_traversal)
+    truncated = _score(3, True, graph_traversal)
+    assert full > 0
+    assert truncated == pytest.approx(full, rel=1e-9)
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_truncated_descent_matches_static_background(
+    background_td_deep_chain_db, graph_traversal
+):
+    """A descent truncated right at the first background node must give the
+    same score as not traversing the background at all."""
+    static_background = _score(10_000, False, graph_traversal)
+    truncated = _score(3, True, graph_traversal)
+    assert truncated == pytest.approx(static_background, rel=1e-9)

--- a/tests/test_zero_supply_cohorts.py
+++ b/tests/test_zero_supply_cohorts.py
@@ -1,0 +1,68 @@
+"""A node cohort that receives zero supply is dropped from the timeline
+(`amount != 0`), but the edges *out* of that cohort can still carry non-zero
+exchange amounts. Those orphaned edges must not be looked up in the activity
+time mapping, where their consumer was never registered."""
+
+from datetime import datetime
+
+import pytest
+
+from bw_timex import TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+STARTING_DATETIME = "2024-01-01"
+
+
+def _score(graph_traversal):
+    tlca = TimexLCA({("foreground", "fu"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(
+        starting_datetime=STARTING_DATETIME,
+        graph_traversal=graph_traversal,
+        traverse_background=True,
+    )
+    tlca.lci()
+    tlca.static_lcia()
+    return tlca.static_score
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_zero_supply_cohort_does_not_break_timeline(
+    zero_weight_background_td_db, graph_traversal
+):
+    # 2024 is interpolated between the 2020 (1 kg CO2) and 2030 (0.5) vintages,
+    # with weights rounded to 3 decimals by `linear_interpolation_weights`.
+    w_2030 = round(
+        (datetime(2024, 1, 1) - datetime(2020, 1, 1)).days
+        / (datetime(2030, 1, 1) - datetime(2020, 1, 1)).days,
+        3,
+    )
+    expected = (1 - w_2030) * 1.0 + w_2030 * 0.5
+    assert _score(graph_traversal) == pytest.approx(expected, rel=1e-9)
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_zero_weight_date_is_equivalent_to_leaving_it_out(
+    request, graph_traversal
+):
+    request.getfixturevalue("zero_weight_background_td_db")
+    with_zero = _score(graph_traversal)
+    request.getfixturevalue("single_date_background_td_db")
+    without_zero = _score(graph_traversal)
+    assert with_zero == pytest.approx(without_zero, rel=1e-9)
+
+
+@pytest.mark.parametrize("graph_traversal", ["priority", "bfs"])
+def test_all_zero_cohort_does_not_break_the_descent(
+    zero_weight_first_background_td_db, graph_traversal
+):
+    """The zero-weight date routes to a different background variant than the
+    non-zero one, so one variant's cohort is all zeros. Convolving it away
+    yields an empty temporal distribution, which must not blow up the descent:
+    the cohort simply carries nothing."""
+    # All the supply happens in 2034, i.e. is sourced from the 2030 vintage.
+    assert _score(graph_traversal) == pytest.approx(0.5, rel=1e-9)


### PR DESCRIPTION
Six defects that surface when `traverse_background=True` runs on ecoinvent/premise-scale data, plus the memory work needed to get such a system through `lci()`. Found while running the EV/premise example with `traverse_background=True`.

### Fixes

* **Several exchanges between the same two nodes** raised `MultipleTechnosphereExchanges` (priority) or `ValueError` (bfs), and were silently reduced to the first one on the proxy path. Legitimate modelling — ecoinvent/premise do it routinely (e.g. two heat inputs from one market). They are merged into one edge carrying their summed amount and the amount-weighted combination of their temporal distributions and temporal evolutions.
* **A process consuming its own product lost that loop.** The self-consumption entry and the production entry share the diagonal, and the datapackage does not sum duplicate indices, so the production entry overwrote it. The loop is now netted into the production entry. `graph_traversal="bfs"` also emitted such an edge twice with different amounts (variant split *and* variant descent); it now walks the loop like any other.
* **`KeyError` in `get_time_mapping_key`** for node cohorts reached only through zero-amount edges: their producing row is removed by the zero-amount filter, while the edges below them survive and then look up a consumer that was never registered. Those orphaned edges are dropped instead.
* **A descent stopped by `cutoff` or `max_calc` dropped everything upstream of the truncation**, because frontier nodes were marked variant-resolved and therefore temporalized. They are leaves, so they are sourced as temporal markets, pinned to the variant the descent resolved them to.
* **`ValueError: Empty array`** when a variant split hands the descent a cohort whose amounts are all zero.
* **`static_lcia()` refused to work without an expanded technosphere**; it now characterizes the dynamic inventory with the static factors.

### Memory

`lci(keep_activity_dimension=False)` accumulates the dynamic inventory per (biosphere flow, time) instead of per activity: same static and dynamic scores, same emission timing, no contribution analysis by activity. Together with sharing one column between timeline rows of the same temporal market, storing only non-zero background flows, and dropping per-row LCI copies that only the (unavailable) disaggregation could use, this is what makes a premise-scale time-explicit system fit in memory.

### Tests

Six new test modules with three fixtures, each reproducing its defect first: duplicate and differently-typed exchanges, self-consuming processes, zero-supply cohorts, truncated descents, shared temporal markets, timeline-based static LCIA and the score-only inventory. Parametrized over both engines and both `traverse_background` settings where applicable.