### PR TITLE
Document the release workflow in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,105 @@ The API reference is generated from the docstrings with [mkdocstrings](https://m
 
 Both sections end up as admonitions in the rendered docs. Build the docs with `zensical build` and check that it reports no `griffe:` warnings - those point at docstrings that don't parse the way they look like they should.
 
+## Releasing a new version
+
+`bw_timex` is published in three places, and each one is triggered differently:
+
+| Target | Triggered by | Automated |
+|---|---|---|
+| [PyPI](https://pypi.org/project/bw_timex/) | creating the GitHub release | yes, by `python-package-deploy.yml` |
+| [GitHub release](https://github.com/brightway-lca/bw_timex/releases) | `gh release create` | no |
+| [conda `diepers` channel](https://anaconda.org/diepers/bw_timex) | `conda/build_upload.sh` | no, run locally |
+
+The version number lives in exactly one place, `bw_timex/__init__.py`. `pyproject.toml` reads it through `tool.setuptools.dynamic`, and the conda recipe reads it with a regex, so bumping that one line is enough.
+
+### 1. Prepare the release PR
+
+Branch off `main`, never commit the bump directly:
+
+```bash
+git checkout -b release/vX.Y.Z origin/main
+```
+
+Bump `__version__` in `bw_timex/__init__.py`, following [semantic versioning](https://semver.org) - new features mean a minor bump, fixes alone a patch.
+
+Then close out the changelog. `CHANGES.md` collects entries under `## Unreleased` as PRs merge; turn that heading into the new version with today's date:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+```
+
+Before opening the PR, check the section is actually complete. Entries are easy to lose when a change lands outside the usual PR flow - anything pushed straight to `main`, or shipped as a side effect of a larger branch. Compare against the commits since the last tag:
+
+```bash
+git log --oneline vLAST..origin/main
+```
+
+Every user-visible change needs a line, each ending in a link to its PR (`([#207](https://github.com/brightway-lca/bw_timex/pull/207))`) or, if it never went through one, to its commit.
+
+Open the PR, let CI pass, merge it.
+
+### 2. Tag and create the GitHub release
+
+Tag the **merge commit** of that PR, not your local branch tip:
+
+```bash
+git checkout main && git pull --ff-only
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Release notes are the changelog section for that version, copied verbatim - no rewriting, no summarising. Extract it and hand it to `gh`:
+
+```bash
+awk '/^## \[X\.Y\.Z\]/{f=1;next} /^## \[/{f=0} f' CHANGES.md | sed '/^$/d' > /tmp/notes.md
+gh release create vX.Y.Z --title "vX.Y.Z" --notes-file /tmp/notes.md --verify-tag
+```
+
+!!! warning "This is the point of no return"
+
+    Creating the release is the irreversible step. `python-package-deploy.yml` runs `on: release: [created]` and publishes to PyPI, and a version number can never be reused there - not even after deleting the release. Make sure the tag points where you think it does before running this.
+
+Watch the run and confirm the version actually landed:
+
+```bash
+gh run list --limit 3
+curl -s https://pypi.org/pypi/bw_timex/json | python -c "import sys,json; print(json.load(sys.stdin)['info']['version'])"
+```
+
+### 3. Publish to conda
+
+The conda package is built and uploaded by hand, from a checkout that is already at the released version - the recipe builds the working tree (`source: path: ..`), so make sure `main` is checked out, clean, and pulled.
+
+One-time setup:
+
+```bash
+conda install -n base conda-build anaconda-client
+anaconda login          # needs write access to the `diepers` channel
+```
+
+Then:
+
+```bash
+bash conda/build_upload.sh
+```
+
+The recipe generates its `run:` requirements from `pyproject.toml`, so the conda package and the wheel cannot declare different dependencies. If you add a dependency whose conda name differs from its PyPI name, add it to the `conda_names` mapping at the top of `conda/meta.yaml`.
+
+!!! note "Why one dependency is unpinned on conda"
+
+    `pyproject.toml` requires `bw_graph_tools >=0.9`, but conda has no such build - it exists only on the `cmutel` channel, which stops at 0.6 - so the constraint is dropped through the `unpinned_on_conda` list in the recipe. `bw_timex` never imports the package directly and the test suite passes against 0.6, but this does mean conda and PyPI users can end up on different versions of it. `pip check` reports the mismatch during the build without failing it. Remove the entry once a new enough build reaches a conda channel.
+
+Confirm the upload:
+
+```bash
+conda search -c diepers bw_timex
+```
+
+### 4. Check the docs rebuilt
+
+[Read the Docs](https://docs.brightway.dev/projects/bw-timex) builds from `.readthedocs.yaml` on every push to `main`, so the release PR already triggered it. Confirm the new version renders and that the changelog page shows the new section.
+
 ## Report bugs or errors
 
 Something is not working as expected? You have two options:


### PR DESCRIPTION
The release steps were undocumented, and several of them are easy to get wrong in ways that cannot be undone. Writes down the full sequence as a `## Releasing a new version` section.

Covers:

* **Where the version lives** - `bw_timex/__init__.py` is the single source of truth; `pyproject.toml` reads it via `tool.setuptools.dynamic` and the conda recipe via regex, so one line is the whole bump
* **The release PR** - branch off `main`, bump, turn `## Unreleased` into `## [X.Y.Z] - YYYY-MM-DD`, and check the section against `git log vLAST..origin/main` first, since entries go missing for changes that skip the usual PR flow
* **Tag and release** - tag the merge commit, and build the notes by copying the changelog section verbatim (with the `awk` snippet to extract it), which is the existing convention
* **Conda** - the one-time `conda-build`/`anaconda-client` setup and `conda/build_upload.sh`, plus the `conda_names` mapping for dependencies whose conda name differs
* **Read the Docs** - already triggered by the merge, just needs checking

Two warnings that seemed worth making loud:

* Creating the GitHub release is what publishes to PyPI (`on: release: [created]`), and a version number can never be reused there
* Why `bw_graph_tools` is unpinned in the conda recipe, and the condition for removing that exception - context that otherwise only exists in the recipe comment added in #211

Uses `!!!` admonitions rather than GitHub's `> [!WARNING]` syntax, since this file is included into the docs via `--8<-- "CONTRIBUTING.md"` and the rest of the site uses the mkdocs style. Trade-off is that they render as literal text when reading `CONTRIBUTING.md` on GitHub.

Every command in the section was run against this repo before writing it down.