### PR TITLE
Point site_url at the published docs domain

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -2,7 +2,7 @@
 site_name = "bw_timex"
 site_description = "Time-explicit Life Cycle Assessment"
 site_author = "Timo Diepers, Amelie Müller, Arthur Jakobs"
-site_url = "https://timodiepers.github.io/bw_timex/"
+site_url = "https://docs.brightway.dev/projects/bw-timex/en/latest/"
 
 repo_name = "brightway-lca/bw_timex"
 repo_url = "https://github.com/brightway-lca/bw_timex"


### PR DESCRIPTION
`site_url` in `zensical.toml` was still the fork's GitHub Pages preview (`https://timodiepers.github.io/bw_timex/`) left over from the zensical migration.

It feeds the canonical `<link>` tags and `sitemap.xml` of the built site. Because `.readthedocs.yaml` builds through a `commands:` block, Read the Docs does not rewrite them, so the site published at `docs.brightway.dev` was advertising a stale fork preview as its canonical URL.

Points it at `https://docs.brightway.dev/projects/bw-timex/en/latest/` instead, which is where `bw-timex.readthedocs.io` redirects.

`repo_name`, `repo_url`, `edit_uri` and `GITHUB_REPO` in `docs/convert_notebooks.py` already point at `brightway-lca/bw_timex` and are unchanged.