### PR TITLE
fix: give the biosphere flip array one entry per matrix index

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+* Fixed `ShapeMismatch` in `lci()` for processes with more than one biosphere exchange, by sizing the biosphere `flip_array` to the number of matrix entries (only raised with `bw_processing` >= 1.5; no numeric results change) ([#213](https://github.com/brightway-lca/bw_timex/pull/213))
+
 ## [1.2.0] - 2026-08-14
 * Migrated the documentation from Sphinx to [Zensical](https://zensical.org), with the example pages generated from the notebooks ([#202](https://github.com/brightway-lca/bw_timex/pull/202))
 * Added name-based exchange lookup to `get_exchange`, `add_temporal_distribution_to_exchange` and `add_temporal_evolution_to_exchange`, via `input_name`/`output_name` (optionally narrowed down with `input_location`/`output_location` and `input_product`/`output_product`), which avoids having to know the machine-generated codes of e.g. ecoinvent nodes ([#202](https://github.com/brightway-lca/bw_timex/pull/202))

--- a/bw_timex/matrix_modifier.py
+++ b/bw_timex/matrix_modifier.py
@@ -186,7 +186,10 @@ class MatrixModifier:
                     indices,
                     dtype=bwp.INDICES_DTYPE,
                 ),
-                flip_array=np.array([False], dtype=bool),
+                # Biosphere exchanges are never flipped: the sign of the flow
+                # is carried by the amount itself. One entry per index, since
+                # bw_processing requires matching shapes.
+                flip_array=np.zeros(len(indices), dtype=bool),
             )
         return datapackage_biosphere
 

--- a/tests/test_biosphere_flip_array.py
+++ b/tests/test_biosphere_flip_array.py
@@ -1,0 +1,116 @@
+"""The biosphere datapackage passes one `flip_array` entry per matrix entry.
+
+`bw_processing` only validates the shape of `flip_array` when it contains at
+least one `True`, so a length-1 all-`False` array slips through unnoticed on
+some versions and raises `ShapeMismatch` on others. The contract is the same
+either way: the flip vector has to be as long as the indices vector.
+"""
+
+from datetime import datetime
+
+import bw2data as bd
+import bw_processing as bwp
+import numpy as np
+import pytest
+from bw2data.tests import bw2test
+
+from bw_timex import TemporalDistribution, TimexLCA
+
+METHOD = ("GWP", "example")
+DATABASE_DATES = {
+    "background_2020": datetime.strptime("2020", "%Y"),
+    "background_2030": datetime.strptime("2030", "%Y"),
+    "foreground": "dynamic",
+}
+
+
+@pytest.fixture
+@bw2test
+def multi_bioflow_db():
+    bd.Database("bio").write(
+        {
+            ("bio", "CO2"): {"type": "emission", "name": "carbon dioxide"},
+            ("bio", "CH4"): {"type": "emission", "name": "methane"},
+            ("bio", "N2O"): {"type": "emission", "name": "nitrous oxide"},
+        }
+    )
+
+    for db_name, co2_amount in (("background_2020", 1), ("background_2030", 0.5)):
+        bd.Database(db_name).write(
+            {
+                (db_name, "B"): {
+                    "name": "node b",
+                    "location": "somewhere",
+                    "reference product": "B",
+                    "exchanges": [
+                        {"amount": 1, "type": "production", "input": (db_name, "B")},
+                        {
+                            "amount": co2_amount,
+                            "type": "biosphere",
+                            "input": ("bio", "CO2"),
+                        },
+                    ],
+                },
+            }
+        )
+
+    bd.Database("foreground").write(
+        {
+            ("foreground", "A"): {
+                "name": "node a",
+                "location": "somewhere",
+                "reference product": "A",
+                "exchanges": [
+                    {"amount": 1, "type": "production", "input": ("foreground", "A")},
+                    # more than one biosphere flow on the temporalized process:
+                    # this is what makes the flip vector too short
+                    {"amount": 2, "type": "biosphere", "input": ("bio", "CO2")},
+                    {"amount": 3, "type": "biosphere", "input": ("bio", "CH4")},
+                    {"amount": 4, "type": "biosphere", "input": ("bio", "N2O")},
+                    {
+                        "amount": 1,
+                        "type": "technosphere",
+                        "input": ("background_2020", "B"),
+                        "temporal_distribution": TemporalDistribution(
+                            date=np.array([-2], dtype="timedelta64[Y]"),
+                            amount=np.array([1]),
+                        ),
+                    },
+                ],
+            },
+        }
+    )
+
+    bd.Method(METHOD).write([(("bio", "CO2"), 1), (("bio", "CH4"), 25), (("bio", "N2O"), 300)])
+
+    for db in bd.databases:
+        bd.Database(db).process()
+
+
+def test_biosphere_flip_array_matches_indices(multi_bioflow_db, monkeypatch):
+    calls = []
+    original = bwp.Datapackage.add_persistent_vector
+
+    def recording_add_persistent_vector(self, **kwargs):
+        if kwargs.get("matrix") == "biosphere_matrix":
+            calls.append(kwargs)
+        return original(self, **kwargs)
+
+    monkeypatch.setattr(
+        bwp.Datapackage, "add_persistent_vector", recording_add_persistent_vector
+    )
+
+    tlca = TimexLCA({("foreground", "A"): 1}, METHOD, DATABASE_DATES)
+    tlca.build_timeline(starting_datetime="2024-01-01")
+    tlca.lci()
+
+    assert calls, "no biosphere matrix entries were created"
+    for kwargs in calls:
+        flip_array = kwargs.get("flip_array")
+        if flip_array is None:
+            continue
+        assert flip_array.shape == kwargs["indices_array"].shape, (
+            "`flip_array` shape "
+            f"{flip_array.shape} doesn't match `indices_array` "
+            f"{kwargs['indices_array'].shape}"
+        )


### PR DESCRIPTION
Fixes #212.

## What went wrong

`MatrixModifier.create_biosphere_datapackage` passed a hardcoded

```python
flip_array=np.array([False], dtype=bool)
```

while `indices_array` holds one entry per biosphere exchange of the producer. Any temporalized producer with more than one elementary flow therefore built a mismatched pair — 1 flip entry vs. N indices. With real data that is the normal case (the reporter's `glider production, passenger car` has 8 flows); toy databases with a single flow per process never showed it.

## Why it only surfaces now

bw_processing wrapped the dtype and shape validation in `if flip_array.sum():`, which an all-`False` array never enters. Up to and including 1.4 the mismatch was skipped, the array was not stored, and the matrix came out correct. bw_processing 1.5 moved both checks out of that guard, so from 1.5 on the same call raises `ShapeMismatch`. `uv.lock` currently resolves bw_processing 1.0, which is why CI never hit the strict path.

## The fix

`np.zeros(len(indices), dtype=bool)`, as suggested in the issue. Biosphere exchanges are never flipped — flipping negates technosphere inputs, while the sign of an elementary flow is carried by its amount (a negative amount is an uptake). An all-`False` array of the correct length is exactly the previous intent, just not broadcast-broken, and bw_processing still declines to store it. **No numeric results change** on any version.

## Test

`tests/test_biosphere_flip_array.py` builds a foreground process with three elementary flows, records every `biosphere_matrix` call into the datapackage, and asserts `flip_array.shape == indices_array.shape`. Before the fix it reports `flip_array shape (1,) doesn't match indices_array (3,)` — the issue's failure, minus the dependency on which bw_processing is installed. Full suite: 298 passed.
